### PR TITLE
feat: Discover Features V2 over DIDComm V2

### DIFF
--- a/packages/core/src/agent/AgentBaseMessage.ts
+++ b/packages/core/src/agent/AgentBaseMessage.ts
@@ -4,8 +4,8 @@ import type { DidCommMessageVersion, PlaintextMessage } from '../didcomm/types'
 
 export interface AgentBaseMessage {
   readonly type: string
+  readonly didCommVersion: DidCommMessageVersion
 
-  get didCommVersion(): DidCommMessageVersion
   get id(): string
   get threadId(): string | undefined
 

--- a/packages/core/src/agent/Dispatcher.ts
+++ b/packages/core/src/agent/Dispatcher.ts
@@ -36,7 +36,7 @@ class Dispatcher {
 
   public async dispatch(messageContext: InboundMessageContext): Promise<void> {
     const { agentContext, connection, senderKey, recipientKey, message } = messageContext
-    const messageHandler = this.messageHandlerRegistry.getHandlerForMessageType(message.type)
+    const messageHandler = this.messageHandlerRegistry.getHandlerForMessageType(message.type, message.didCommVersion)
 
     if (!messageHandler) {
       throw new AriesFrameworkError(`No handler for message type "${message.type}" found`)

--- a/packages/core/src/agent/MessageHandlerRegistry.ts
+++ b/packages/core/src/agent/MessageHandlerRegistry.ts
@@ -1,5 +1,5 @@
 import type { MessageHandler } from './MessageHandler'
-import type { ConstructableDidCommMessage } from '../didcomm'
+import type { ConstructableDidCommMessage, DidCommMessageVersion } from '../didcomm'
 
 import { injectable } from 'tsyringe'
 
@@ -13,22 +13,32 @@ export class MessageHandlerRegistry {
     this.messageHandlers.push(messageHandler)
   }
 
-  public getHandlerForMessageType(messageType: string): MessageHandler | undefined {
+  public getHandlerForMessageType(
+    messageType: string,
+    didcommVersion: DidCommMessageVersion
+  ): MessageHandler | undefined {
     const incomingMessageType = parseMessageType(messageType)
 
     for (const handler of this.messageHandlers) {
       for (const MessageClass of handler.supportedMessages) {
-        if (canHandleMessageType(MessageClass, incomingMessageType)) return handler
+        if (didcommVersion === MessageClass.didCommVersion && canHandleMessageType(MessageClass, incomingMessageType)) {
+          return handler
+        }
       }
     }
   }
 
-  public getMessageClassForMessageType(messageType: string): ConstructableDidCommMessage | undefined {
+  public getMessageClassForMessageType(
+    messageType: string,
+    didcommVersion: DidCommMessageVersion
+  ): ConstructableDidCommMessage | undefined {
     const incomingMessageType = parseMessageType(messageType)
 
     for (const handler of this.messageHandlers) {
       for (const MessageClass of handler.supportedMessages) {
-        if (canHandleMessageType(MessageClass, incomingMessageType)) return MessageClass
+        if (didcommVersion === MessageClass.didCommVersion && canHandleMessageType(MessageClass, incomingMessageType)) {
+          return MessageClass
+        }
       }
     }
   }

--- a/packages/core/src/agent/MessageReceiver.ts
+++ b/packages/core/src/agent/MessageReceiver.ts
@@ -153,7 +153,9 @@ export class MessageReceiver {
     const { plaintextMessage, senderKey, recipientKey } = unpackedMessage
 
     this.logger.info(
-      `Received message with type '${plaintextMessage['@type']}', recipient key ${recipientKey?.fingerprint} and sender key ${senderKey?.fingerprint}`,
+      `Received message with type '${plaintextMessage['@type'] ?? plaintextMessage['type']}', recipient key ${
+        recipientKey?.fingerprint
+      } and sender key ${senderKey?.fingerprint}`,
       plaintextMessage
     )
 

--- a/packages/core/src/agent/MessageReceiver.ts
+++ b/packages/core/src/agent/MessageReceiver.ts
@@ -300,7 +300,9 @@ export class MessageReceiver {
       throw new AriesFrameworkError(`No type found in the message: ${message}`)
     }
 
-    const MessageClass = this.messageHandlerRegistry.getMessageClassForMessageType(messageType)
+    const didcommVersion = isPlaintextMessageV1(message) ? DidCommMessageVersion.V1 : DidCommMessageVersion.V2
+
+    const MessageClass = this.messageHandlerRegistry.getMessageClassForMessageType(messageType, didcommVersion)
 
     if (!MessageClass) {
       throw new ProblemReportError(`No message class found for message type "${messageType}"`, {

--- a/packages/core/src/agent/MessageReceiver.ts
+++ b/packages/core/src/agent/MessageReceiver.ts
@@ -7,7 +7,7 @@ import type { ConnectionRecord } from '../modules/connections'
 import type { InboundTransport } from '../transport'
 
 import { InjectionSymbols } from '../constants'
-import { isPlaintextMessageV1, isPlaintextMessageV2 } from '../didcomm'
+import { DidCommMessageVersion, isPlaintextMessageV1, isPlaintextMessageV2 } from '../didcomm'
 import { getPlaintextMessageType, isEncryptedMessage, isPlaintextMessage } from '../didcomm/helpers'
 import { AriesFrameworkError } from '../error'
 import { Logger } from '../logger'

--- a/packages/core/src/agent/MessageSender.ts
+++ b/packages/core/src/agent/MessageSender.ts
@@ -3,7 +3,7 @@ import type { PackMessageParams } from './EnvelopeService'
 import type { AgentMessageSentEvent } from './Events'
 import type { TransportSession } from './TransportService'
 import type { AgentContext } from './context'
-import type { DidCommV1Message, EncryptedMessage, OutboundPackage } from '../didcomm'
+import type { EncryptedMessage, OutboundPackage } from '../didcomm'
 import type { ConnectionRecord } from '../modules/connections'
 import type { ResolvedDidCommService } from '../modules/didcomm'
 import type { DidDocument } from '../modules/dids'
@@ -217,7 +217,7 @@ export class MessageSender {
     }
   ) {
     const { agentContext, connection, outOfBand } = outboundMessageContext
-    const message = outboundMessageContext.message as DidCommV1Message
+    const message = outboundMessageContext.message
 
     const errors: Error[] = []
 
@@ -320,8 +320,7 @@ export class MessageSender {
     // an incoming message.
     const [firstOurAuthenticationKey] = ourAuthenticationKeys
     // If the returnRoute is already set we won't override it. This allows to set the returnRoute manually if this is desired.
-    const shouldAddReturnRoute =
-      message.transport?.returnRoute === undefined && !this.transportService.hasInboundEndpoint(ourDidDocument)
+    const shouldAddReturnRoute = !message.hasAnyReturnRoute && !this.transportService.hasInboundEndpoint(ourDidDocument)
 
     // Loop through all available services and try to send the message
     for await (const service of services) {

--- a/packages/core/src/agent/MessageSender.ts
+++ b/packages/core/src/agent/MessageSender.ts
@@ -320,7 +320,8 @@ export class MessageSender {
     // an incoming message.
     const [firstOurAuthenticationKey] = ourAuthenticationKeys
     // If the returnRoute is already set we won't override it. This allows to set the returnRoute manually if this is desired.
-    const shouldAddReturnRoute = !message.hasAnyReturnRoute && !this.transportService.hasInboundEndpoint(ourDidDocument)
+    const shouldAddReturnRoute =
+      !message.hasAnyReturnRoute() && !this.transportService.hasInboundEndpoint(ourDidDocument)
 
     // Loop through all available services and try to send the message
     for await (const service of services) {

--- a/packages/core/src/agent/__tests__/MessageHandlerRegistry.test.ts
+++ b/packages/core/src/agent/__tests__/MessageHandlerRegistry.test.ts
@@ -1,6 +1,6 @@
 import type { MessageHandler } from '../MessageHandler'
 
-import { DidCommV1Message } from '../../didcomm'
+import { DidCommMessageVersion, DidCommV1Message } from '../../didcomm'
 import { parseMessageType } from '../../utils/messageType'
 import { MessageHandlerRegistry } from '../MessageHandlerRegistry'
 
@@ -112,28 +112,32 @@ describe('MessageHandlerRegistry', () => {
   describe('getMessageClassForMessageType()', () => {
     it('should return the correct message class for a registered message type', () => {
       const messageClass = messageHandlerRegistry.getMessageClassForMessageType(
-        'https://didcomm.org/connections/1.0/invitation'
+        'https://didcomm.org/connections/1.0/invitation',
+        DidCommMessageVersion.V1
       )
       expect(messageClass).toBe(ConnectionInvitationTestMessage)
     })
 
     it('should return undefined if no message class is registered for the message type', () => {
       const messageClass = messageHandlerRegistry.getMessageClassForMessageType(
-        'https://didcomm.org/non-existing/1.0/invitation'
+        'https://didcomm.org/non-existing/1.0/invitation',
+        DidCommMessageVersion.V1
       )
       expect(messageClass).toBeUndefined()
     })
 
     it('should return the message class with a higher minor version for the message type', () => {
       const messageClass = messageHandlerRegistry.getMessageClassForMessageType(
-        'https://didcomm.org/fake-protocol/1.0/message'
+        'https://didcomm.org/fake-protocol/1.0/message',
+        DidCommMessageVersion.V1
       )
       expect(messageClass).toBe(CustomProtocolMessage)
     })
 
     it('should not return the message class with a different major version', () => {
       const messageClass = messageHandlerRegistry.getMessageClassForMessageType(
-        'https://didcomm.org/fake-protocol/2.0/message'
+        'https://didcomm.org/fake-protocol/2.0/message',
+        DidCommMessageVersion.V1
       )
       expect(messageClass).toBeUndefined()
     })

--- a/packages/core/src/agent/getOutboundMessageContext.ts
+++ b/packages/core/src/agent/getOutboundMessageContext.ts
@@ -81,8 +81,8 @@ export async function getOutboundMessageContext(
 
   if (
     !(message instanceof DidCommV1Message) ||
-    !(lastReceivedMessage instanceof DidCommV1Message) ||
-    !(lastSentMessage instanceof DidCommV1Message)
+    (lastReceivedMessage !== undefined && !(lastReceivedMessage instanceof DidCommV1Message)) ||
+    (lastSentMessage !== undefined && !(lastSentMessage instanceof DidCommV1Message))
   ) {
     throw new AriesFrameworkError('No connection record associated with DIDComm V2 messages exchange')
   }

--- a/packages/core/src/decorators/thread/ThreadDecoratorExtension.ts
+++ b/packages/core/src/decorators/thread/ThreadDecoratorExtension.ts
@@ -21,6 +21,10 @@ export function ThreadDecorated<T extends DidComV1BaseMessageConstructor>(Base: 
       return this.thread?.threadId ?? this.id
     }
 
+    public get parentThreadId(): string | undefined {
+      return this.thread?.parentThreadId
+    }
+
     public setThread(options: Partial<ThreadDecorator>) {
       this.thread = new ThreadDecorator(options)
     }

--- a/packages/core/src/didcomm/index.ts
+++ b/packages/core/src/didcomm/index.ts
@@ -1,3 +1,4 @@
+import type { DidCommMessageVersion } from './types'
 import type { DidCommV1Message } from './versions/v1'
 import type { DidCommV2Message } from './versions/v2'
 import type { ParsedMessageType } from '../utils/messageType'
@@ -9,4 +10,7 @@ export * from './types'
 export * from './helpers'
 export * from './JweEnvelope'
 
-export type ConstructableDidCommMessage = Constructor<DidCommV1Message | DidCommV2Message> & { type: ParsedMessageType }
+export type ConstructableDidCommMessage = Constructor<DidCommV1Message | DidCommV2Message> & {
+  type: ParsedMessageType
+  didCommVersion: DidCommMessageVersion
+}

--- a/packages/core/src/didcomm/index.ts
+++ b/packages/core/src/didcomm/index.ts
@@ -6,6 +6,7 @@ import type { Constructor } from '../utils/mixins'
 
 export * from './versions/v1'
 export * from './versions/v2'
+export * from './transformers'
 export * from './types'
 export * from './helpers'
 export * from './JweEnvelope'

--- a/packages/core/src/didcomm/transformers.ts
+++ b/packages/core/src/didcomm/transformers.ts
@@ -1,0 +1,39 @@
+import { Attachment, AttachmentData, V2Attachment, V2AttachmentData } from '../decorators/attachment'
+
+export function toV2Attachment(v1Attachment: Attachment): V2Attachment {
+  const { id, description, byteCount, filename, lastmodTime, mimeType, data } = v1Attachment
+  return new V2Attachment({
+    id,
+    description,
+    byteCount,
+    filename,
+    lastmodTime,
+    mediaType: mimeType,
+    data: new V2AttachmentData({
+      base64: data.base64,
+      json: data.json,
+      jws: data.jws,
+      links: data.links,
+      hash: data.sha256,
+    }),
+  })
+}
+
+export function toV1Attachment(v2Attachment: V2Attachment): Attachment {
+  const { id, description, byteCount, filename, lastmodTime, mediaType, data } = v2Attachment
+  return new Attachment({
+    id,
+    description,
+    byteCount,
+    filename,
+    lastmodTime,
+    mimeType: mediaType,
+    data: new AttachmentData({
+      base64: data.base64,
+      json: data.json,
+      jws: data.jws,
+      links: data.links,
+      sha256: data.hash,
+    }),
+  })
+}

--- a/packages/core/src/didcomm/versions/v1/DidCommV1Message.ts
+++ b/packages/core/src/didcomm/versions/v1/DidCommV1Message.ts
@@ -33,9 +33,9 @@ export class DidCommV1Message extends Decorated implements AgentBaseMessage {
   @Exclude()
   public readonly allowDidSovPrefix: boolean = false
 
-  public get didCommVersion(): DidCommMessageVersion {
-    return DidCommMessageVersion.V1
-  }
+  @Exclude()
+  public readonly didCommVersion = DidCommMessageVersion.V1
+  public static readonly didCommVersion = DidCommMessageVersion.V1
 
   public serviceDecorator(): ServiceDecorator | undefined {
     return this.service

--- a/packages/core/src/didcomm/versions/v2/DidCommV2BaseMessage.ts
+++ b/packages/core/src/didcomm/versions/v2/DidCommV2BaseMessage.ts
@@ -17,11 +17,19 @@ export type DidCommV2MessageParams = {
   to?: string | string[]
   thid?: string
   parentThreadId?: string
+  senderOrder?: number
+  receivedOrders?: { [key: string]: number } // TODO: Update to DIDComm V2 format
   createdTime?: number
   expiresTime?: number
   fromPrior?: string
   attachments?: Array<V2Attachment>
   body?: unknown
+}
+
+type DidCommV2ReceiverOrder = {
+  id: string
+  last: number
+  gaps: number[]
 }
 
 export class DidCommV2BaseMessage {
@@ -63,6 +71,16 @@ export class DidCommV2BaseMessage {
   @IsOptional()
   public parentThreadId?: string
 
+  @Expose({ name: 'sender_order' })
+  @IsNumber()
+  @IsOptional()
+  public senderOrder?: number
+
+  @Expose({ name: 'received_orders' })
+  @IsOptional()
+  @IsArray()
+  public receivedOrders?: DidCommV2ReceiverOrder[]
+
   @Expose({ name: 'from_prior' })
   @IsString()
   @IsOptional()
@@ -86,6 +104,12 @@ export class DidCommV2BaseMessage {
       this.to = typeof options.to === 'string' ? [options.to] : options.to
       this.thid = options.thid
       this.parentThreadId = options.parentThreadId
+      this.senderOrder = options.senderOrder
+      this.receivedOrders = Object.entries(options.receivedOrders ?? {}).map(([id, last]) => ({
+        id,
+        last,
+        gaps: [],
+      }))
       this.createdTime = options.createdTime
       this.expiresTime = options.expiresTime
       this.fromPrior = options.fromPrior

--- a/packages/core/src/didcomm/versions/v2/DidCommV2Message.ts
+++ b/packages/core/src/didcomm/versions/v2/DidCommV2Message.ts
@@ -4,6 +4,8 @@ import type { ServiceDecorator } from '../../../decorators/service/ServiceDecora
 import type { ThreadDecorator } from '../../../decorators/thread/ThreadDecorator'
 import type { PlaintextMessage } from '../../types'
 
+import { Exclude } from 'class-transformer'
+
 import { AriesFrameworkError } from '../../../error'
 import { JsonTransformer } from '../../../utils/JsonTransformer'
 import { DidCommMessageVersion } from '../../types'
@@ -11,9 +13,9 @@ import { DidCommMessageVersion } from '../../types'
 import { DidCommV2BaseMessage } from './DidCommV2BaseMessage'
 
 export class DidCommV2Message extends DidCommV2BaseMessage implements AgentBaseMessage {
-  public get didCommVersion(): DidCommMessageVersion {
-    return DidCommMessageVersion.V2
-  }
+  @Exclude()
+  public readonly didCommVersion = DidCommMessageVersion.V2
+  public static readonly didCommVersion = DidCommMessageVersion.V2
 
   public toJSON(): PlaintextMessage {
     return JsonTransformer.toJSON(this) as PlaintextDidCommV2Message

--- a/packages/core/src/didcomm/versions/v2/DidCommV2Message.ts
+++ b/packages/core/src/didcomm/versions/v2/DidCommV2Message.ts
@@ -25,8 +25,8 @@ export class DidCommV2Message extends DidCommV2BaseMessage implements AgentBaseM
     return undefined
   }
 
-  public get threadId(): string | undefined {
-    return this.thid
+  public get threadId(): string {
+    return this.thid ?? this.id
   }
 
   public setThread(options: Partial<ThreadDecorator>) {

--- a/packages/core/src/didcomm/versions/v2/DidCommV2Message.ts
+++ b/packages/core/src/didcomm/versions/v2/DidCommV2Message.ts
@@ -1,6 +1,7 @@
 import type { PlaintextDidCommV2Message } from './types'
 import type { AgentBaseMessage } from '../../../agent/AgentBaseMessage'
 import type { ServiceDecorator } from '../../../decorators/service/ServiceDecorator'
+import type { ThreadDecorator } from '../../../decorators/thread/ThreadDecorator'
 import type { PlaintextMessage } from '../../types'
 
 import { AriesFrameworkError } from '../../../error'
@@ -24,6 +25,17 @@ export class DidCommV2Message extends DidCommV2BaseMessage implements AgentBaseM
 
   public get threadId(): string | undefined {
     return this.thid
+  }
+
+  public setThread(options: Partial<ThreadDecorator>) {
+    this.thid = options.threadId
+    this.parentThreadId = options.parentThreadId
+    this.senderOrder = options.senderOrder
+    this.receivedOrders = Object.entries(options.receivedOrders ?? {}).map(([id, last]) => ({
+      id,
+      last,
+      gaps: [],
+    }))
   }
 
   public hasAnyReturnRoute() {

--- a/packages/core/src/modules/discover-features/DiscoverFeaturesEvents.ts
+++ b/packages/core/src/modules/discover-features/DiscoverFeaturesEvents.ts
@@ -1,6 +1,6 @@
 import type { BaseEvent } from '../../agent/Events'
 import type { Feature, FeatureQueryOptions } from '../../agent/models'
-import type { DidCommV1Message } from '../../didcomm'
+import type { DidCommV1Message, DidCommV2Message } from '../../didcomm'
 import type { ConnectionRecord } from '../connections'
 
 export enum DiscoverFeaturesEventTypes {
@@ -11,7 +11,7 @@ export enum DiscoverFeaturesEventTypes {
 export interface DiscoverFeaturesQueryReceivedEvent extends BaseEvent {
   type: typeof DiscoverFeaturesEventTypes.QueryReceived
   payload: {
-    message: DidCommV1Message
+    message: DidCommV1Message | DidCommV2Message
     queries: FeatureQueryOptions[]
     protocolVersion: string
     connection: ConnectionRecord
@@ -22,7 +22,7 @@ export interface DiscoverFeaturesQueryReceivedEvent extends BaseEvent {
 export interface DiscoverFeaturesDisclosureReceivedEvent extends BaseEvent {
   type: typeof DiscoverFeaturesEventTypes.DisclosureReceived
   payload: {
-    message: DidCommV1Message
+    message: DidCommV1Message | DidCommV2Message
     disclosures: Feature[]
     protocolVersion: string
     connection: ConnectionRecord

--- a/packages/core/src/modules/discover-features/DiscoverFeaturesServiceOptions.ts
+++ b/packages/core/src/modules/discover-features/DiscoverFeaturesServiceOptions.ts
@@ -1,16 +1,19 @@
+import type { AgentBaseMessage } from '../../agent/AgentBaseMessage'
 import type { FeatureQueryOptions } from '../../agent/models'
-import type { DidCommV1Message } from '../../didcomm'
+import type { ConnectionRecord } from '../connections'
 
 export interface CreateQueryOptions {
+  connectionRecord?: ConnectionRecord
   queries: FeatureQueryOptions[]
   comment?: string
 }
 
 export interface CreateDisclosureOptions {
+  connectionRecord?: ConnectionRecord
   disclosureQueries: FeatureQueryOptions[]
   threadId?: string
 }
 
-export interface DiscoverFeaturesProtocolMsgReturnType<MessageType extends DidCommV1Message> {
+export interface DiscoverFeaturesProtocolMsgReturnType<MessageType extends AgentBaseMessage> {
   message: MessageType
 }

--- a/packages/core/src/modules/discover-features/__tests__/v2-discover-features.e2e.test.ts
+++ b/packages/core/src/modules/discover-features/__tests__/v2-discover-features.e2e.test.ts
@@ -6,11 +6,13 @@ import type {
 
 import { ReplaySubject } from 'rxjs'
 
-import { getIndySdkModules } from '../../../../../indy-sdk/tests/setupIndySdkModule'
+import { getAskarAnonCredsIndyModules } from '../../../../../anoncreds/tests/legacyAnonCredsSetup'
 import { setupSubjectTransports } from '../../../../tests'
 import { getAgentOptions, makeConnection } from '../../../../tests/helpers'
 import { Agent } from '../../../agent/Agent'
 import { GoalCode, Feature } from '../../../agent/models'
+import { DidCommMessageVersion } from '../../../didcomm'
+import { OutOfBandVersion } from '../../oob'
 import { DiscoverFeaturesEventTypes } from '../DiscoverFeaturesEvents'
 
 import { waitForDisclosureSubject, waitForQuerySubject } from './helpers'
@@ -20,7 +22,7 @@ const faberAgentOptions = getAgentOptions(
   {
     endpoints: ['rxjs:faber'],
   },
-  getIndySdkModules()
+  getAskarAnonCredsIndyModules()
 )
 
 const aliceAgentOptions = getAgentOptions(
@@ -28,206 +30,213 @@ const aliceAgentOptions = getAgentOptions(
   {
     endpoints: ['rxjs:alice'],
   },
-  getIndySdkModules()
+  getAskarAnonCredsIndyModules()
 )
 
-describe('v2 discover features', () => {
-  let faberAgent: Agent
-  let aliceAgent: Agent
-  let aliceConnection: ConnectionRecord
-  let faberConnection: ConnectionRecord
+describe.each([[DidCommMessageVersion.V1], [DidCommMessageVersion.V2]])(
+  `v2 discover features - %s`,
+  (didcommVersion) => {
+    let faberAgent: Agent
+    let aliceAgent: Agent
+    let aliceConnection: ConnectionRecord
+    let faberConnection: ConnectionRecord
 
-  beforeAll(async () => {
-    faberAgent = new Agent(faberAgentOptions)
-    aliceAgent = new Agent(aliceAgentOptions)
-    setupSubjectTransports([faberAgent, aliceAgent])
+    beforeAll(async () => {
+      faberAgent = new Agent(faberAgentOptions)
+      aliceAgent = new Agent(aliceAgentOptions)
+      setupSubjectTransports([faberAgent, aliceAgent])
 
-    await faberAgent.initialize()
-    await aliceAgent.initialize()
-    ;[faberConnection, aliceConnection] = await makeConnection(faberAgent, aliceAgent)
-  })
-
-  afterAll(async () => {
-    await faberAgent.shutdown()
-    await faberAgent.wallet.delete()
-    await aliceAgent.shutdown()
-    await aliceAgent.wallet.delete()
-  })
-
-  test('Faber asks Alice for issue credential protocol support', async () => {
-    const faberReplay = new ReplaySubject<DiscoverFeaturesDisclosureReceivedEvent>()
-    const aliceReplay = new ReplaySubject<DiscoverFeaturesQueryReceivedEvent>()
-
-    faberAgent.discovery.config.autoAcceptQueries
-    faberAgent.events
-      .observable<DiscoverFeaturesDisclosureReceivedEvent>(DiscoverFeaturesEventTypes.DisclosureReceived)
-      .subscribe(faberReplay)
-    aliceAgent.events
-      .observable<DiscoverFeaturesQueryReceivedEvent>(DiscoverFeaturesEventTypes.QueryReceived)
-      .subscribe(aliceReplay)
-
-    await faberAgent.discovery.queryFeatures({
-      connectionId: faberConnection.id,
-      protocolVersion: 'v2',
-      queries: [{ featureType: 'protocol', match: 'https://didcomm.org/revocation_notification/*' }],
+      await faberAgent.initialize()
+      await aliceAgent.initialize()
+      ;[faberConnection, aliceConnection] = await makeConnection(
+        faberAgent,
+        aliceAgent,
+        didcommVersion === DidCommMessageVersion.V2 ? OutOfBandVersion.V2 : undefined
+      )
     })
 
-    const query = await waitForQuerySubject(aliceReplay, { timeoutMs: 10000 })
-
-    expect(query).toMatchObject({
-      protocolVersion: 'v2',
-      queries: [{ featureType: 'protocol', match: 'https://didcomm.org/revocation_notification/*' }],
+    afterAll(async () => {
+      await faberAgent.shutdown()
+      await faberAgent.wallet.delete()
+      await aliceAgent.shutdown()
+      await aliceAgent.wallet.delete()
     })
 
-    const disclosure = await waitForDisclosureSubject(faberReplay, { timeoutMs: 10000 })
+    test('Faber asks Alice for issue credential protocol support', async () => {
+      const faberReplay = new ReplaySubject<DiscoverFeaturesDisclosureReceivedEvent>()
+      const aliceReplay = new ReplaySubject<DiscoverFeaturesQueryReceivedEvent>()
 
-    expect(disclosure).toMatchObject({
-      protocolVersion: 'v2',
-      disclosures: [
-        { type: 'protocol', id: 'https://didcomm.org/revocation_notification/1.0', roles: ['holder'] },
-        { type: 'protocol', id: 'https://didcomm.org/revocation_notification/2.0', roles: ['holder'] },
-      ],
-    })
-  })
+      faberAgent.discovery.config.autoAcceptQueries
+      faberAgent.events
+        .observable<DiscoverFeaturesDisclosureReceivedEvent>(DiscoverFeaturesEventTypes.DisclosureReceived)
+        .subscribe(faberReplay)
+      aliceAgent.events
+        .observable<DiscoverFeaturesQueryReceivedEvent>(DiscoverFeaturesEventTypes.QueryReceived)
+        .subscribe(aliceReplay)
 
-  test('Faber defines a supported goal code and Alice queries', async () => {
-    const faberReplay = new ReplaySubject<DiscoverFeaturesQueryReceivedEvent>()
-    const aliceReplay = new ReplaySubject<DiscoverFeaturesDisclosureReceivedEvent>()
+      await faberAgent.discovery.queryFeatures({
+        connectionId: faberConnection.id,
+        protocolVersion: 'v2',
+        queries: [{ featureType: 'protocol', match: 'https://didcomm.org/revocation_notification/*' }],
+      })
 
-    aliceAgent.events
-      .observable<DiscoverFeaturesDisclosureReceivedEvent>(DiscoverFeaturesEventTypes.DisclosureReceived)
-      .subscribe(aliceReplay)
-    faberAgent.events
-      .observable<DiscoverFeaturesQueryReceivedEvent>(DiscoverFeaturesEventTypes.QueryReceived)
-      .subscribe(faberReplay)
+      const query = await waitForQuerySubject(aliceReplay, { timeoutMs: 10000 })
 
-    // Register some goal codes
-    faberAgent.features.register(new GoalCode({ id: 'faber.vc.issuance' }), new GoalCode({ id: 'faber.vc.query' }))
+      expect(query).toMatchObject({
+        protocolVersion: 'v2',
+        queries: [{ featureType: 'protocol', match: 'https://didcomm.org/revocation_notification/*' }],
+      })
 
-    await aliceAgent.discovery.queryFeatures({
-      connectionId: aliceConnection.id,
-      protocolVersion: 'v2',
-      queries: [{ featureType: 'goal-code', match: '*' }],
-    })
+      const disclosure = await waitForDisclosureSubject(faberReplay, { timeoutMs: 10000 })
 
-    const query = await waitForQuerySubject(faberReplay, { timeoutMs: 10000 })
-
-    expect(query).toMatchObject({
-      protocolVersion: 'v2',
-      queries: [{ featureType: 'goal-code', match: '*' }],
+      expect(disclosure).toMatchObject({
+        protocolVersion: 'v2',
+        disclosures: [
+          { type: 'protocol', id: 'https://didcomm.org/revocation_notification/1.0', roles: ['holder'] },
+          { type: 'protocol', id: 'https://didcomm.org/revocation_notification/2.0', roles: ['holder'] },
+        ],
+      })
     })
 
-    const disclosure = await waitForDisclosureSubject(aliceReplay, { timeoutMs: 10000 })
+    test('Faber defines a supported goal code and Alice queries', async () => {
+      const faberReplay = new ReplaySubject<DiscoverFeaturesQueryReceivedEvent>()
+      const aliceReplay = new ReplaySubject<DiscoverFeaturesDisclosureReceivedEvent>()
 
-    expect(disclosure).toMatchObject({
-      protocolVersion: 'v2',
-      disclosures: [
-        { type: 'goal-code', id: 'faber.vc.issuance' },
-        { type: 'goal-code', id: 'faber.vc.query' },
-      ],
+      aliceAgent.events
+        .observable<DiscoverFeaturesDisclosureReceivedEvent>(DiscoverFeaturesEventTypes.DisclosureReceived)
+        .subscribe(aliceReplay)
+      faberAgent.events
+        .observable<DiscoverFeaturesQueryReceivedEvent>(DiscoverFeaturesEventTypes.QueryReceived)
+        .subscribe(faberReplay)
+
+      // Register some goal codes
+      faberAgent.features.register(new GoalCode({ id: 'faber.vc.issuance' }), new GoalCode({ id: 'faber.vc.query' }))
+
+      await aliceAgent.discovery.queryFeatures({
+        connectionId: aliceConnection.id,
+        protocolVersion: 'v2',
+        queries: [{ featureType: 'goal-code', match: '*' }],
+      })
+
+      const query = await waitForQuerySubject(faberReplay, { timeoutMs: 10000 })
+
+      expect(query).toMatchObject({
+        protocolVersion: 'v2',
+        queries: [{ featureType: 'goal-code', match: '*' }],
+      })
+
+      const disclosure = await waitForDisclosureSubject(aliceReplay, { timeoutMs: 10000 })
+
+      expect(disclosure).toMatchObject({
+        protocolVersion: 'v2',
+        disclosures: [
+          { type: 'goal-code', id: 'faber.vc.issuance' },
+          { type: 'goal-code', id: 'faber.vc.query' },
+        ],
+      })
     })
-  })
 
-  test('Faber defines a custom feature and Alice queries', async () => {
-    const faberReplay = new ReplaySubject<DiscoverFeaturesQueryReceivedEvent>()
-    const aliceReplay = new ReplaySubject<DiscoverFeaturesDisclosureReceivedEvent>()
+    test('Faber defines a custom feature and Alice queries', async () => {
+      const faberReplay = new ReplaySubject<DiscoverFeaturesQueryReceivedEvent>()
+      const aliceReplay = new ReplaySubject<DiscoverFeaturesDisclosureReceivedEvent>()
 
-    aliceAgent.events
-      .observable<DiscoverFeaturesDisclosureReceivedEvent>(DiscoverFeaturesEventTypes.DisclosureReceived)
-      .subscribe(aliceReplay)
-    faberAgent.events
-      .observable<DiscoverFeaturesQueryReceivedEvent>(DiscoverFeaturesEventTypes.QueryReceived)
-      .subscribe(faberReplay)
+      aliceAgent.events
+        .observable<DiscoverFeaturesDisclosureReceivedEvent>(DiscoverFeaturesEventTypes.DisclosureReceived)
+        .subscribe(aliceReplay)
+      faberAgent.events
+        .observable<DiscoverFeaturesQueryReceivedEvent>(DiscoverFeaturesEventTypes.QueryReceived)
+        .subscribe(faberReplay)
 
-    // Define a custom feature type
-    class GenericFeature extends Feature {
-      public 'generic-field'!: string
+      // Define a custom feature type
+      class GenericFeature extends Feature {
+        public 'generic-field'!: string
 
-      public constructor(options: { id: string; genericField: string }) {
-        super({ id: options.id, type: 'generic' })
-        this['generic-field'] = options.genericField
+        public constructor(options: { id: string; genericField: string }) {
+          super({ id: options.id, type: 'generic' })
+          this['generic-field'] = options.genericField
+        }
       }
-    }
 
-    // Register a custom feature
-    faberAgent.features.register(new GenericFeature({ id: 'custom-feature', genericField: 'custom-field' }))
+      // Register a custom feature
+      faberAgent.features.register(new GenericFeature({ id: 'custom-feature', genericField: 'custom-field' }))
 
-    await aliceAgent.discovery.queryFeatures({
-      connectionId: aliceConnection.id,
-      protocolVersion: 'v2',
-      queries: [{ featureType: 'generic', match: 'custom-feature' }],
+      await aliceAgent.discovery.queryFeatures({
+        connectionId: aliceConnection.id,
+        protocolVersion: 'v2',
+        queries: [{ featureType: 'generic', match: 'custom-feature' }],
+      })
+
+      const query = await waitForQuerySubject(faberReplay, { timeoutMs: 10000 })
+
+      expect(query).toMatchObject({
+        protocolVersion: 'v2',
+        queries: [{ featureType: 'generic', match: 'custom-feature' }],
+      })
+
+      const disclosure = await waitForDisclosureSubject(aliceReplay, { timeoutMs: 10000 })
+
+      expect(disclosure).toMatchObject({
+        protocolVersion: 'v2',
+        disclosures: [
+          {
+            type: 'generic',
+            id: 'custom-feature',
+            'generic-field': 'custom-field',
+          },
+        ],
+      })
     })
 
-    const query = await waitForQuerySubject(faberReplay, { timeoutMs: 10000 })
+    test('Faber proactively sends a set of features to Alice', async () => {
+      const faberReplay = new ReplaySubject<DiscoverFeaturesQueryReceivedEvent>()
+      const aliceReplay = new ReplaySubject<DiscoverFeaturesDisclosureReceivedEvent>()
 
-    expect(query).toMatchObject({
-      protocolVersion: 'v2',
-      queries: [{ featureType: 'generic', match: 'custom-feature' }],
+      aliceAgent.events
+        .observable<DiscoverFeaturesDisclosureReceivedEvent>(DiscoverFeaturesEventTypes.DisclosureReceived)
+        .subscribe(aliceReplay)
+      faberAgent.events
+        .observable<DiscoverFeaturesQueryReceivedEvent>(DiscoverFeaturesEventTypes.QueryReceived)
+        .subscribe(faberReplay)
+
+      // Register a custom feature
+      faberAgent.features.register(
+        new Feature({ id: 'AIP2.0', type: 'aip' }),
+        new Feature({ id: 'AIP2.0/INDYCRED', type: 'aip' }),
+        new Feature({ id: 'AIP2.0/MEDIATE', type: 'aip' })
+      )
+
+      await faberAgent.discovery.discloseFeatures({
+        connectionId: faberConnection.id,
+        protocolVersion: 'v2',
+        disclosureQueries: [{ featureType: 'aip', match: '*' }],
+      })
+
+      const disclosure = await waitForDisclosureSubject(aliceReplay, { timeoutMs: 10000 })
+
+      expect(disclosure).toMatchObject({
+        protocolVersion: 'v2',
+        disclosures: [
+          { type: 'aip', id: 'AIP2.0' },
+          { type: 'aip', id: 'AIP2.0/INDYCRED' },
+          { type: 'aip', id: 'AIP2.0/MEDIATE' },
+        ],
+      })
     })
 
-    const disclosure = await waitForDisclosureSubject(aliceReplay, { timeoutMs: 10000 })
+    test('Faber asks Alice for issue credential protocol support synchronously', async () => {
+      const matchingFeatures = await faberAgent.discovery.queryFeatures({
+        connectionId: faberConnection.id,
+        protocolVersion: 'v2',
+        queries: [{ featureType: 'protocol', match: 'https://didcomm.org/revocation_notification/*' }],
+        awaitDisclosures: true,
+      })
 
-    expect(disclosure).toMatchObject({
-      protocolVersion: 'v2',
-      disclosures: [
-        {
-          type: 'generic',
-          id: 'custom-feature',
-          'generic-field': 'custom-field',
-        },
-      ],
+      expect(matchingFeatures).toMatchObject({
+        features: [
+          { type: 'protocol', id: 'https://didcomm.org/revocation_notification/1.0', roles: ['holder'] },
+          { type: 'protocol', id: 'https://didcomm.org/revocation_notification/2.0', roles: ['holder'] },
+        ],
+      })
     })
-  })
-
-  test('Faber proactively sends a set of features to Alice', async () => {
-    const faberReplay = new ReplaySubject<DiscoverFeaturesQueryReceivedEvent>()
-    const aliceReplay = new ReplaySubject<DiscoverFeaturesDisclosureReceivedEvent>()
-
-    aliceAgent.events
-      .observable<DiscoverFeaturesDisclosureReceivedEvent>(DiscoverFeaturesEventTypes.DisclosureReceived)
-      .subscribe(aliceReplay)
-    faberAgent.events
-      .observable<DiscoverFeaturesQueryReceivedEvent>(DiscoverFeaturesEventTypes.QueryReceived)
-      .subscribe(faberReplay)
-
-    // Register a custom feature
-    faberAgent.features.register(
-      new Feature({ id: 'AIP2.0', type: 'aip' }),
-      new Feature({ id: 'AIP2.0/INDYCRED', type: 'aip' }),
-      new Feature({ id: 'AIP2.0/MEDIATE', type: 'aip' })
-    )
-
-    await faberAgent.discovery.discloseFeatures({
-      connectionId: faberConnection.id,
-      protocolVersion: 'v2',
-      disclosureQueries: [{ featureType: 'aip', match: '*' }],
-    })
-
-    const disclosure = await waitForDisclosureSubject(aliceReplay, { timeoutMs: 10000 })
-
-    expect(disclosure).toMatchObject({
-      protocolVersion: 'v2',
-      disclosures: [
-        { type: 'aip', id: 'AIP2.0' },
-        { type: 'aip', id: 'AIP2.0/INDYCRED' },
-        { type: 'aip', id: 'AIP2.0/MEDIATE' },
-      ],
-    })
-  })
-
-  test('Faber asks Alice for issue credential protocol support synchronously', async () => {
-    const matchingFeatures = await faberAgent.discovery.queryFeatures({
-      connectionId: faberConnection.id,
-      protocolVersion: 'v2',
-      queries: [{ featureType: 'protocol', match: 'https://didcomm.org/revocation_notification/*' }],
-      awaitDisclosures: true,
-    })
-
-    expect(matchingFeatures).toMatchObject({
-      features: [
-        { type: 'protocol', id: 'https://didcomm.org/revocation_notification/1.0', roles: ['holder'] },
-        { type: 'protocol', id: 'https://didcomm.org/revocation_notification/2.0', roles: ['holder'] },
-      ],
-    })
-  })
-})
+  }
+)

--- a/packages/core/src/modules/discover-features/protocol/v2/handlers/V2DisclosuresMessageHandler.ts
+++ b/packages/core/src/modules/discover-features/protocol/v2/handlers/V2DisclosuresMessageHandler.ts
@@ -2,10 +2,11 @@ import type { MessageHandler, MessageHandlerInboundMessage } from '../../../../.
 import type { V2DiscoverFeaturesService } from '../V2DiscoverFeaturesService'
 
 import { V2DisclosuresMessage } from '../messages'
+import { V2DisclosuresDidCommV2Message } from '../messages/V2DisclosuresDidCommV2Message'
 
 export class V2DisclosuresMessageHandler implements MessageHandler {
   private discoverFeaturesService: V2DiscoverFeaturesService
-  public supportedMessages = [V2DisclosuresMessage]
+  public supportedMessages = [V2DisclosuresMessage, V2DisclosuresDidCommV2Message]
 
   public constructor(discoverFeaturesService: V2DiscoverFeaturesService) {
     this.discoverFeaturesService = discoverFeaturesService

--- a/packages/core/src/modules/discover-features/protocol/v2/handlers/V2QueriesMessageHandler.ts
+++ b/packages/core/src/modules/discover-features/protocol/v2/handlers/V2QueriesMessageHandler.ts
@@ -1,26 +1,27 @@
 import type { MessageHandler, MessageHandlerInboundMessage } from '../../../../../agent/MessageHandler'
 import type { V2DiscoverFeaturesService } from '../V2DiscoverFeaturesService'
 
-import { OutboundMessageContext } from '../../../../../agent/models'
+import { getOutboundMessageContext } from '../../../../../agent/getOutboundMessageContext'
 import { V2QueriesMessage } from '../messages'
+import { V2QueriesDidCommV2Message } from '../messages/V2QueriesDidCommV2Message'
 
 export class V2QueriesMessageHandler implements MessageHandler {
   private discoverFeaturesService: V2DiscoverFeaturesService
-  public supportedMessages = [V2QueriesMessage]
+  public supportedMessages = [V2QueriesMessage, V2QueriesDidCommV2Message]
 
   public constructor(discoverFeaturesService: V2DiscoverFeaturesService) {
     this.discoverFeaturesService = discoverFeaturesService
   }
 
   public async handle(inboundMessage: MessageHandlerInboundMessage<V2QueriesMessageHandler>) {
-    const connection = inboundMessage.assertReadyConnection()
+    const connectionRecord = inboundMessage.assertReadyConnection()
 
     const discloseMessage = await this.discoverFeaturesService.processQuery(inboundMessage)
 
     if (discloseMessage) {
-      return new OutboundMessageContext(discloseMessage.message, {
-        agentContext: inboundMessage.agentContext,
-        connection,
+      return getOutboundMessageContext(inboundMessage.agentContext, {
+        message: discloseMessage.message,
+        connectionRecord,
       })
     }
   }

--- a/packages/core/src/modules/discover-features/protocol/v2/messages/V2DisclosuresDidCommV2Message.ts
+++ b/packages/core/src/modules/discover-features/protocol/v2/messages/V2DisclosuresDidCommV2Message.ts
@@ -1,0 +1,51 @@
+import type { V2DisclosuresMessageOptions } from './V2DisclosuresMessageOptions'
+
+import { Type } from 'class-transformer'
+import { IsInstance, IsObject, ValidateNested } from 'class-validator'
+
+import { Feature } from '../../../../../agent/models'
+import { DidCommV2Message } from '../../../../../didcomm'
+import { IsValidMessageType, parseMessageType } from '../../../../../utils/messageType'
+
+class V2DisclosuresMessageBody {
+  public constructor(options: { disclosures: Feature[] }) {
+    if (options) {
+      this.disclosures = options.disclosures
+    }
+  }
+  @IsInstance(Feature, { each: true })
+  @Type(() => Feature)
+  public disclosures!: Feature[]
+}
+
+export class V2DisclosuresDidCommV2Message extends DidCommV2Message {
+  public readonly allowDidSovPrefix = false
+
+  public constructor(options: V2DisclosuresMessageOptions) {
+    super()
+
+    if (options) {
+      this.id = options.id ?? this.generateId()
+      this.body = new V2DisclosuresMessageBody({ disclosures: options.features ?? [] })
+
+      if (options.threadId) {
+        this.setThread({
+          threadId: options.threadId,
+        })
+      }
+    }
+  }
+
+  @IsValidMessageType(V2DisclosuresDidCommV2Message.type)
+  public readonly type = V2DisclosuresDidCommV2Message.type.messageTypeUri
+  public static readonly type = parseMessageType('https://didcomm.org/discover-features/2.0/disclosures')
+
+  @IsObject()
+  @ValidateNested()
+  @Type(() => V2DisclosuresMessageBody)
+  public body!: V2DisclosuresMessageBody
+
+  public get disclosures() {
+    return this.body.disclosures
+  }
+}

--- a/packages/core/src/modules/discover-features/protocol/v2/messages/V2DisclosuresMessage.ts
+++ b/packages/core/src/modules/discover-features/protocol/v2/messages/V2DisclosuresMessage.ts
@@ -1,15 +1,11 @@
+import type { V2DisclosuresMessageOptions } from './V2DisclosuresMessageOptions'
+
 import { Type } from 'class-transformer'
 import { IsInstance } from 'class-validator'
 
 import { Feature } from '../../../../../agent/models'
 import { DidCommV1Message } from '../../../../../didcomm'
 import { IsValidMessageType, parseMessageType } from '../../../../../utils/messageType'
-
-export interface V2DisclosuresMessageOptions {
-  id?: string
-  threadId?: string
-  features?: Feature[]
-}
 
 export class V2DisclosuresMessage extends DidCommV1Message {
   public constructor(options: V2DisclosuresMessageOptions) {

--- a/packages/core/src/modules/discover-features/protocol/v2/messages/V2DisclosuresMessageOptions.ts
+++ b/packages/core/src/modules/discover-features/protocol/v2/messages/V2DisclosuresMessageOptions.ts
@@ -1,0 +1,7 @@
+import type { Feature } from '../../../../../agent/models'
+
+export interface V2DisclosuresMessageOptions {
+  id?: string
+  threadId?: string
+  features?: Feature[]
+}

--- a/packages/core/src/modules/discover-features/protocol/v2/messages/V2QueriesDidCommV2Message.ts
+++ b/packages/core/src/modules/discover-features/protocol/v2/messages/V2QueriesDidCommV2Message.ts
@@ -1,0 +1,46 @@
+import type { V2QueriesMessageOptions } from './V2QueriesMessageOptions'
+
+import { Type } from 'class-transformer'
+import { ArrayNotEmpty, IsInstance, IsObject, ValidateNested } from 'class-validator'
+
+import { FeatureQuery } from '../../../../../agent/models'
+import { DidCommV2Message } from '../../../../../didcomm'
+import { IsValidMessageType, parseMessageType } from '../../../../../utils/messageType'
+
+class V2QueriesMessageBody {
+  public constructor(options: { queries: FeatureQuery[] }) {
+    if (options) {
+      this.queries = options.queries
+    }
+  }
+  @IsInstance(FeatureQuery, { each: true })
+  @Type(() => FeatureQuery)
+  @ArrayNotEmpty()
+  public queries!: FeatureQuery[]
+}
+
+export class V2QueriesDidCommV2Message extends DidCommV2Message {
+  public readonly allowDidSovPrefix = false
+
+  public constructor(options: V2QueriesMessageOptions) {
+    super()
+
+    if (options) {
+      this.id = options.id ?? this.generateId()
+      this.body = new V2QueriesMessageBody({ queries: options.queries.map((q) => new FeatureQuery(q)) })
+    }
+  }
+
+  @IsValidMessageType(V2QueriesDidCommV2Message.type)
+  public readonly type = V2QueriesDidCommV2Message.type.messageTypeUri
+  public static readonly type = parseMessageType('https://didcomm.org/discover-features/2.0/queries')
+
+  @IsObject()
+  @ValidateNested()
+  @Type(() => V2QueriesMessageBody)
+  public body!: V2QueriesMessageBody
+
+  public get queries() {
+    return this.body.queries
+  }
+}

--- a/packages/core/src/modules/discover-features/protocol/v2/messages/V2QueriesMessage.ts
+++ b/packages/core/src/modules/discover-features/protocol/v2/messages/V2QueriesMessage.ts
@@ -1,4 +1,4 @@
-import type { FeatureQueryOptions } from '../../../../../agent/models'
+import type { V2QueriesMessageOptions } from './V2QueriesMessageOptions'
 
 import { Type } from 'class-transformer'
 import { ArrayNotEmpty, IsInstance } from 'class-validator'
@@ -7,14 +7,8 @@ import { FeatureQuery } from '../../../../../agent/models'
 import { DidCommV1Message } from '../../../../../didcomm'
 import { IsValidMessageType, parseMessageType } from '../../../../../utils/messageType'
 
-export interface V2DiscoverFeaturesQueriesMessageOptions {
-  id?: string
-  queries: FeatureQueryOptions[]
-  comment?: string
-}
-
 export class V2QueriesMessage extends DidCommV1Message {
-  public constructor(options: V2DiscoverFeaturesQueriesMessageOptions) {
+  public constructor(options: V2QueriesMessageOptions) {
     super()
 
     if (options) {

--- a/packages/core/src/modules/discover-features/protocol/v2/messages/V2QueriesMessageOptions.ts
+++ b/packages/core/src/modules/discover-features/protocol/v2/messages/V2QueriesMessageOptions.ts
@@ -1,0 +1,6 @@
+import type { FeatureQueryOptions } from '../../../../../agent/models'
+
+export interface V2QueriesMessageOptions {
+  id?: string
+  queries: FeatureQueryOptions[]
+}

--- a/packages/core/src/modules/discover-features/services/DiscoverFeaturesService.ts
+++ b/packages/core/src/modules/discover-features/services/DiscoverFeaturesService.ts
@@ -1,7 +1,7 @@
 import type { EventEmitter } from '../../../agent/EventEmitter'
 import type { FeatureRegistry } from '../../../agent/FeatureRegistry'
 import type { InboundMessageContext } from '../../../agent/models/InboundMessageContext'
-import type { DidCommV1Message } from '../../../didcomm'
+import type { DidCommV1Message, DidCommV2Message } from '../../../didcomm'
 import type { Logger } from '../../../logger'
 import type { DiscoverFeaturesModuleConfig } from '../DiscoverFeaturesModuleConfig'
 import type {
@@ -32,13 +32,15 @@ export abstract class DiscoverFeaturesService {
 
   public abstract createQuery(
     options: CreateQueryOptions
-  ): Promise<DiscoverFeaturesProtocolMsgReturnType<DidCommV1Message>>
+  ): Promise<DiscoverFeaturesProtocolMsgReturnType<DidCommV1Message | DidCommV2Message>>
   public abstract processQuery(
-    messageContext: InboundMessageContext<DidCommV1Message>
-  ): Promise<DiscoverFeaturesProtocolMsgReturnType<DidCommV1Message> | void>
+    messageContext: InboundMessageContext<DidCommV1Message | DidCommV2Message>
+  ): Promise<DiscoverFeaturesProtocolMsgReturnType<DidCommV1Message | DidCommV2Message> | void>
 
   public abstract createDisclosure(
     options: CreateDisclosureOptions
-  ): Promise<DiscoverFeaturesProtocolMsgReturnType<DidCommV1Message>>
-  public abstract processDisclosure(messageContext: InboundMessageContext<DidCommV1Message>): Promise<void>
+  ): Promise<DiscoverFeaturesProtocolMsgReturnType<DidCommV1Message | DidCommV2Message>>
+  public abstract processDisclosure(
+    messageContext: InboundMessageContext<DidCommV1Message | DidCommV2Message>
+  ): Promise<void>
 }

--- a/packages/core/src/modules/problem-reports/versions/v2/helpers.ts
+++ b/packages/core/src/modules/problem-reports/versions/v2/helpers.ts
@@ -2,7 +2,7 @@ import type { PlaintextDidCommV2Message } from '../../../../didcomm'
 
 import { ProblemReportReason } from '../../models/ProblemReportReason'
 
-import { ProblemReportMessage } from './messages'
+import { V2ProblemReportMessage } from './messages'
 
 /**
  * Build the v2 problem report message to the recipient.
@@ -12,11 +12,11 @@ import { ProblemReportMessage } from './messages'
 export const buildProblemReportV2Message = (
   plaintextMessage: PlaintextDidCommV2Message,
   errorMessage: string
-): ProblemReportMessage | undefined => {
+): V2ProblemReportMessage | undefined => {
   // Cannot send problem report for message with unknown sender or recipient
   if (!plaintextMessage.from || !plaintextMessage.to?.length) return
 
-  return new ProblemReportMessage({
+  return new V2ProblemReportMessage({
     parentThreadId: plaintextMessage.id,
     from: plaintextMessage.to.length ? plaintextMessage.to[0] : undefined,
     to: plaintextMessage.from,

--- a/packages/core/src/modules/problem-reports/versions/v2/index.ts
+++ b/packages/core/src/modules/problem-reports/versions/v2/index.ts
@@ -1,2 +1,2 @@
-export { ProblemReportMessage as V2ProblemReportMessage } from './messages'
+export { V2ProblemReportMessage } from './messages'
 export { buildProblemReportV2Message } from './helpers'

--- a/packages/core/src/modules/problem-reports/versions/v2/messages/V2ProblemReportMessage.ts
+++ b/packages/core/src/modules/problem-reports/versions/v2/messages/V2ProblemReportMessage.ts
@@ -27,7 +27,7 @@ export class ProblemReportBody {
   public args?: string[]
 }
 
-export class ProblemReportMessage extends DidCommV2Message {
+export class V2ProblemReportMessage extends DidCommV2Message {
   public constructor(options?: V2ProblemReportMessageOptions) {
     super(options)
     if (options) {
@@ -36,8 +36,8 @@ export class ProblemReportMessage extends DidCommV2Message {
     }
   }
 
-  @IsValidMessageType(ProblemReportMessage.type)
-  public readonly type = ProblemReportMessage.type.messageTypeUri
+  @IsValidMessageType(V2ProblemReportMessage.type)
+  public readonly type = V2ProblemReportMessage.type.messageTypeUri
   public static readonly type = parseMessageType('https://didcomm.org/report-problem/2.0/problem-report')
 
   @Expose({ name: 'body' })

--- a/packages/core/src/modules/problem-reports/versions/v2/messages/index.ts
+++ b/packages/core/src/modules/problem-reports/versions/v2/messages/index.ts
@@ -1,1 +1,1 @@
-export * from './ProblemReportMessage'
+export * from './V2ProblemReportMessage'

--- a/packages/core/src/storage/didcomm/DidCommMessageRecord.ts
+++ b/packages/core/src/storage/didcomm/DidCommMessageRecord.ts
@@ -58,13 +58,13 @@ export class DidCommMessageRecord extends BaseRecord<DefaultDidCommMessageTags> 
   }
 
   public getTags() {
-    const messageId = this.message['@id'] as string
-    const messageType = this.message['@type'] as string
+    const messageId = (this.message['@id'] ?? this.message['id']) as string
+    const messageType = (this.message['@type'] ?? this.message['type']) as string
 
     const { protocolName, protocolMajorVersion, protocolMinorVersion, messageName } = parseMessageType(messageType)
 
     const thread = this.message['~thread']
-    let threadId = messageId
+    let threadId = (this.message['thid'] ?? messageId) as string
 
     if (isJsonObject(thread) && typeof thread.thid === 'string') {
       threadId = thread.thid
@@ -89,7 +89,7 @@ export class DidCommMessageRecord extends BaseRecord<DefaultDidCommMessageTags> 
   public getMessageInstance<MessageClass extends ConstructableDidCommMessage = ConstructableDidCommMessage>(
     messageClass: MessageClass
   ): InstanceType<MessageClass> {
-    const messageType = parseMessageType(this.message['@type'] as string)
+    const messageType = parseMessageType((this.message['@type'] ?? this.message['type']) as string)
 
     if (!canHandleMessageType(messageClass, messageType)) {
       throw new AriesFrameworkError('Provided message class type does not match type of stored message')


### PR DESCRIPTION
Discover Features 2.0 is one of those protocols that are suitable for both DIDComm V1 and V2. However, this becomes a bit complicated because current AFJ model considers that a given message type is defined for either V1 or V2.

So after an interesting discussion in a previous AFJ WG Call, we found out that we can leave each protocol determine which versions it supports and register both models into the `MessageHandlerRegistry`, which will now allow to filter not only by message type (PIURI) but also by DIDComm version.

In this PR we have:
- Different fixes and adaptations for DIDComm V2 (like attachment transformers, message handling, etc.) found during the work of other PRs (#1546 and #1560). This would make this PR to be the basis of those, which will hopefully only add new protocols and make their review easier
- New handling of received messages in `MessageReceiver` and `Dispatcher` to figure out whether it is a DIDComm V1 or V2 message and find the right class and handler
- Updates in Discover Features module to add DIDComm V2 modeling for Query and Disclosure messages, and register/process both in a single handler and service
- There are some slight API changes, like the return types and events, due to messages can be now either be DIDComm V1 or V2. I think in the next major release (before merging DIDComm V2 to main) we can remove the complete message object from the event, as the relevant fields are sent as separate properties (and in case we want to go low level and get the complete message we can subscribe  to `AgentMessageProcessedEvent`)
- Discover Features V2 E2E test has been updated to work in both DIDComm V1 and V2. This makes it to require Askar. As we'll switch soon our tests to node 18 + shared components I guess there is no problem on that

