### PR TITLE
feat: add goal codes to v2 protocols

### DIFF
--- a/packages/core/src/modules/credentials/protocol/CredentialProtocolOptions.ts
+++ b/packages/core/src/modules/credentials/protocol/CredentialProtocolOptions.ts
@@ -89,18 +89,29 @@ export type GetCredentialFormatDataReturn<CFs extends CredentialFormat[] = Crede
   credential?: CredentialFormatDataMessagePayload<CFs, 'credential'>
 }
 
-export interface CreateCredentialProposalOptions<CFs extends CredentialFormatService[]> {
-  connectionRecord: ConnectionRecord
-  credentialFormats: CredentialFormatPayload<ExtractCredentialFormats<CFs>, 'createProposal'>
-  autoAcceptCredential?: AutoAcceptCredential
+interface BaseOptions {
   comment?: string
+  autoAcceptCredential?: AutoAcceptCredential
+
+  /**
+   * Will be ignored for v1 protocol as it is not supported
+   */
+  goalCode?: string
+
+  /**
+   * Will be ignored for v1 protocol as it is not supported
+   */
+  goal?: string
 }
 
-export interface AcceptCredentialProposalOptions<CFs extends CredentialFormatService[]> {
+export interface CreateCredentialProposalOptions<CFs extends CredentialFormatService[]> extends BaseOptions {
+  connectionRecord: ConnectionRecord
+  credentialFormats: CredentialFormatPayload<ExtractCredentialFormats<CFs>, 'createProposal'>
+}
+
+export interface AcceptCredentialProposalOptions<CFs extends CredentialFormatService[]> extends BaseOptions {
   credentialRecord: CredentialExchangeRecord
   credentialFormats?: CredentialFormatPayload<ExtractCredentialFormats<CFs>, 'acceptProposal'>
-  autoAcceptCredential?: AutoAcceptCredential
-  comment?: string
 }
 
 export interface NegotiateCredentialProposalOptions<CFs extends CredentialFormatService[]> {
@@ -108,42 +119,42 @@ export interface NegotiateCredentialProposalOptions<CFs extends CredentialFormat
   credentialFormats: CredentialFormatPayload<ExtractCredentialFormats<CFs>, 'createOffer'>
   autoAcceptCredential?: AutoAcceptCredential
   comment?: string
+
+  /**
+   * Will be ignored for v1 protocol as it is not supported
+   */
+  goalCode?: string
+
+  /**
+   * Will be ignored for v1 protocol as it is not supported
+   */
+  goal?: string
 }
 
-export interface CreateCredentialOfferOptions<CFs extends CredentialFormatService[]> {
+export interface CreateCredentialOfferOptions<CFs extends CredentialFormatService[]> extends BaseOptions {
   // Create offer can also be used for connection-less, so connection is optional
   connectionRecord?: ConnectionRecord
   credentialFormats: CredentialFormatPayload<ExtractCredentialFormats<CFs>, 'createOffer'>
-  autoAcceptCredential?: AutoAcceptCredential
-  comment?: string
 }
 
-export interface AcceptCredentialOfferOptions<CFs extends CredentialFormatService[]> {
+export interface AcceptCredentialOfferOptions<CFs extends CredentialFormatService[]> extends BaseOptions {
   credentialRecord: CredentialExchangeRecord
   credentialFormats?: CredentialFormatPayload<ExtractCredentialFormats<CFs>, 'acceptOffer'>
-  autoAcceptCredential?: AutoAcceptCredential
-  comment?: string
 }
 
-export interface NegotiateCredentialOfferOptions<CFs extends CredentialFormatService[]> {
+export interface NegotiateCredentialOfferOptions<CFs extends CredentialFormatService[]> extends BaseOptions {
   credentialRecord: CredentialExchangeRecord
   credentialFormats: CredentialFormatPayload<ExtractCredentialFormats<CFs>, 'createProposal'>
-  autoAcceptCredential?: AutoAcceptCredential
-  comment?: string
 }
 
-export interface CreateCredentialRequestOptions<CFs extends CredentialFormatService[]> {
+export interface CreateCredentialRequestOptions<CFs extends CredentialFormatService[]> extends BaseOptions {
   connectionRecord: ConnectionRecord
   credentialFormats: CredentialFormatPayload<ExtractCredentialFormats<CFs>, 'createRequest'>
-  autoAcceptCredential?: AutoAcceptCredential
-  comment?: string
 }
 
-export interface AcceptCredentialRequestOptions<CFs extends CredentialFormatService[]> {
+export interface AcceptCredentialRequestOptions<CFs extends CredentialFormatService[]> extends BaseOptions {
   credentialRecord: CredentialExchangeRecord
   credentialFormats?: CredentialFormatPayload<ExtractCredentialFormats<CFs>, 'acceptRequest'>
-  autoAcceptCredential?: AutoAcceptCredential
-  comment?: string
 }
 
 export interface AcceptCredentialOptions {

--- a/packages/core/src/modules/credentials/protocol/v2/CredentialFormatCoordinator.ts
+++ b/packages/core/src/modules/credentials/protocol/v2/CredentialFormatCoordinator.ts
@@ -30,11 +30,15 @@ export class CredentialFormatCoordinator<CFs extends CredentialFormatService[]> 
       formatServices,
       credentialRecord,
       comment,
+      goalCode,
+      goal,
     }: {
       formatServices: CredentialFormatService[]
       credentialFormats: CredentialFormatPayload<ExtractCredentialFormats<CFs>, 'createProposal'>
       credentialRecord: CredentialExchangeRecord
       comment?: string
+      goalCode?: string
+      goal?: string
     }
   ): Promise<V2ProposeCredentialMessage> {
     const didCommMessageRepository = agentContext.dependencyManager.resolve(DidCommMessageRepository)
@@ -66,8 +70,10 @@ export class CredentialFormatCoordinator<CFs extends CredentialFormatService[]> 
       id: credentialRecord.threadId,
       formats,
       proposalAttachments,
-      comment: comment,
+      comment,
       credentialPreview,
+      goalCode,
+      goal,
     })
 
     message.setThread({ threadId: credentialRecord.threadId, parentThreadId: credentialRecord.parentThreadId })
@@ -118,11 +124,15 @@ export class CredentialFormatCoordinator<CFs extends CredentialFormatService[]> 
       credentialFormats,
       formatServices,
       comment,
+      goalCode,
+      goal,
     }: {
       credentialRecord: CredentialExchangeRecord
       credentialFormats?: CredentialFormatPayload<ExtractCredentialFormats<CFs>, 'acceptProposal'>
       formatServices: CredentialFormatService[]
       comment?: string
+      goalCode?: string
+      goal?: string
     }
   ) {
     const didCommMessageRepository = agentContext.dependencyManager.resolve(DidCommMessageRepository)
@@ -180,6 +190,8 @@ export class CredentialFormatCoordinator<CFs extends CredentialFormatService[]> 
       credentialPreview,
       offerAttachments,
       comment,
+      goalCode,
+      goal,
     })
 
     message.setThread({ threadId: credentialRecord.threadId, parentThreadId: credentialRecord.parentThreadId })
@@ -207,11 +219,15 @@ export class CredentialFormatCoordinator<CFs extends CredentialFormatService[]> 
       formatServices,
       credentialRecord,
       comment,
+      goalCode,
+      goal,
     }: {
       formatServices: CredentialFormatService[]
       credentialFormats: CredentialFormatPayload<ExtractCredentialFormats<CFs>, 'createOffer'>
       credentialRecord: CredentialExchangeRecord
       comment?: string
+      goalCode?: string
+      goal?: string
     }
   ): Promise<V2OfferCredentialMessage> {
     const didCommMessageRepository = agentContext.dependencyManager.resolve(DidCommMessageRepository)
@@ -250,6 +266,8 @@ export class CredentialFormatCoordinator<CFs extends CredentialFormatService[]> 
     const message = new V2OfferCredentialMessage({
       formats,
       comment,
+      goalCode,
+      goal,
       offerAttachments,
       credentialPreview,
     })
@@ -302,11 +320,15 @@ export class CredentialFormatCoordinator<CFs extends CredentialFormatService[]> 
       credentialFormats,
       formatServices,
       comment,
+      goalCode,
+      goal,
     }: {
       credentialRecord: CredentialExchangeRecord
       credentialFormats?: CredentialFormatPayload<ExtractCredentialFormats<CFs>, 'acceptOffer'>
       formatServices: CredentialFormatService[]
       comment?: string
+      goalCode?: string
+      goal?: string
     }
   ) {
     const didCommMessageRepository = agentContext.dependencyManager.resolve(DidCommMessageRepository)
@@ -343,6 +365,8 @@ export class CredentialFormatCoordinator<CFs extends CredentialFormatService[]> 
       formats,
       requestAttachments: requestAttachments,
       comment,
+      goalCode,
+      goal,
     })
 
     message.setThread({ threadId: credentialRecord.threadId, parentThreadId: credentialRecord.parentThreadId })
