### PR TITLE
ci: fix git checkout path and update setup-node

### DIFF
--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -14,7 +14,7 @@ jobs:
     name: Release Canary
     if: "!startsWith(github.event.head_commit.message, 'chore(release): v')"
     steps:
-      - name: Checkout agent-framework-javascript
+      - name: Checkout credo-ts
         uses: actions/checkout@v4
         with:
           # pulls all commits (needed for lerna to correctly version)
@@ -25,7 +25,7 @@ jobs:
         uses: ./.github/actions/setup-libindy
 
       - name: Setup NodeJS
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18
           cache: 'yarn'
@@ -74,7 +74,7 @@ jobs:
         uses: ./.github/actions/setup-libindy
 
       - name: Setup NodeJS
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18
           cache: 'yarn'

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -12,7 +12,7 @@ env:
   TEST_AGENT_PUBLIC_DID_SEED: 000000000000000000000000Trustee9
   ENDORSER_AGENT_PUBLIC_DID_SEED: 00000000000000000000000Endorser9
   GENESIS_TXN_PATH: network/genesis/local-genesis.txn
-  LIB_INDY_STRG_POSTGRES: /home/runner/work/agent-framework-javascript/indy-sdk/experimental/plugins/postgres_storage/target/release # for Linux
+  LIB_INDY_STRG_POSTGRES: /home/runner/work/credo-ts/indy-sdk/experimental/plugins/postgres_storage/target/release # for Linux
   NODE_OPTIONS: --max_old_space_size=6144
 
 # Make sure we're not running multiple release steps at the same time as this can give issues with determining the next npm version to release.
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-20.04
     name: Validate
     steps:
-      - name: Checkout agent-framework-javascript
+      - name: Checkout credo-ts
         uses: actions/checkout@v4
 
       # setup dependencies
@@ -58,7 +58,7 @@ jobs:
         uses: ./.github/actions/setup-libindy
 
       - name: Setup NodeJS
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18
           cache: 'yarn'
@@ -111,7 +111,7 @@ jobs:
         uses: ./.github/actions/setup-postgres-wallet-plugin
 
       - name: Setup NodeJS
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'yarn'
@@ -143,7 +143,7 @@ jobs:
         uses: ./.github/actions/setup-libindy
 
       - name: Setup NodeJS
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18
           cache: 'yarn'


### PR DESCRIPTION
Same issue as the one fixed in #1669 when we changed from aries-framework-javascript to agent-framework-javascript.

Also updates the deprecated setup-node action (supersedes #1624).