### PR TITLE
fix(anoncreds): check whether the tails location is a URL

### DIFF
--- a/packages/anoncreds/package.json
+++ b/packages/anoncreds/package.json
@@ -31,9 +31,9 @@
     "reflect-metadata": "^0.1.13"
   },
   "devDependencies": {
+    "@credo-ts/node": "0.4.2",
     "@hyperledger/anoncreds-nodejs": "^0.2.0",
     "@hyperledger/anoncreds-shared": "^0.2.0",
-    "@credo-ts/node": "0.4.2",
     "rimraf": "^4.4.0",
     "rxjs": "^7.8.0",
     "typescript": "~4.9.5"

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -73,6 +73,7 @@ export {
   deepEquality,
   asArray,
   equalsIgnoreOrder,
+  isUri,
 } from './utils'
 export * from './logger'
 export * from './error'


### PR DESCRIPTION
When you register a tailsfile, but you want to have an external endorser sign this transaction, this bug will happen. When creating the TXN, it will first replace the `tailsFileLocation` from a file path to a URL and upload it. After the endorser signed the TXN, it will be submitted again, running through the same code, and the `tailsFileLocation` will be replaced from a `URL` to another `URL` and uploaded again.

Best solution I could come up with to check wether the tails file is already uploaded.

TBH, it would be far better to have a different API for the `internal` vs `external`. Right now there is quite some code (like storing the revocation registry definition private parts) and now this that should **only** happen in either.

Also, reusing the `tailsFileLocation` for the URL and the file path does not really have my preference. Maybe in `0.6` we could introduce a `tailsFileFsLocation` and `tailsFileRemoteLocation`? Maybe this is a bit too overengineerd, but it was the reason why there was this bug in credo.