@@ -370,11 +394,15 @@ export class CredentialFormatCoordinator<CFs extends CredentialFormatService[]> 
       formatServices,
       credentialRecord,
       comment,
+      goalCode,
+      goal,
     }: {
       formatServices: CredentialFormatService[]
       credentialFormats: CredentialFormatPayload<ExtractCredentialFormats<CFs>, 'createRequest'>
       credentialRecord: CredentialExchangeRecord
       comment?: string
+      goalCode?: string
+      goal?: string
     }
   ): Promise<V2RequestCredentialMessage> {
     const didCommMessageRepository = agentContext.dependencyManager.resolve(DidCommMessageRepository)
@@ -396,6 +424,8 @@ export class CredentialFormatCoordinator<CFs extends CredentialFormatService[]> 
     const message = new V2RequestCredentialMessage({
       formats,
       comment,
+      goalCode,
+      goal,
       requestAttachments: requestAttachments,
     })
 
@@ -447,11 +477,15 @@ export class CredentialFormatCoordinator<CFs extends CredentialFormatService[]> 
       credentialFormats,
       formatServices,
       comment,
+      goalCode,
+      goal,
     }: {
       credentialRecord: CredentialExchangeRecord
       credentialFormats?: CredentialFormatPayload<ExtractCredentialFormats<CFs>, 'acceptRequest'>
       formatServices: CredentialFormatService[]
       comment?: string
+      goalCode?: string
+      goal?: string
     }
   ) {
     const didCommMessageRepository = agentContext.dependencyManager.resolve(DidCommMessageRepository)
@@ -496,6 +530,8 @@ export class CredentialFormatCoordinator<CFs extends CredentialFormatService[]> 
       formats,
       credentialAttachments: credentialAttachments,
       comment,
+      goalCode,
+      goal,
     })
 
     message.setThread({ threadId: credentialRecord.threadId, parentThreadId: credentialRecord.parentThreadId })

