### PR TITLE
chore: make deprecated packages private

### DIFF
--- a/packages/anoncreds-rs/package.json
+++ b/packages/anoncreds-rs/package.json
@@ -3,6 +3,7 @@
   "main": "build/index",
   "types": "build/index",
   "version": "0.4.2",
+  "private": true,
   "files": [
     "build"
   ],

--- a/packages/indy-sdk/package.json
+++ b/packages/indy-sdk/package.json
@@ -2,6 +2,7 @@
   "name": "@credo-ts/indy-sdk",
   "main": "build/index",
   "types": "build/index",
+  "private": true,
   "version": "0.4.2",
   "files": [
     "build"

--- a/packages/sd-jwt-vc/package.json
+++ b/packages/sd-jwt-vc/package.json
@@ -3,6 +3,7 @@
   "main": "build/index",
   "types": "build/index",
   "version": "0.4.2",
+  "private": true,
   "files": [
     "build"
   ],


### PR DESCRIPTION
Making these packages temporarily private before the 0.5.0 to see if we will release them under 0.5.0

Otherwise It'd be great if we can keep the `@credo-ts` scope on NPM as clean as possible:
- `@credo-ts/sd-jwt-vc` -> integrated into core in #1708 
- `@credo-ts/anoncreds-rs` -> I'd like to merge this with `@credo-ts/anoncreds` if we remove indy-sdk
- `@credo-ts/indy-sdk` -> we're trying to deprecate this one, so no need to publish it anymore

If we end up still releasing them for 0.5.0 I'll just create a PR again to set them to not private