### PR TITLE
feat: updated getAllPoolTransactions method

### DIFF
--- a/packages/indy-vdr/src/pool/IndyVdrPoolService.ts
+++ b/packages/indy-vdr/src/pool/IndyVdrPoolService.ts
@@ -160,7 +160,11 @@ export class IndyVdrPoolService {
    * Get all pool transactions
    */
   public getAllPoolTransactions() {
-    return Promise.allSettled(this.pools.map((pool) => pool.transactions))
+    return Promise.allSettled(
+      this.pools.map(async (pool) => {
+        return { config: pool.config, transactions: await pool.transactions }
+      })
+    )
   }
 
   /**


### PR DESCRIPTION
Updated `getAllPoolTransactions` method to include the pool config as part of the result so we know which pool is which.
BC Wallet already uses this in a yarn patch to the Credo-ts package. I figured I'd get it in the main repo so others could use it and we didn't have to keep maintaining the patch.