--- a/packages/core/src/modules/credentials/protocol/v2/V2CredentialProtocol.ts
+++ b/packages/core/src/modules/credentials/protocol/v2/V2CredentialProtocol.ts
@@ -114,7 +114,14 @@ export class V2CredentialProtocol<CFs extends CredentialFormatService[] = Creden
    */
   public async createProposal(
     agentContext: AgentContext,
-    { connectionRecord, credentialFormats, comment, autoAcceptCredential }: CreateCredentialProposalOptions<CFs>
+    {
+      connectionRecord,
+      credentialFormats,
+      comment,
+      goal,
+      goalCode,
+      autoAcceptCredential,
+    }: CreateCredentialProposalOptions<CFs>
   ): Promise<CredentialProtocolMsgReturnType<AgentMessage>> {
     agentContext.config.logger.debug('Get the Format Service and Create Proposal Message')
 
@@ -138,6 +145,8 @@ export class V2CredentialProtocol<CFs extends CredentialFormatService[] = Creden
       credentialRecord,
       formatServices,
       comment,
+      goal,
+      goalCode,
     })
 
     agentContext.config.logger.debug('Save record and emit state change event')
@@ -232,7 +241,14 @@ export class V2CredentialProtocol<CFs extends CredentialFormatService[] = Creden
 
   public async acceptProposal(
     agentContext: AgentContext,
-    { credentialRecord, credentialFormats, autoAcceptCredential, comment }: AcceptCredentialProposalOptions<CFs>
+    {
+      credentialRecord,
+      credentialFormats,
+      autoAcceptCredential,
+      comment,
+      goal,
+      goalCode,
+    }: AcceptCredentialProposalOptions<CFs>
   ): Promise<CredentialProtocolMsgReturnType<V2OfferCredentialMessage>> {
     // Assert
     credentialRecord.assertProtocolVersion('v2')
@@ -264,6 +280,8 @@ export class V2CredentialProtocol<CFs extends CredentialFormatService[] = Creden
       credentialRecord,
       formatServices,
       comment,
+      goal,
+      goalCode,
       credentialFormats,
     })
 
@@ -283,7 +301,14 @@ export class V2CredentialProtocol<CFs extends CredentialFormatService[] = Creden
    */
   public async negotiateProposal(
     agentContext: AgentContext,
-    { credentialRecord, credentialFormats, autoAcceptCredential, comment }: NegotiateCredentialProposalOptions<CFs>
+    {
+      credentialRecord,
+      credentialFormats,
+      autoAcceptCredential,
+      comment,
+      goal,
+      goalCode,
+    }: NegotiateCredentialProposalOptions<CFs>
   ): Promise<CredentialProtocolMsgReturnType<V2OfferCredentialMessage>> {
     // Assert
     credentialRecord.assertProtocolVersion('v2')
@@ -305,6 +330,8 @@ export class V2CredentialProtocol<CFs extends CredentialFormatService[] = Creden
       credentialFormats,
       credentialRecord,
       comment,
+      goal,
+      goalCode,
     })
 
     credentialRecord.autoAcceptCredential = autoAcceptCredential ?? credentialRecord.autoAcceptCredential
