### PR TITLE
feat(dids)!: did caching

### DIFF
--- a/packages/anoncreds-rs/tests/LocalDidResolver.ts
+++ b/packages/anoncreds-rs/tests/LocalDidResolver.ts
@@ -4,6 +4,7 @@ import { DidsApi } from '@aries-framework/core'
 
 export class LocalDidResolver implements DidResolver {
   public readonly supportedMethods = ['sov', 'indy']
+  public readonly allowsCaching = false
 
   public async resolve(agentContext: AgentContext, did: string): Promise<DidResolutionResult> {
     const didDocumentMetadata = {}

--- a/packages/cheqd/src/dids/CheqdDidResolver.ts
+++ b/packages/cheqd/src/dids/CheqdDidResolver.ts
@@ -19,6 +19,7 @@ import { filterResourcesByNameAndType, getClosestResourceVersion, renderResource
 
 export class CheqdDidResolver implements DidResolver {
   public readonly supportedMethods = ['cheqd']
+  public readonly allowsCaching = true
 
   public async resolve(agentContext: AgentContext, did: string, parsed: ParsedDid): Promise<DidResolutionResult> {
     const didDocumentMetadata = {}

--- a/packages/core/src/modules/connections/__tests__/InMemoryDidRegistry.ts
+++ b/packages/core/src/modules/connections/__tests__/InMemoryDidRegistry.ts
@@ -15,6 +15,8 @@ import { DidRecord, DidDocumentRole, DidRepository } from '../../dids'
 export class InMemoryDidRegistry implements DidRegistrar, DidResolver {
   public readonly supportedMethods = ['inmemory']
 
+  public readonly allowsCaching = false
+
   private dids: Record<string, DidDocument> = {}
 
   public async create(agentContext: AgentContext, options: DidCreateOptions): Promise<DidCreateResult> {

--- a/packages/core/src/modules/dids/domain/DidResolver.ts
+++ b/packages/core/src/modules/dids/domain/DidResolver.ts
@@ -3,6 +3,8 @@ import type { ParsedDid, DidResolutionResult, DidResolutionOptions } from '../ty
 
 export interface DidResolver {
   readonly supportedMethods: string[]
+  readonly allowsCaching: boolean
+
   resolve(
     agentContext: AgentContext,
     did: string,

--- a/packages/core/src/modules/dids/methods/jwk/JwkDidResolver.ts
+++ b/packages/core/src/modules/dids/methods/jwk/JwkDidResolver.ts
@@ -7,6 +7,11 @@ import { DidJwk } from './DidJwk'
 export class JwkDidResolver implements DidResolver {
   public readonly supportedMethods = ['jwk']
 
+  /**
+   * No remote resolving done, did document is dynamically constructed. To not pollute the cache we don't allow caching
+   */
+  public readonly allowsCaching = false
+
   public async resolve(agentContext: AgentContext, did: string): Promise<DidResolutionResult> {
     const didDocumentMetadata = {}
 

--- a/packages/core/src/modules/dids/methods/key/KeyDidResolver.ts
+++ b/packages/core/src/modules/dids/methods/key/KeyDidResolver.ts
@@ -7,6 +7,11 @@ import { DidKey } from './DidKey'
 export class KeyDidResolver implements DidResolver {
   public readonly supportedMethods = ['key']
 
+  /**
+   * No remote resolving done, did document is dynamically constructed. To not pollute the cache we don't allow caching
+   */
+  public readonly allowsCaching = false
+
   public async resolve(agentContext: AgentContext, did: string): Promise<DidResolutionResult> {
     const didDocumentMetadata = {}
 

--- a/packages/core/src/modules/dids/methods/peer/PeerDidResolver.ts
+++ b/packages/core/src/modules/dids/methods/peer/PeerDidResolver.ts
@@ -14,6 +14,11 @@ import { didToNumAlgo4DidDocument, isShortFormDidPeer4 } from './peerDidNumAlgo4
 export class PeerDidResolver implements DidResolver {
   public readonly supportedMethods = ['peer']
 
+  /**
+   * No remote resolving done, did document is fetched from storage. To not pollute the cache we don't allow caching
+   */
+  public readonly allowsCaching = false
+
   public async resolve(agentContext: AgentContext, did: string): Promise<DidResolutionResult> {
     const didRepository = agentContext.dependencyManager.resolve(DidRepository)
 

--- a/packages/core/src/modules/dids/methods/web/WebDidResolver.ts
+++ b/packages/core/src/modules/dids/methods/web/WebDidResolver.ts
@@ -11,6 +11,8 @@ import { DidDocument } from '../../domain'
 export class WebDidResolver implements DidResolver {
   public readonly supportedMethods
 
+  public readonly allowsCaching = true
+
   // FIXME: Would be nice if we don't have to provide a did resolver instance
   private _resolverInstance = new Resolver()
   private resolver = didWeb.getResolver()

--- a/packages/core/src/modules/dids/services/__tests__/DidResolverService.test.ts
+++ b/packages/core/src/modules/dids/services/__tests__/DidResolverService.test.ts
@@ -2,6 +2,7 @@ import type { DidResolver } from '../../domain'
 
 import { getAgentConfig, getAgentContext, mockFunction } from '../../../../../tests/helpers'
 import { JsonTransformer } from '../../../../utils/JsonTransformer'
+import { CacheModuleConfig, InMemoryLruCache } from '../../../cache'
 import { DidsModuleConfig } from '../../DidsModuleConfig'
 import didKeyEd25519Fixture from '../../__tests__/__fixtures__/didKeyEd25519.json'
 import { DidDocument } from '../../domain'
@@ -9,18 +10,26 @@ import { parseDid } from '../../domain/parse'
 import { DidResolverService } from '../DidResolverService'
 
 const didResolverMock = {
+  allowsCaching: true,
   supportedMethods: ['key'],
   resolve: jest.fn(),
 } as DidResolver
 
+const cache = new InMemoryLruCache({ limit: 10 })
 const agentConfig = getAgentConfig('DidResolverService')
-const agentContext = getAgentContext()
+const agentContext = getAgentContext({
+  registerInstances: [[CacheModuleConfig, new CacheModuleConfig({ cache })]],
+})
 
 describe('DidResolverService', () => {
   const didResolverService = new DidResolverService(
     agentConfig.logger,
     new DidsModuleConfig({ resolvers: [didResolverMock] })
   )
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
 
   it('should correctly find and call the correct resolver for a specified did', async () => {
     const returnValue = {
@@ -33,12 +42,70 @@ describe('DidResolverService', () => {
     mockFunction(didResolverMock.resolve).mockResolvedValue(returnValue)
 
     const result = await didResolverService.resolve(agentContext, 'did:key:xxxx', { someKey: 'string' })
-    expect(result).toEqual(returnValue)
+    expect(result).toEqual({
+      ...returnValue,
+      didResolutionMetadata: {
+        ...returnValue.didResolutionMetadata,
+        resolutionTime: expect.any(Number),
+        servedFromCache: false,
+      },
+    })
 
     expect(didResolverMock.resolve).toHaveBeenCalledTimes(1)
     expect(didResolverMock.resolve).toHaveBeenCalledWith(agentContext, 'did:key:xxxx', parseDid('did:key:xxxx'), {
       someKey: 'string',
     })
+  })
+
+  it('should return cached did document when resolved multiple times within caching duration', async () => {
+    const returnValue = {
+      didDocument: JsonTransformer.fromJSON(didKeyEd25519Fixture, DidDocument),
+      didDocumentMetadata: {},
+      didResolutionMetadata: {
+        contentType: 'application/did+ld+json',
+      },
+    }
+    mockFunction(didResolverMock.resolve).mockResolvedValue(returnValue)
+
+    const result = await didResolverService.resolve(agentContext, 'did:key:cached', { someKey: 'string' })
+    const cachedValue = await cache.get(agentContext, 'did:resolver:did:key:cached')
+
+    expect(result).toEqual({
+      ...returnValue,
+      didResolutionMetadata: {
+        ...returnValue.didResolutionMetadata,
+        resolutionTime: expect.any(Number),
+        servedFromCache: false,
+      },
+    })
+
+    expect(cachedValue).toEqual({
+      ...returnValue,
+      didDocument: returnValue.didDocument.toJSON(),
+      didResolutionMetadata: {
+        ...returnValue.didResolutionMetadata,
+        resolutionTime: expect.any(Number),
+        servedFromCache: false,
+      },
+    })
+
+    expect(didResolverMock.resolve).toHaveBeenCalledTimes(1)
+    expect(didResolverMock.resolve).toHaveBeenCalledWith(agentContext, 'did:key:cached', parseDid('did:key:cached'), {
+      someKey: 'string',
+    })
+
+    const resultCached = await didResolverService.resolve(agentContext, 'did:key:cached', { someKey: 'string' })
+    expect(resultCached).toEqual({
+      ...returnValue,
+      didResolutionMetadata: {
+        ...returnValue.didResolutionMetadata,
+        resolutionTime: expect.any(Number),
+        servedFromCache: true,
+      },
+    })
+
+    // Still called once because served from cache
+    expect(didResolverMock.resolve).toHaveBeenCalledTimes(1)
   })
 
   it("should return an error with 'invalidDid' if the did string couldn't be parsed", async () => {

--- a/packages/core/src/modules/dids/types.ts
+++ b/packages/core/src/modules/dids/types.ts
@@ -2,11 +2,34 @@ import type { DidDocument } from './domain'
 import type { DIDDocumentMetadata, DIDResolutionMetadata, DIDResolutionOptions, ParsedDID } from 'did-resolver'
 
 export type ParsedDid = ParsedDID
-export type DidResolutionOptions = DIDResolutionOptions
 export type DidDocumentMetadata = DIDDocumentMetadata
+
+export interface DidResolutionOptions extends DIDResolutionOptions {
+  /**
+   * Whether to resolve the did document from the cache.
+   *
+   * @default true
+   */
+  useCache?: boolean
+
+  /**
+   * Whether to persist the did document in the cache.
+   *
+   * @default true
+   */
+  persistInCache?: boolean
+
+  /**
+   * How many seconds to persist the resolved document
+   *
+   * @default 3600
+   */
+  cacheDurationInSeconds?: number
+}
 
 export interface DidResolutionMetadata extends DIDResolutionMetadata {
   message?: string
+  servedFromCache?: boolean
 }
 
 export interface DidResolutionResult {

--- a/packages/indy-sdk/src/dids/IndySdkIndyDidResolver.ts
+++ b/packages/indy-sdk/src/dids/IndySdkIndyDidResolver.ts
@@ -16,6 +16,8 @@ import { addServicesFromEndpointsAttrib } from './didSovUtil'
 export class IndySdkIndyDidResolver implements DidResolver {
   public readonly supportedMethods = ['indy']
 
+  public readonly allowsCaching = true
+
   public async resolve(agentContext: AgentContext, did: string): Promise<DidResolutionResult> {
     const didDocumentMetadata = {}
 

--- a/packages/indy-sdk/src/dids/IndySdkSovDidResolver.ts
+++ b/packages/indy-sdk/src/dids/IndySdkSovDidResolver.ts
@@ -12,6 +12,8 @@ import { addServicesFromEndpointsAttrib, sovDidDocumentFromDid } from './didSovU
 export class IndySdkSovDidResolver implements DidResolver {
   public readonly supportedMethods = ['sov']
 
+  public readonly allowsCaching = true
+
   public async resolve(agentContext: AgentContext, did: string, parsed: ParsedDid): Promise<DidResolutionResult> {
     const didDocumentMetadata = {}
 

--- a/packages/indy-vdr/src/dids/IndyVdrIndyDidResolver.ts
+++ b/packages/indy-vdr/src/dids/IndyVdrIndyDidResolver.ts
@@ -9,6 +9,8 @@ import { buildDidDocument } from './didIndyUtil'
 export class IndyVdrIndyDidResolver implements DidResolver {
   public readonly supportedMethods = ['indy']
 
+  public readonly allowsCaching = true
+
   public async resolve(agentContext: AgentContext, did: string): Promise<DidResolutionResult> {
     const didDocumentMetadata = {}
     try {

--- a/packages/indy-vdr/src/dids/IndyVdrSovDidResolver.ts
+++ b/packages/indy-vdr/src/dids/IndyVdrSovDidResolver.ts
@@ -12,6 +12,8 @@ import { addServicesFromEndpointsAttrib, sovDidDocumentFromDid } from './didSovU
 export class IndyVdrSovDidResolver implements DidResolver {
   public readonly supportedMethods = ['sov']
 
+  public readonly allowsCaching = true
+
   public async resolve(agentContext: AgentContext, did: string, parsed: ParsedDid): Promise<DidResolutionResult> {
     const didDocumentMetadata = {}
 

--- a/packages/tenants/tests/tenants.e2e.test.ts
+++ b/packages/tenants/tests/tenants.e2e.test.ts
@@ -1,6 +1,6 @@
 import type { InitConfig } from '@aries-framework/core'
 
-import { ConnectionsModule, OutOfBandRecord, Agent } from '@aries-framework/core'
+import { ConnectionsModule, OutOfBandRecord, Agent, CacheModule, InMemoryLruCache } from '@aries-framework/core'
 import { agentDependencies } from '@aries-framework/node'
 
 import { SubjectInboundTransport } from '../../../tests/transport/SubjectInboundTransport'
@@ -39,6 +39,9 @@ const agent1 = new Agent({
     connections: new ConnectionsModule({
       autoAcceptConnections: true,
     }),
+    cache: new CacheModule({
+      cache: new InMemoryLruCache({ limit: 500 }),
+    }),
   },
   dependencies: agentDependencies,
 })
@@ -50,6 +53,9 @@ const agent2 = new Agent({
     indySdk: new IndySdkModule({ indySdk }),
     connections: new ConnectionsModule({
       autoAcceptConnections: true,
+    }),
+    cache: new CacheModule({
+      cache: new InMemoryLruCache({ limit: 500 }),
     }),
   },
   dependencies: agentDependencies,


### PR DESCRIPTION
Adds support for caching of did resolver results. I saw that in a lot flows we're resoling the same did multiple times, and thus sometimes hitting the ledger 5 times for the same did. This adds a default cache of 5 minutes for did documents.

You can disable this by passing options to resolve, and I've disabled it for dids where it doesn't make sense: `did:peer`, `did:key` and `did:jwk`.


BREAKING CHANGE: it is now required to set the `allowsCaching` on a `DidResolver` implementation. When set to `true` the `DidResolverService` will allow the results from the `DidResolver` implementation to be cached. When `false`, a result from the `DidResolver` will NEVER be cached. It is advised to not allow caching for dynamically generated or stored did documents (such as `did:peer`, `did:key` and `did:jwk`), but do allow caching for resolvers that are expensive to call (think a ledger did method such as `did:cheqd` or `did:indy`).