### PR TITLE
fix: add concurrency config for processing message concurrently

### DIFF
--- a/packages/core/src/agent/Agent.ts
+++ b/packages/core/src/agent/Agent.ts
@@ -7,7 +7,7 @@ import type { InitConfig } from '../types'
 import type { Subscription } from 'rxjs'
 
 import { Subject } from 'rxjs'
-import { concatMap, takeUntil } from 'rxjs/operators'
+import { mergeMap, takeUntil } from 'rxjs/operators'
 
 import { InjectionSymbols } from '../constants'
 import { SigningProviderToken } from '../crypto'
@@ -115,15 +115,17 @@ export class Agent<AgentModules extends AgentModulesInput = any> extends BaseAge
       .observable<AgentMessageReceivedEvent>(AgentEventTypes.AgentMessageReceived)
       .pipe(
         takeUntil(stop$),
-        concatMap((e) =>
-          this.messageReceiver
-            .receiveMessage(e.payload.message, {
-              connection: e.payload.connection,
-              contextCorrelationId: e.payload.contextCorrelationId,
-            })
-            .catch((error) => {
-              this.logger.error('Failed to process message', { error })
-            })
+        mergeMap(
+          (e) =>
+            this.messageReceiver
+              .receiveMessage(e.payload.message, {
+                connection: e.payload.connection,
+                contextCorrelationId: e.payload.contextCorrelationId,
+              })
+              .catch((error) => {
+                this.logger.error('Failed to process message', { error })
+              }),
+          this.agentConfig.processMessagesConcurrently ? undefined : 1
         )
       )
       .subscribe()

--- a/packages/core/src/agent/AgentConfig.ts
+++ b/packages/core/src/agent/AgentConfig.ts
@@ -184,6 +184,10 @@ export class AgentConfig {
     return this.initConfig.autoUpdateStorageOnStartup ?? false
   }
 
+  public get processMessagesConcurrently() {
+    return this.initConfig.processMessagesConcurrently ?? false
+  }
+
   public extend(config: Partial<InitConfig>): AgentConfig {
     return new AgentConfig(
       { ...this.initConfig, logger: this.logger, label: this.label, ...config },

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -62,6 +62,7 @@ export interface InitConfig {
   useLegacyDidSovPrefix?: boolean
   connectionImageUrl?: string
   autoUpdateStorageOnStartup?: boolean
+  processMessagesConcurrently?: boolean
 
   /**
    * @deprecated configure `autoAcceptConnections` on the `ConnectionsModule` class


### PR DESCRIPTION
`concatMap` pipe processes messages synchronously, this PR adds the `concurrency` config and replaces `concatMap` with `mergeMap` to allow messages to be processed concurrently. Now that multi-tenant is supported, it will be helpful to process multiple messages at a time.

Signed-off-by: Pritam Singh <pkspritam16@gmail.com>