@@ -324,7 +351,14 @@ export class V2CredentialProtocol<CFs extends CredentialFormatService[] = Creden
    */
   public async createOffer(
     agentContext: AgentContext,
-    { credentialFormats, autoAcceptCredential, comment, connectionRecord }: CreateCredentialOfferOptions<CFs>
+    {
+      credentialFormats,
+      autoAcceptCredential,
+      comment,
+      goal,
+      goalCode,
+      connectionRecord,
+    }: CreateCredentialOfferOptions<CFs>
   ): Promise<CredentialProtocolMsgReturnType<V2OfferCredentialMessage>> {
     const credentialRepository = agentContext.dependencyManager.resolve(CredentialRepository)
 
@@ -346,6 +380,8 @@ export class V2CredentialProtocol<CFs extends CredentialFormatService[] = Creden
       credentialFormats,
       credentialRecord,
       comment,
+      goal,
+      goalCode,
     })
 
     agentContext.config.logger.debug(
@@ -442,7 +478,14 @@ export class V2CredentialProtocol<CFs extends CredentialFormatService[] = Creden
 
   public async acceptOffer(
     agentContext: AgentContext,
-    { credentialRecord, autoAcceptCredential, comment, credentialFormats }: AcceptCredentialOfferOptions<CFs>
+    {
+      credentialRecord,
+      autoAcceptCredential,
+      comment,
+      goal,
+      goalCode,
+      credentialFormats,
+    }: AcceptCredentialOfferOptions<CFs>
   ) {
     const didCommMessageRepository = agentContext.dependencyManager.resolve(DidCommMessageRepository)
 
@@ -474,6 +517,8 @@ export class V2CredentialProtocol<CFs extends CredentialFormatService[] = Creden
       credentialRecord,
       formatServices,
       comment,
+      goal,
+      goalCode,
       credentialFormats,
     })
 
@@ -493,7 +538,14 @@ export class V2CredentialProtocol<CFs extends CredentialFormatService[] = Creden
    */
   public async negotiateOffer(
     agentContext: AgentContext,
-    { credentialRecord, credentialFormats, autoAcceptCredential, comment }: NegotiateCredentialOfferOptions<CFs>
+    {
+      credentialRecord,
+      credentialFormats,
+      autoAcceptCredential,
+      comment,
+      goal,
+      goalCode,
+    }: NegotiateCredentialOfferOptions<CFs>
   ): Promise<CredentialProtocolMsgReturnType<V2ProposeCredentialMessage>> {
     // Assert
     credentialRecord.assertProtocolVersion('v2')
@@ -515,6 +567,8 @@ export class V2CredentialProtocol<CFs extends CredentialFormatService[] = Creden
       credentialFormats,
       credentialRecord,
       comment,
+      goal,
+      goalCode,
     })
 
     credentialRecord.autoAcceptCredential = autoAcceptCredential ?? credentialRecord.autoAcceptCredential
@@ -530,7 +584,14 @@ export class V2CredentialProtocol<CFs extends CredentialFormatService[] = Creden
    */
   public async createRequest(
     agentContext: AgentContext,
-    { credentialFormats, autoAcceptCredential, comment, connectionRecord }: CreateCredentialRequestOptions<CFs>
+    {
+      credentialFormats,
+      autoAcceptCredential,
+      comment,
+      goal,
+      goalCode,
+      connectionRecord,
+    }: CreateCredentialRequestOptions<CFs>
   ): Promise<CredentialProtocolMsgReturnType<V2RequestCredentialMessage>> {
     const credentialRepository = agentContext.dependencyManager.resolve(CredentialRepository)
 
@@ -552,6 +613,8 @@ export class V2CredentialProtocol<CFs extends CredentialFormatService[] = Creden
       credentialFormats,
       credentialRecord,
       comment,
+      goal,
+      goalCode,
     })
 
     agentContext.config.logger.debug(
@@ -659,7 +722,14 @@ export class V2CredentialProtocol<CFs extends CredentialFormatService[] = Creden
 
   public async acceptRequest(
     agentContext: AgentContext,
-    { credentialRecord, autoAcceptCredential, comment, credentialFormats }: AcceptCredentialRequestOptions<CFs>
+    {
+      credentialRecord,
+      autoAcceptCredential,
+      comment,
+      goal,
+      goalCode,
+      credentialFormats,
+    }: AcceptCredentialRequestOptions<CFs>
   ) {
     const didCommMessageRepository = agentContext.dependencyManager.resolve(DidCommMessageRepository)
 
@@ -690,6 +760,8 @@ export class V2CredentialProtocol<CFs extends CredentialFormatService[] = Creden
       credentialRecord,
       formatServices,
       comment,
+      goal,
+      goalCode,
       credentialFormats,
     })
 

