### PR TITLE
feat(mesage-pickup): option for awaiting completion

### DIFF
--- a/packages/core/src/modules/message-pickup/MessagePickupApiOptions.ts
+++ b/packages/core/src/modules/message-pickup/MessagePickupApiOptions.ts
@@ -29,6 +29,8 @@ export interface PickupMessagesOptions<MPPs extends MessagePickupProtocol[] = Me
   protocolVersion: MessagePickupProtocolVersionType<MPPs>
   recipientDid?: string
   batchSize?: number
+  awaitCompletion?: boolean
+  awaitCompletionTimeoutMs?: number
 }
 
 export interface SetLiveDeliveryModeOptions<MPPs extends MessagePickupProtocol[] = MessagePickupProtocol[]> {

--- a/packages/core/src/modules/message-pickup/MessagePickupEvents.ts
+++ b/packages/core/src/modules/message-pickup/MessagePickupEvents.ts
@@ -1,9 +1,11 @@
 import type { MessagePickupSession } from './MessagePickupSession'
 import type { BaseEvent } from '../../agent/Events'
+import type { ConnectionRecord } from '../connections'
 
 export enum MessagePickupEventTypes {
   LiveSessionSaved = 'LiveSessionSaved',
   LiveSessionRemoved = 'LiveSessionRemoved',
+  MessagePickupCompleted = 'MessagePickupCompleted',
 }
 
 export interface MessagePickupLiveSessionSavedEvent extends BaseEvent {
@@ -17,5 +19,13 @@ export interface MessagePickupLiveSessionRemovedEvent extends BaseEvent {
   type: typeof MessagePickupEventTypes.LiveSessionRemoved
   payload: {
     session: MessagePickupSession
+  }
+}
+
+export interface MessagePickupCompletedEvent extends BaseEvent {
+  type: typeof MessagePickupEventTypes.MessagePickupCompleted
+  payload: {
+    connection: ConnectionRecord
+    threadId?: string
   }
 }

--- a/packages/core/src/modules/message-pickup/__tests__/pickup.test.ts
+++ b/packages/core/src/modules/message-pickup/__tests__/pickup.test.ts
@@ -41,6 +41,8 @@ describe('E2E Pick Up protocol', () => {
   let mediatorAgent: Agent
 
   afterEach(async () => {
+    await recipientAgent.mediationRecipient.stopMessagePickup()
+
     await recipientAgent.shutdown()
     await recipientAgent.wallet.delete()
     await mediatorAgent.shutdown()
@@ -103,6 +105,66 @@ describe('E2E Pick Up protocol', () => {
       content: message,
     })
 
+    expect(basicMessage.content).toBe(message)
+  })
+
+  test('E2E manual Pick Up V1 loop - waiting for completion', async () => {
+    const mediatorMessages = new Subject<SubjectMessage>()
+
+    const subjectMap = {
+      'wss://mediator': mediatorMessages,
+    }
+
+    // Initialize mediatorReceived message
+    mediatorAgent = new Agent(mediatorOptions)
+    mediatorAgent.registerOutboundTransport(new SubjectOutboundTransport(subjectMap))
+    mediatorAgent.registerInboundTransport(new SubjectInboundTransport(mediatorMessages))
+    await mediatorAgent.initialize()
+
+    // Create connection to use for recipient
+    const mediatorOutOfBandRecord = await mediatorAgent.oob.createInvitation({
+      label: 'mediator invitation',
+      handshake: true,
+      handshakeProtocols: [HandshakeProtocol.DidExchange],
+    })
+
+    // Initialize recipient
+    recipientAgent = new Agent(recipientOptions)
+    recipientAgent.registerOutboundTransport(new SubjectOutboundTransport(subjectMap))
+    await recipientAgent.initialize()
+
+    // Connect
+    const mediatorInvitation = mediatorOutOfBandRecord.outOfBandInvitation
+
+    let { connectionRecord: recipientMediatorConnection } = await recipientAgent.oob.receiveInvitationFromUrl(
+      mediatorInvitation.toUrl({ domain: 'https://example.com/ssi' })
+    )
+
+    recipientMediatorConnection = await recipientAgent.connections.returnWhenIsConnected(
+      recipientMediatorConnection!.id
+    )
+
+    let [mediatorRecipientConnection] = await mediatorAgent.connections.findAllByOutOfBandId(mediatorOutOfBandRecord.id)
+
+    mediatorRecipientConnection = await mediatorAgent.connections.returnWhenIsConnected(mediatorRecipientConnection!.id)
+
+    // Now they are connected, reinitialize recipient agent in order to lose the session (as with SubjectTransport it remains open)
+    await recipientAgent.shutdown()
+    await recipientAgent.initialize()
+
+    const message = 'hello pickup V1'
+    await mediatorAgent.basicMessages.sendMessage(mediatorRecipientConnection.id, message)
+
+    const basicMessagePromise = waitForBasicMessage(recipientAgent, {
+      content: message,
+    })
+    await recipientAgent.messagePickup.pickupMessages({
+      connectionId: recipientMediatorConnection.id,
+      protocolVersion: 'v1',
+      awaitCompletion: true,
+    })
+
+    const basicMessage = await basicMessagePromise
     expect(basicMessage.content).toBe(message)
   })
 
@@ -185,7 +247,70 @@ describe('E2E Pick Up protocol', () => {
     })
 
     expect((secondStatusMessage as V2StatusMessage).messageCount).toBe(0)
+  })
 
-    await recipientAgent.mediationRecipient.stopMessagePickup()
+  test('E2E manual Pick Up V2 loop - waiting for completion', async () => {
+    const mediatorMessages = new Subject<SubjectMessage>()
+
+    // FIXME: we harcoded that pickup of messages MUST be using ws(s) scheme when doing implicit pickup
+    // For liver delivery we need a duplex transport. however that means we can't test it with the subject transport. Using wss here to 'hack' this. We should
+    // extend the API to allow custom schemes (or maybe add a `supportsDuplex` transport / `supportMultiReturnMessages`)
+    // For pickup v2 pickup message (which we're testing here) we could just as well use `http` as it is just request/response.
+    const subjectMap = {
+      'wss://mediator': mediatorMessages,
+    }
+
+    // Initialize mediatorReceived message
+    mediatorAgent = new Agent(mediatorOptions)
+    mediatorAgent.registerOutboundTransport(new SubjectOutboundTransport(subjectMap))
+    mediatorAgent.registerInboundTransport(new SubjectInboundTransport(mediatorMessages))
+    await mediatorAgent.initialize()
+
+    // Create connection to use for recipient
+    const mediatorOutOfBandRecord = await mediatorAgent.oob.createInvitation({
+      label: 'mediator invitation',
+      handshake: true,
+      handshakeProtocols: [HandshakeProtocol.DidExchange],
+    })
+
+    // Initialize recipient
+    recipientAgent = new Agent(recipientOptions)
+    recipientAgent.registerOutboundTransport(new SubjectOutboundTransport(subjectMap))
+    await recipientAgent.initialize()
+
+    // Connect
+    const mediatorInvitation = mediatorOutOfBandRecord.outOfBandInvitation
+
+    let { connectionRecord: recipientMediatorConnection } = await recipientAgent.oob.receiveInvitationFromUrl(
+      mediatorInvitation.toUrl({ domain: 'https://example.com/ssi' })
+    )
+
+    recipientMediatorConnection = await recipientAgent.connections.returnWhenIsConnected(
+      recipientMediatorConnection!.id
+    )
+
+    let [mediatorRecipientConnection] = await mediatorAgent.connections.findAllByOutOfBandId(mediatorOutOfBandRecord.id)
+
+    mediatorRecipientConnection = await mediatorAgent.connections.returnWhenIsConnected(mediatorRecipientConnection!.id)
+
+    // Now they are connected, reinitialize recipient agent in order to lose the session (as with SubjectTransport it remains open)
+    await recipientAgent.shutdown()
+    await recipientAgent.initialize()
+
+    const message = 'hello pickup V2'
+
+    await mediatorAgent.basicMessages.sendMessage(mediatorRecipientConnection.id, message)
+
+    const basicMessagePromise = waitForBasicMessage(recipientAgent, {
+      content: message,
+    })
+    await recipientAgent.messagePickup.pickupMessages({
+      connectionId: recipientMediatorConnection.id,
+      protocolVersion: 'v2',
+      awaitCompletion: true,
+    })
+
+    const basicMessage = await basicMessagePromise
+    expect(basicMessage.content).toBe(message)
   })
 })

