### PR TITLE
docs: readme cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,12 +49,15 @@ Credo is a framework written in TypeScript for building **SSI Agents and DIDComm
 
 ## Features
 
+See [Supported Features](https://credo.js.org/guides/features) on the Credo website for a full list of supported features.
+
 - 🏃 Runs in React Native & Node.JS
 - 🔒 DIDComm v1 support
 - 🌎 [Aries Interop Profile](https://github.com/hyperledger/aries-rfcs/blob/main/concepts/0302-aries-interop-profile/README.md) v1 & v2 support
   - With support for Chat, Mediator Coordination, Indy Credentials & and JSON-LD Credentials sub-targets
-- `did:sov`, `did:web`, `did:key` and `did:peer`, with pluggable interface for registering custom did methods.
-- OpenID for Verifiable Credential Issuance (only receiving JSON-LD credentials for now)
+- `did:web`, `did:key`, `did:jwk`, `did:peer`, `did:sov`, `did:indy` and `did:cheqd`, with pluggable interface for registering custom did methods.
+- OpenID for Verifiable Credentials
+- W3C Verifiable Credentials, SD-JWT VCs and AnonCreds
 - 💡 Smart Auto Acceptance of Connections, Credentials and Proofs
 - 🏢 Multi tenant module for managing multiple tenants under a single agent.
 
@@ -178,16 +181,7 @@ Documentation on how to get started with Credo can be found at https://credo.js.
 
 To get to know the Credo flow, we built a demo to walk through it yourself together with agents Alice and Faber.
 
-- [Demo](/demo)
-
-### Divergence from Aries RFCs
-
-Although Credo tries to follow the standards as described in the Aries RFCs as much as possible, some features in Credo slightly diverge from the written spec. Below is an overview of the features that diverge from the spec, their impact and the reasons for diverging.
-
-| Feature                                                                                                                                                        | Impact                                                                                                                                                                                                                                                                                                                                                                                                     | Reason                                                                                                                                                                    |
-| -------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Support for `imageUrl` attribute in connection invitation and connection request                                                                               | Properties that are not recognized should be ignored, meaning this shouldn't limit interoperability between agents. As the image url is self-attested it could give a false sense of trust. Better, credential based, method for visually identifying an entity are not present yet.                                                                                                                       | Even though not documented, almost all agents support this feature. Not including this feature means Credo is lacking in features in comparison to other implementations. |
-| Revocation Notification v1 uses a different `thread_id` format ( `indy::<revocation_registry_id>::<credential_revocation_id>`) than specified in the Aries RFC | Any agents adhering to the [revocation notification v1 RFC](https://github.com/hyperledger/aries-rfcs/tree/main/features/0183-revocation-notification) will not be interoperable with Credo. However, revocation notification is considered an optional portion of revocation, therefore this will not break core revocation behavior. Ideally agents should use and implement revocation notification v2. | Actual implementations (ACA-Py) of revocation notification v1 so far have implemented this different format, so this format change was made to remain interoperable.      |
+You can run the demo in the [`/demo`](/demo) directory of this repository.
 
 ## Contributing
 

--- a/packages/anoncreds/README.md
+++ b/packages/anoncreds/README.md
@@ -6,7 +6,7 @@
     height="250px"
   />
 </p>
-<h1 align="center"><b>Credo AnonCreds Interfaces</b></h1>
+<h1 align="center"><b>Credo AnonCreds Module</b></h1>
 <p align="center">
   <a
     href="https://raw.githubusercontent.com/openwallet-foundation/credo-ts/main/LICENSE"

--- a/packages/anoncreds/README.md
+++ b/packages/anoncreds/README.md
@@ -28,8 +28,4 @@
 </p>
 <br />
 
-### Installation
-
-### Quick start
-
-### Example of usage
+Credo AnonCreds provides AnonCreds capabilities of Credo. See the [AnonCreds Setup](https://credo.js.org/guides/getting-started/set-up/anoncreds) for installation instructions.

--- a/packages/askar/README.md
+++ b/packages/askar/README.md
@@ -28,4 +28,4 @@
 </p>
 <br />
 
-Askar module for [Credo](https://github.com/openwallet-foundation/credo-ts.git).
+Credo Askar provides secure storage and crypto capabilities of Credo. See the [Aries Askar Setup](https://credo.js.org/guides/getting-started/set-up/aries-askar) for installation instructions.

--- a/packages/bbs-signatures/README.md
+++ b/packages/bbs-signatures/README.md
@@ -6,7 +6,7 @@
     height="250px"
   />
 </p>
-<h1 align="center"><b>Credo - BBS Module</b></h1>
+<h1 align="center"><b>Credo BBS+ Module</b></h1>
 <p align="center">
   <a
     href="https://raw.githubusercontent.com/openwallet-foundation/credo-ts/main/LICENSE"

--- a/packages/cheqd/README.md
+++ b/packages/cheqd/README.md
@@ -6,7 +6,7 @@
     height="250px"
   />
 </p>
-<h1 align="center"><b>Credo - Cheqd</b></h1>
+<h1 align="center"><b>Credo Cheqd Module</b></h1>
 <p align="center">
   <a
     href="https://raw.githubusercontent.com/openwallet-foundation/credo-ts/main/LICENSE"

--- a/packages/cheqd/README.md
+++ b/packages/cheqd/README.md
@@ -28,8 +28,4 @@
 </p>
 <br />
 
-### Installation
-
-### Quick start
-
-### Example of usage
+Credo cheqd provides integration of the cheqd network into Credo. See the [Cheqd Setup](https://credo.js.org/guides/getting-started/set-up/cheqd) for installation instructions.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -28,4 +28,4 @@
 </p>
 <br />
 
-Credo Core provides the core functionality of Credo. See the [Getting Started Guide](https://github.com/openwallet-foundation/credo-ts#getting-started) for installation instructions.
+Credo Core provides the core functionality of Credo. See the [Getting Started Guide](https://credo.js.org/guides/getting-started) for installation instructions.

--- a/packages/indy-sdk-to-askar-migration/README.md
+++ b/packages/indy-sdk-to-askar-migration/README.md
@@ -28,4 +28,4 @@
 </p>
 <br />
 
-Indy SDK to Askar migration module for [Credo](https://github.com/openwallet-foundation/credo-ts.git).
+Credo Indy SDK to Askar migration provides migration from the legacy and deprecated Indy SDK to Aries Askar. See the [Indy SDK to Askar Migration Guide](https://credo.js.org/guides/updating/update-indy-sdk-to-askar) for instructions.

--- a/packages/indy-vdr/README.md
+++ b/packages/indy-vdr/README.md
@@ -6,7 +6,7 @@
     height="250px"
   />
 </p>
-<h1 align="center"><b>Credo - Indy Verifiable Data Registry (Indy-Vdr)</b></h1>
+<h1 align="center"><b>Credo - Indy Verifiable Data Registry (Indy VDR) Module</b></h1>
 <p align="center">
   <a
     href="https://raw.githubusercontent.com/openwallet-foundation/credo-ts/main/LICENSE"

--- a/packages/indy-vdr/README.md
+++ b/packages/indy-vdr/README.md
@@ -28,8 +28,4 @@
 </p>
 <br />
 
-### Installation
-
-### Quick start
-
-### Example of usage
+Credo Indy VDR provides integration of the Hyperledger Indy blockchain into Credo. See the [Indy VDR Setup](https://credo.js.org/guides/getting-started/set-up/indy-vdr) for installation instructions.

--- a/packages/tenants/README.md
+++ b/packages/tenants/README.md
@@ -6,7 +6,7 @@
     height="250px"
   />
 </p>
-<h1 align="center"><b>Credo - Tenant Module</b></h1>
+<h1 align="center"><b>Credo Tenant Module</b></h1>
 <p align="center">
   <a
     href="https://raw.githubusercontent.com/openwallet-foundation/credo-ts/main/LICENSE"

--- a/packages/tenants/README.md
+++ b/packages/tenants/README.md
@@ -6,7 +6,7 @@
     height="250px"
   />
 </p>
-<h1 align="center"><b>Credo Tenant Module</b></h1>
+<h1 align="center"><b>Credo Tenants Module</b></h1>
 <p align="center">
   <a
     href="https://raw.githubusercontent.com/openwallet-foundation/credo-ts/main/LICENSE"


### PR DESCRIPTION
Some cleanup updates to the README.

I've moved some sections over to the docs, we should probably also move the left-over parts to the docs (like installation for Action menu package) so it's not scattered anymore.

Will open a PR in docs soon also with migration etc.. and all the changes in 0.5.0