--- a/packages/core/src/modules/credentials/protocol/v2/messages/V2IssueCredentialMessage.ts
+++ b/packages/core/src/modules/credentials/protocol/v2/messages/V2IssueCredentialMessage.ts
@@ -9,6 +9,8 @@ import { CredentialFormatSpec } from '../../../models'
 export interface V2IssueCredentialMessageOptions {
   id?: string
   comment?: string
+  goalCode?: string
+  goal?: string
   formats: CredentialFormatSpec[]
   credentialAttachments: Attachment[]
 }
@@ -20,6 +22,8 @@ export class V2IssueCredentialMessage extends AgentMessage {
     if (options) {
       this.id = options.id ?? this.generateId()
       this.comment = options.comment
+      this.goalCode = options.goalCode
+      this.goal = options.goal
       this.formats = options.formats
       this.credentialAttachments = options.credentialAttachments
     }
@@ -46,6 +50,15 @@ export class V2IssueCredentialMessage extends AgentMessage {
   })
   @IsInstance(Attachment, { each: true })
   public credentialAttachments!: Attachment[]
+
+  @Expose({ name: 'goal_code' })
+  @IsString()
+  @IsOptional()
+  public goalCode?: string
+
+  @IsString()
+  @IsOptional()
+  public goal?: string
 
   public getCredentialAttachmentById(id: string): Attachment | undefined {
     return this.credentialAttachments.find((attachment) => attachment.id === id)

--- a/packages/core/src/modules/credentials/protocol/v2/messages/V2OfferCredentialMessage.ts
+++ b/packages/core/src/modules/credentials/protocol/v2/messages/V2OfferCredentialMessage.ts
@@ -15,6 +15,8 @@ export interface V2OfferCredentialMessageOptions {
   credentialPreview: V2CredentialPreview
   replacementId?: string
   comment?: string
+  goalCode?: string
+  goal?: string
 }
 
 export class V2OfferCredentialMessage extends AgentMessage {
@@ -23,6 +25,8 @@ export class V2OfferCredentialMessage extends AgentMessage {
     if (options) {
       this.id = options.id ?? this.generateId()
       this.comment = options.comment
+      this.goalCode = options.goalCode
+      this.goal = options.goal
       this.formats = options.formats
       this.credentialPreview = options.credentialPreview
       this.offerAttachments = options.offerAttachments
@@ -42,6 +46,15 @@ export class V2OfferCredentialMessage extends AgentMessage {
   @IsString()
   @IsOptional()
   public comment?: string
+
+  @Expose({ name: 'goal_code' })
+  @IsString()
+  @IsOptional()
+  public goalCode?: string
+
+  @IsString()
+  @IsOptional()
+  public goal?: string
 
   @Expose({ name: 'credential_preview' })
   @Type(() => V2CredentialPreview)

--- a/packages/core/src/modules/credentials/protocol/v2/messages/V2ProposeCredentialMessage.ts
+++ b/packages/core/src/modules/credentials/protocol/v2/messages/V2ProposeCredentialMessage.ts
@@ -13,6 +13,8 @@ export interface V2ProposeCredentialMessageOptions {
   formats: CredentialFormatSpec[]
   proposalAttachments: Attachment[]
   comment?: string
+  goalCode?: string
+  goal?: string
   credentialPreview?: V2CredentialPreview
   attachments?: Attachment[]
 }
@@ -23,6 +25,8 @@ export class V2ProposeCredentialMessage extends AgentMessage {
     if (options) {
       this.id = options.id ?? this.generateId()
       this.comment = options.comment
+      this.goalCode = options.goalCode
+      this.goal = options.goal
       this.credentialPreview = options.credentialPreview
       this.formats = options.formats
       this.proposalAttachments = options.proposalAttachments
@@ -63,6 +67,15 @@ export class V2ProposeCredentialMessage extends AgentMessage {
   @IsOptional()
   @IsString()
   public comment?: string
+
+  @Expose({ name: 'goal_code' })
+  @IsString()
+  @IsOptional()
+  public goalCode?: string
+
+  @IsString()
+  @IsOptional()
+  public goal?: string
 
   public getProposalAttachmentById(id: string): Attachment | undefined {
     return this.proposalAttachments.find((attachment) => attachment.id === id)

--- a/packages/core/src/modules/credentials/protocol/v2/messages/V2RequestCredentialMessage.ts
+++ b/packages/core/src/modules/credentials/protocol/v2/messages/V2RequestCredentialMessage.ts
@@ -9,6 +9,8 @@ import { CredentialFormatSpec } from '../../../models'
 export interface V2RequestCredentialMessageOptions {
   id?: string
   formats: CredentialFormatSpec[]
+  goalCode?: string
+  goal?: string
   requestAttachments: Attachment[]
   comment?: string
 }
@@ -19,6 +21,8 @@ export class V2RequestCredentialMessage extends AgentMessage {
     if (options) {
       this.id = options.id ?? this.generateId()
       this.comment = options.comment
+      this.goalCode = options.goalCode
+      this.goal = options.goal
       this.formats = options.formats
       this.requestAttachments = options.requestAttachments
     }
@@ -50,6 +54,15 @@ export class V2RequestCredentialMessage extends AgentMessage {
   @IsOptional()
   @IsString()
   public comment?: string
+
+  @Expose({ name: 'goal_code' })
+  @IsString()
+  @IsOptional()
+  public goalCode?: string
+
+  @IsString()
+  @IsOptional()
+  public goal?: string
 
   public getRequestAttachmentById(id: string): Attachment | undefined {
     return this.requestAttachments.find((attachment) => attachment.id === id)

--- a/packages/core/src/modules/proofs/protocol/ProofProtocolOptions.ts
+++ b/packages/core/src/modules/proofs/protocol/ProofProtocolOptions.ts
@@ -73,9 +73,18 @@ export type GetProofFormatDataReturn<PFs extends ProofFormat[] = ProofFormat[]> 
 }
 
 interface BaseOptions {
-  goalCode?: string
   comment?: string
   autoAcceptProof?: AutoAcceptProof
+
+  /**
+   * Will be ignored for v1 protocol as it is not supported
+   */
+  goalCode?: string
+
+  /**
+   * Will be ignored for v1 protocol as it is not supported
+   */
+  goal?: string
 }
 
 export interface CreateProofProposalOptions<PFs extends ProofFormatService[]> extends BaseOptions {

--- a/packages/core/src/modules/proofs/protocol/v2/ProofFormatCoordinator.ts
+++ b/packages/core/src/modules/proofs/protocol/v2/ProofFormatCoordinator.ts
@@ -30,12 +30,14 @@ export class ProofFormatCoordinator<PFs extends ProofFormatService[]> {
       proofRecord,
       comment,
       goalCode,
+      goal,
     }: {
       formatServices: ProofFormatService[]
       proofFormats: ProofFormatPayload<ExtractProofFormats<PFs>, 'createProposal'>
       proofRecord: ProofExchangeRecord
       comment?: string
       goalCode?: string
+      goal?: string
     }
   ): Promise<V2ProposePresentationMessage> {
     const didCommMessageRepository = agentContext.dependencyManager.resolve(DidCommMessageRepository)
@@ -60,6 +62,7 @@ export class ProofFormatCoordinator<PFs extends ProofFormatService[]> {
       proposalAttachments,
       comment: comment,
       goalCode,
+      goal,
     })
 
     message.setThread({ threadId: proofRecord.threadId, parentThreadId: proofRecord.parentThreadId })
@@ -111,6 +114,7 @@ export class ProofFormatCoordinator<PFs extends ProofFormatService[]> {
       formatServices,
       comment,
       goalCode,
+      goal,
       presentMultiple,
       willConfirm,
     }: {
@@ -119,6 +123,7 @@ export class ProofFormatCoordinator<PFs extends ProofFormatService[]> {
       formatServices: ProofFormatService[]
       comment?: string
       goalCode?: string
+      goal?: string
       presentMultiple?: boolean
       willConfirm?: boolean
     }
@@ -156,6 +161,7 @@ export class ProofFormatCoordinator<PFs extends ProofFormatService[]> {
       requestAttachments,
       comment,
       goalCode,
+      goal,
       presentMultiple,
       willConfirm,
     })
@@ -186,6 +192,7 @@ export class ProofFormatCoordinator<PFs extends ProofFormatService[]> {
       proofRecord,
       comment,
       goalCode,
+      goal,
       presentMultiple,
       willConfirm,
     }: {
@@ -194,6 +201,7 @@ export class ProofFormatCoordinator<PFs extends ProofFormatService[]> {
       proofRecord: ProofExchangeRecord
       comment?: string
       goalCode?: string
+      goal?: string
       presentMultiple?: boolean
       willConfirm?: boolean
     }
@@ -219,6 +227,7 @@ export class ProofFormatCoordinator<PFs extends ProofFormatService[]> {
       comment,
       requestAttachments,
       goalCode,
+      goal,
       presentMultiple,
       willConfirm,
     })
@@ -273,6 +282,7 @@ export class ProofFormatCoordinator<PFs extends ProofFormatService[]> {
       comment,
       lastPresentation,
       goalCode,
+      goal,
     }: {
       proofRecord: ProofExchangeRecord
       proofFormats?: ProofFormatPayload<ExtractProofFormats<PFs>, 'acceptRequest'>
@@ -280,6 +290,7 @@ export class ProofFormatCoordinator<PFs extends ProofFormatService[]> {
       comment?: string
       lastPresentation?: boolean
       goalCode?: string
+      goal?: string
     }
   ) {
     const didCommMessageRepository = agentContext.dependencyManager.resolve(DidCommMessageRepository)
@@ -326,6 +337,7 @@ export class ProofFormatCoordinator<PFs extends ProofFormatService[]> {
       comment,
       lastPresentation,
       goalCode,
+      goal,
     })
 
     message.setThread({ threadId: proofRecord.threadId, parentThreadId: proofRecord.parentThreadId })

--- a/packages/core/src/modules/proofs/protocol/v2/V2ProofProtocol.ts
+++ b/packages/core/src/modules/proofs/protocol/v2/V2ProofProtocol.ts
@@ -106,6 +106,7 @@ export class V2ProofProtocol<PFs extends ProofFormatService[] = ProofFormatServi
       comment,
       autoAcceptProof,
       goalCode,
+      goal,
       parentThreadId,
     }: CreateProofProposalOptions<PFs>
   ): Promise<{ proofRecord: ProofExchangeRecord; message: AgentMessage }> {
@@ -131,6 +132,7 @@ export class V2ProofProtocol<PFs extends ProofFormatService[] = ProofFormatServi
       formatServices,
       comment,
       goalCode,
+      goal,
     })
 
     agentContext.config.logger.debug('Save record and emit state change event')
@@ -228,7 +230,15 @@ export class V2ProofProtocol<PFs extends ProofFormatService[] = ProofFormatServi
 
   public async acceptProposal(
     agentContext: AgentContext,
-    { proofRecord, proofFormats, autoAcceptProof, comment, goalCode, willConfirm }: AcceptProofProposalOptions<PFs>
+    {
+      proofRecord,
+      proofFormats,
+      autoAcceptProof,
+      comment,
+      goalCode,
+      goal,
+      willConfirm,
+    }: AcceptProofProposalOptions<PFs>
   ): Promise<ProofProtocolMsgReturnType<V2RequestPresentationMessage>> {
     // Assert
     proofRecord.assertProtocolVersion('v2')
@@ -262,6 +272,7 @@ export class V2ProofProtocol<PFs extends ProofFormatService[] = ProofFormatServi
       comment,
       proofFormats,
       goalCode,
+      goal,
       willConfirm,
       // Not supported at the moment
       presentMultiple: false,
@@ -283,7 +294,15 @@ export class V2ProofProtocol<PFs extends ProofFormatService[] = ProofFormatServi
    */
   public async negotiateProposal(
     agentContext: AgentContext,
-    { proofRecord, proofFormats, autoAcceptProof, comment, goalCode, willConfirm }: NegotiateProofProposalOptions<PFs>
+    {
+      proofRecord,
+      proofFormats,
+      autoAcceptProof,
+      comment,
+      goalCode,
+      goal,
+      willConfirm,
+    }: NegotiateProofProposalOptions<PFs>
   ): Promise<ProofProtocolMsgReturnType<V2RequestPresentationMessage>> {
     // Assert
     proofRecord.assertProtocolVersion('v2')
@@ -306,6 +325,7 @@ export class V2ProofProtocol<PFs extends ProofFormatService[] = ProofFormatServi
       proofRecord,
       comment,
       goalCode,
+      goal,
       willConfirm,
       // Not supported at the moment
       presentMultiple: false,
@@ -331,6 +351,7 @@ export class V2ProofProtocol<PFs extends ProofFormatService[] = ProofFormatServi
       connectionRecord,
       parentThreadId,
       goalCode,
+      goal,
       willConfirm,
     }: CreateProofRequestOptions<PFs>
   ): Promise<ProofProtocolMsgReturnType<V2RequestPresentationMessage>> {
@@ -356,6 +377,7 @@ export class V2ProofProtocol<PFs extends ProofFormatService[] = ProofFormatServi
       proofRecord,
       comment,
       goalCode,
+      goal,
       willConfirm,
     })
 
@@ -459,7 +481,7 @@ export class V2ProofProtocol<PFs extends ProofFormatService[] = ProofFormatServi
 
   public async acceptRequest(
     agentContext: AgentContext,
-    { proofRecord, autoAcceptProof, comment, proofFormats, goalCode }: AcceptProofRequestOptions<PFs>
+    { proofRecord, autoAcceptProof, comment, proofFormats, goalCode, goal }: AcceptProofRequestOptions<PFs>
   ) {
     const didCommMessageRepository = agentContext.dependencyManager.resolve(DidCommMessageRepository)
 
@@ -492,6 +514,7 @@ export class V2ProofProtocol<PFs extends ProofFormatService[] = ProofFormatServi
       comment,
       proofFormats,
       goalCode,
+      goal,
       // Sending multiple presentation messages not supported at the moment
       lastPresentation: true,
     })
@@ -512,7 +535,7 @@ export class V2ProofProtocol<PFs extends ProofFormatService[] = ProofFormatServi
    */
   public async negotiateRequest(
     agentContext: AgentContext,
-    { proofRecord, proofFormats, autoAcceptProof, comment, goalCode }: NegotiateProofRequestOptions<PFs>
+    { proofRecord, proofFormats, autoAcceptProof, comment, goalCode, goal }: NegotiateProofRequestOptions<PFs>
   ): Promise<ProofProtocolMsgReturnType<V2ProposeCredentialMessage>> {
     // Assert
     proofRecord.assertProtocolVersion('v2')
@@ -535,6 +558,7 @@ export class V2ProofProtocol<PFs extends ProofFormatService[] = ProofFormatServi
       proofRecord,
       comment,
       goalCode,
+      goal,
     })
 
     proofRecord.autoAcceptProof = autoAcceptProof ?? proofRecord.autoAcceptProof

--- a/packages/core/src/modules/proofs/protocol/v2/messages/V2PresentationMessage.ts
+++ b/packages/core/src/modules/proofs/protocol/v2/messages/V2PresentationMessage.ts
@@ -9,8 +9,9 @@ import { ProofFormatSpec } from '../../../models/ProofFormatSpec'
 
 export interface V2PresentationMessageOptions {
   id?: string
-  goalCode?: string
   comment?: string
+  goalCode?: string
+  goal?: string
   lastPresentation?: boolean
   presentationAttachments: Attachment[]
   formats: ProofFormatSpec[]
@@ -26,6 +27,7 @@ export class V2PresentationMessage extends AgentMessage {
       this.id = options.id ?? uuid()
       this.comment = options.comment
       this.goalCode = options.goalCode
+      this.goal = options.goal
       this.lastPresentation = options.lastPresentation ?? true
 
       this.formats = options.formats
@@ -45,6 +47,10 @@ export class V2PresentationMessage extends AgentMessage {
   @IsString()
   @IsOptional()
   public goalCode?: string
+
+  @IsString()
+  @IsOptional()
+  public goal?: string
 
   @Expose({ name: 'last_presentation' })
   @IsBoolean()

--- a/packages/core/src/modules/proofs/protocol/v2/messages/V2ProposePresentationMessage.ts
+++ b/packages/core/src/modules/proofs/protocol/v2/messages/V2ProposePresentationMessage.ts
@@ -11,6 +11,7 @@ export interface V2ProposePresentationMessageOptions {
   id?: string
   comment?: string
   goalCode?: string
+  goal?: string
   proposalAttachments: Attachment[]
   formats: ProofFormatSpec[]
 }
@@ -25,6 +26,7 @@ export class V2ProposePresentationMessage extends AgentMessage {
       this.id = options.id ?? uuid()
       this.comment = options.comment
       this.goalCode = options.goalCode
+      this.goal = options.goal
       this.formats = options.formats
       this.proposalAttachments = options.proposalAttachments
     }
@@ -42,6 +44,10 @@ export class V2ProposePresentationMessage extends AgentMessage {
   @IsString()
   @IsOptional()
   public goalCode?: string
+
+  @IsString()
+  @IsOptional()
+  public goal?: string
 
   @Type(() => ProofFormatSpec)
   @IsArray()

--- a/packages/core/src/modules/proofs/protocol/v2/messages/V2RequestPresentationMessage.ts
+++ b/packages/core/src/modules/proofs/protocol/v2/messages/V2RequestPresentationMessage.ts
@@ -11,6 +11,7 @@ export interface V2RequestPresentationMessageOptions {
   id?: string
   comment?: string
   goalCode?: string
+  goal?: string
   presentMultiple?: boolean
   willConfirm?: boolean
   formats: ProofFormatSpec[]
@@ -26,6 +27,7 @@ export class V2RequestPresentationMessage extends AgentMessage {
       this.requestAttachments = []
       this.id = options.id ?? uuid()
       this.comment = options.comment
+      this.goal = options.goal
       this.goalCode = options.goalCode
       this.willConfirm = options.willConfirm ?? true
       this.presentMultiple = options.presentMultiple ?? false
@@ -46,6 +48,10 @@ export class V2RequestPresentationMessage extends AgentMessage {
   @IsString()
   @IsOptional()
   public goalCode?: string
+
+  @IsString()
+  @IsOptional()
+  public goal?: string
 
   @Expose({ name: 'will_confirm' })
   @IsBoolean()


### PR DESCRIPTION
Adds the `goal` and `goal_code` properties to all the messages and interfaces for v2 protocols.

`goal_code` was already enabled for proof messages, but not goal. No validation, no logic to it, just something an user of Credo can use to add context to an exchange. 

Goal codes are adopted by v2 of the protocols.