--- a/packages/core/src/modules/message-pickup/protocol/v1/V1MessagePickupProtocol.ts
+++ b/packages/core/src/modules/message-pickup/protocol/v1/V1MessagePickupProtocol.ts
@@ -1,8 +1,10 @@
 import type { AgentContext } from '../../../../agent'
 import type { AgentMessage } from '../../../../agent/AgentMessage'
+import type { AgentMessageReceivedEvent } from '../../../../agent/Events'
 import type { FeatureRegistry } from '../../../../agent/FeatureRegistry'
 import type { InboundMessageContext } from '../../../../agent/models/InboundMessageContext'
 import type { DependencyManager } from '../../../../plugins'
+import type { MessagePickupCompletedEvent } from '../../MessagePickupEvents'
 import type { MessagePickupRepository } from '../../storage/MessagePickupRepository'
 import type {
   DeliverMessagesProtocolOptions,
@@ -12,10 +14,13 @@ import type {
   SetLiveDeliveryModeProtocolReturnType,
 } from '../MessagePickupProtocolOptions'
 
+import { EventEmitter } from '../../../../agent/EventEmitter'
+import { AgentEventTypes } from '../../../../agent/Events'
 import { OutboundMessageContext, Protocol } from '../../../../agent/models'
 import { InjectionSymbols } from '../../../../constants'
 import { CredoError } from '../../../../error'
 import { injectable } from '../../../../plugins'
+import { MessagePickupEventTypes } from '../../MessagePickupEvents'
 import { MessagePickupModuleConfig } from '../../MessagePickupModuleConfig'
 import { BaseMessagePickupProtocol } from '../BaseMessagePickupProtocol'
 
@@ -33,7 +38,7 @@ export class V1MessagePickupProtocol extends BaseMessagePickupProtocol {
    * Registers the protocol implementation (handlers, feature registry) on the agent.
    */
   public register(dependencyManager: DependencyManager, featureRegistry: FeatureRegistry): void {
-    dependencyManager.registerMessageHandlers([new V1BatchPickupHandler(this), new V1BatchHandler()])
+    dependencyManager.registerMessageHandlers([new V1BatchPickupHandler(this), new V1BatchHandler(this)])
 
     featureRegistry.register(
       new Protocol({
@@ -74,6 +79,7 @@ export class V1MessagePickupProtocol extends BaseMessagePickupProtocol {
       (await pickupMessageQueue.takeFromQueue({
         connectionId: connectionRecord.id,
         limit: batchSize, // TODO: Define as config parameter for message holder side
+        deleteMessages: true,
       }))
 
     const batchMessages = messagesToDeliver.map(
@@ -126,5 +132,41 @@ export class V1MessagePickupProtocol extends BaseMessagePickupProtocol {
     })
 
     return new OutboundMessageContext(batchMessage, { agentContext: messageContext.agentContext, connection })
+  }
+
+  public async processBatch(messageContext: InboundMessageContext<V1BatchMessage>) {
+    const { message: batchMessage, agentContext } = messageContext
+    const { messages } = batchMessage
+
+    const connection = messageContext.assertReadyConnection()
+
+    const eventEmitter = messageContext.agentContext.dependencyManager.resolve(EventEmitter)
+
+    messages.forEach((message) => {
+      eventEmitter.emit<AgentMessageReceivedEvent>(messageContext.agentContext, {
+        type: AgentEventTypes.AgentMessageReceived,
+        payload: {
+          message: message.message,
+          contextCorrelationId: messageContext.agentContext.contextCorrelationId,
+        },
+      })
+    })
+
+    // A Batch message without messages at all means that we are done with the
+    // message pickup process (Note: this is not optimal since we'll always doing an extra
+    // Batch Pickup. However, it is safer and should be faster than waiting an entire loop
+    // interval to retrieve more messages)
+    if (messages.length === 0) {
+      eventEmitter.emit<MessagePickupCompletedEvent>(messageContext.agentContext, {
+        type: MessagePickupEventTypes.MessagePickupCompleted,
+        payload: {
+          connection,
+          threadId: batchMessage.threadId,
+        },
+      })
+      return null
+    }
+
+    return (await this.createPickupMessage(agentContext, { connectionRecord: connection })).message
   }
 }

--- a/packages/core/src/modules/message-pickup/protocol/v2/handlers/V2StatusHandler.ts
+++ b/packages/core/src/modules/message-pickup/protocol/v2/handlers/V2StatusHandler.ts
@@ -7,15 +7,15 @@ import { V2StatusMessage } from '../messages'
 
 export class V2StatusHandler implements MessageHandler {
   public supportedMessages = [V2StatusMessage]
-  private messagePickupService: V2MessagePickupProtocol
+  private messagePickupProtocol: V2MessagePickupProtocol
 
-  public constructor(messagePickupService: V2MessagePickupProtocol) {
-    this.messagePickupService = messagePickupService
+  public constructor(messagePickupProtocol: V2MessagePickupProtocol) {
+    this.messagePickupProtocol = messagePickupProtocol
   }
 
   public async handle(messageContext: InboundMessageContext<V2StatusMessage>) {
     const connection = messageContext.assertReadyConnection()
-    const deliveryRequestMessage = await this.messagePickupService.processStatus(messageContext)
+    const deliveryRequestMessage = await this.messagePickupProtocol.processStatus(messageContext)
 
     if (deliveryRequestMessage) {
       return new OutboundMessageContext(deliveryRequestMessage, {

--- a/packages/core/src/modules/routing/MediationRecipientApi.ts
+++ b/packages/core/src/modules/routing/MediationRecipientApi.ts
@@ -206,6 +206,12 @@ export class MediationRecipientApi {
           try {
             if (pickupStrategy === MediatorPickupStrategy.PickUpV2LiveMode) {
               // Start Pickup v2 protocol in live mode (retrieve any queued message before)
+              await this.messagePickupApi.pickupMessages({
+                connectionId: mediator.connectionId,
+                protocolVersion: 'v2',
+                awaitCompletion: true,
+              })
+
               await this.messagePickupApi.setLiveDeliveryMode({
                 connectionId: mediator.connectionId,
                 liveDelivery: true,
@@ -263,8 +269,15 @@ export class MediationRecipientApi {
       }
       case MediatorPickupStrategy.PickUpV2LiveMode:
         // PickUp V2 in Live Mode will retrieve queued messages and then set up live delivery mode
-        this.logger.info(`Starting pickup of messages from mediator '${mediatorRecord.id}'`)
+        this.logger.info(`Starting Live Mode pickup of messages from mediator '${mediatorRecord.id}'`)
         await this.monitorMediatorWebSocketEvents(mediatorRecord, mediatorPickupStrategy)
+
+        await this.messagePickupApi.pickupMessages({
+          connectionId: mediatorConnection.id,
+          protocolVersion: 'v2',
+          awaitCompletion: true,
+        })
+
         await this.messagePickupApi.setLiveDeliveryMode({
           connectionId: mediatorConnection.id,
           liveDelivery: true,


### PR DESCRIPTION
Add a blocking mode for `MessagePickupApi.pickupMessages()`, where the agent will wait until all messages have been effectively retrieved and therefore the message pickup process is completed.

This tries to solve two main situations:

1) Retrieve queued messages BEFORE setting live mode in agents configured with `MediatorPickupStrategy.PickUpV2LiveMode`. This allows supporting the case where the mediator does not support `live-delivery-change` message (which is the case of AFJ <= 0.4.2 and AFAIK ACA-Py's Pick-up v2 plug-in). In such case, mediator will send a problem report that will be logged in the recipient but should not prevent the pick-up flow from being started
2) Facilitate the creation of a process dedicated to message pickup only. For instance, this can be used in mobile agents that are initiated from a background notification handler.

I did not take too much effort on the tests yet as I see there are some improvements in #1754 so maybe I can incorporate them once it's reviewed and merged.