### PR TITLE
fix(core): query credential and proof records by correct DIDComm role

### DIFF
--- a/packages/anoncreds/src/protocols/credentials/v1/V1CredentialProtocol.ts
+++ b/packages/anoncreds/src/protocols/credentials/v1/V1CredentialProtocol.ts
@@ -220,10 +220,12 @@ export class V1CredentialProtocol
       const lastReceivedMessage = await didCommMessageRepository.findAgentMessage(messageContext.agentContext, {
         associatedRecordId: credentialRecord.id,
         messageClass: V1ProposeCredentialMessage,
+        role: DidCommMessageRole.Receiver,
       })
       const lastSentMessage = await didCommMessageRepository.getAgentMessage(messageContext.agentContext, {
         associatedRecordId: credentialRecord.id,
         messageClass: V1OfferCredentialMessage,
+        role: DidCommMessageRole.Sender,
       })
 
       await connectionService.assertConnectionOrOutOfBandExchange(messageContext, {
@@ -299,6 +301,7 @@ export class V1CredentialProtocol
     const proposalMessage = await didCommMessageRepository.getAgentMessage(agentContext, {
       associatedRecordId: credentialRecord.id,
       messageClass: V1ProposeCredentialMessage,
+      role: DidCommMessageRole.Receiver,
     })
 
     // NOTE: We set the credential attributes from the proposal on the record as we've 'accepted' them
@@ -511,10 +514,12 @@ export class V1CredentialProtocol
       const lastSentMessage = await didCommMessageRepository.getAgentMessage(messageContext.agentContext, {
         associatedRecordId: credentialRecord.id,
         messageClass: V1ProposeCredentialMessage,
+        role: DidCommMessageRole.Sender,
       })
       const lastReceivedMessage = await didCommMessageRepository.findAgentMessage(messageContext.agentContext, {
         associatedRecordId: credentialRecord.id,
         messageClass: V1OfferCredentialMessage,
+        role: DidCommMessageRole.Receiver,
       })
 
       // Assert
@@ -595,6 +600,7 @@ export class V1CredentialProtocol
     const offerMessage = await didCommMessageRepository.getAgentMessage(agentContext, {
       associatedRecordId: credentialRecord.id,
       messageClass: V1OfferCredentialMessage,
+      role: DidCommMessageRole.Receiver,
     })
 
     const offerAttachment = offerMessage.getOfferAttachmentById(INDY_CREDENTIAL_OFFER_ATTACHMENT_ID)
@@ -739,10 +745,12 @@ export class V1CredentialProtocol
     const proposalMessage = await didCommMessageRepository.findAgentMessage(messageContext.agentContext, {
       associatedRecordId: credentialRecord.id,
       messageClass: V1ProposeCredentialMessage,
+      role: DidCommMessageRole.Receiver,
     })
     const offerMessage = await didCommMessageRepository.findAgentMessage(messageContext.agentContext, {
       associatedRecordId: credentialRecord.id,
       messageClass: V1OfferCredentialMessage,
+      role: DidCommMessageRole.Sender,
     })
 
     // Assert
@@ -811,10 +819,12 @@ export class V1CredentialProtocol
     const offerMessage = await didCommMessageRepository.getAgentMessage(agentContext, {
       associatedRecordId: credentialRecord.id,
       messageClass: V1OfferCredentialMessage,
+      role: DidCommMessageRole.Sender,
     })
     const requestMessage = await didCommMessageRepository.getAgentMessage(agentContext, {
       associatedRecordId: credentialRecord.id,
       messageClass: V1RequestCredentialMessage,
+      role: DidCommMessageRole.Receiver,
     })
 
     const offerAttachment = offerMessage.getOfferAttachmentById(INDY_CREDENTIAL_OFFER_ATTACHMENT_ID)
@@ -884,10 +894,12 @@ export class V1CredentialProtocol
     const requestCredentialMessage = await didCommMessageRepository.findAgentMessage(messageContext.agentContext, {
       associatedRecordId: credentialRecord.id,
       messageClass: V1RequestCredentialMessage,
+      role: DidCommMessageRole.Sender,
     })
     const offerCredentialMessage = await didCommMessageRepository.findAgentMessage(messageContext.agentContext, {
       associatedRecordId: credentialRecord.id,
       messageClass: V1OfferCredentialMessage,
+      role: DidCommMessageRole.Receiver,
     })
 
     // Assert
@@ -987,10 +999,12 @@ export class V1CredentialProtocol
     const requestCredentialMessage = await didCommMessageRepository.getAgentMessage(messageContext.agentContext, {
       associatedRecordId: credentialRecord.id,
       messageClass: V1RequestCredentialMessage,
+      role: DidCommMessageRole.Receiver,
     })
     const issueCredentialMessage = await didCommMessageRepository.getAgentMessage(messageContext.agentContext, {
       associatedRecordId: credentialRecord.id,
       messageClass: V1IssueCredentialMessage,
+      role: DidCommMessageRole.Sender,
     })
 
     // Assert

--- a/packages/anoncreds/src/protocols/proofs/v1/V1ProofProtocol.ts
+++ b/packages/anoncreds/src/protocols/proofs/v1/V1ProofProtocol.ts
@@ -184,10 +184,12 @@ export class V1ProofProtocol extends BaseProofProtocol implements ProofProtocol<
       const lastReceivedMessage = await didCommMessageRepository.findAgentMessage(agentContext, {
         associatedRecordId: proofRecord.id,
         messageClass: V1ProposePresentationMessage,
+        role: DidCommMessageRole.Receiver,
       })
       const lastSentMessage = await didCommMessageRepository.getAgentMessage(agentContext, {
         associatedRecordId: proofRecord.id,
         messageClass: V1RequestPresentationMessage,
+        role: DidCommMessageRole.Sender,
       })
       await connectionService.assertConnectionOrOutOfBandExchange(messageContext, {
         lastReceivedMessage,
@@ -202,7 +204,7 @@ export class V1ProofProtocol extends BaseProofProtocol implements ProofProtocol<
       })
       await this.updateState(agentContext, proofRecord, ProofState.ProposalReceived)
     } else {
-      agentContext.config.logger.debug('Proof record does not exists yet for incoming proposal')
+      agentContext.config.logger.debug('Proof record does not exist yet for incoming proposal')
 
       // No proof record exists with thread id
       proofRecord = new ProofExchangeRecord({
@@ -220,7 +222,7 @@ export class V1ProofProtocol extends BaseProofProtocol implements ProofProtocol<
       await didCommMessageRepository.saveOrUpdateAgentMessage(agentContext, {
         agentMessage: proposalMessage,
         associatedRecordId: proofRecord.id,
-        role: DidCommMessageRole.Sender,
+        role: DidCommMessageRole.Receiver,
       })
 
       // Save record
@@ -250,6 +252,7 @@ export class V1ProofProtocol extends BaseProofProtocol implements ProofProtocol<
     const proposalMessage = await didCommMessageRepository.getAgentMessage(agentContext, {
       associatedRecordId: proofRecord.id,
       messageClass: V1ProposePresentationMessage,
+      role: DidCommMessageRole.Receiver,
     })
 
     const indyFormat = proofFormats?.indy
@@ -431,10 +434,12 @@ export class V1ProofProtocol extends BaseProofProtocol implements ProofProtocol<
       const lastReceivedMessage = await didCommMessageRepository.findAgentMessage(agentContext, {
         associatedRecordId: proofRecord.id,
         messageClass: V1RequestPresentationMessage,
+        role: DidCommMessageRole.Receiver,
       })
       const lastSentMessage = await didCommMessageRepository.getAgentMessage(agentContext, {
         associatedRecordId: proofRecord.id,
         messageClass: V1ProposePresentationMessage,
+        role: DidCommMessageRole.Sender,
       })
 
       // Assert
@@ -560,10 +565,12 @@ export class V1ProofProtocol extends BaseProofProtocol implements ProofProtocol<
     const requestMessage = await didCommMessageRepository.getAgentMessage(agentContext, {
       associatedRecordId: proofRecord.id,
       messageClass: V1RequestPresentationMessage,
+      role: DidCommMessageRole.Receiver,
     })
     const proposalMessage = await didCommMessageRepository.findAgentMessage(agentContext, {
       associatedRecordId: proofRecord.id,
       messageClass: V1ProposePresentationMessage,
+      role: DidCommMessageRole.Sender,
     })
 
     const requestAttachment = requestMessage.getRequestAttachmentById(INDY_PROOF_REQUEST_ATTACHMENT_ID)
@@ -630,11 +637,13 @@ export class V1ProofProtocol extends BaseProofProtocol implements ProofProtocol<
     const requestMessage = await didCommMessageRepository.getAgentMessage(agentContext, {
       associatedRecordId: proofRecord.id,
       messageClass: V1RequestPresentationMessage,
+      role: DidCommMessageRole.Receiver,
     })
 
     const proposalMessage = await didCommMessageRepository.findAgentMessage(agentContext, {
       associatedRecordId: proofRecord.id,
       messageClass: V1ProposePresentationMessage,
+      role: DidCommMessageRole.Sender,
     })
 
     const requestAttachment = requestMessage.getRequestAttachmentById(INDY_PROOF_REQUEST_ATTACHMENT_ID)
@@ -690,11 +699,13 @@ export class V1ProofProtocol extends BaseProofProtocol implements ProofProtocol<
     const requestMessage = await didCommMessageRepository.getAgentMessage(agentContext, {
       associatedRecordId: proofRecord.id,
       messageClass: V1RequestPresentationMessage,
+      role: DidCommMessageRole.Receiver,
     })
 
     const proposalMessage = await didCommMessageRepository.findAgentMessage(agentContext, {
       associatedRecordId: proofRecord.id,
       messageClass: V1ProposePresentationMessage,
+      role: DidCommMessageRole.Sender,
     })
 
     const requestAttachment = requestMessage.getRequestAttachmentById(INDY_PROOF_REQUEST_ATTACHMENT_ID)
@@ -754,11 +765,13 @@ export class V1ProofProtocol extends BaseProofProtocol implements ProofProtocol<
     const proposalMessage = await didCommMessageRepository.findAgentMessage(agentContext, {
       associatedRecordId: proofRecord.id,
       messageClass: V1ProposePresentationMessage,
+      role: DidCommMessageRole.Receiver,
     })
 
     const requestMessage = await didCommMessageRepository.getAgentMessage(agentContext, {
       associatedRecordId: proofRecord.id,
       messageClass: V1RequestPresentationMessage,
+      role: DidCommMessageRole.Sender,
     })
 
     // Assert
@@ -883,11 +896,13 @@ export class V1ProofProtocol extends BaseProofProtocol implements ProofProtocol<
     const lastReceivedMessage = await didCommMessageRepository.getAgentMessage(agentContext, {
       associatedRecordId: proofRecord.id,
       messageClass: V1RequestPresentationMessage,
+      role: DidCommMessageRole.Receiver,
     })
 
     const lastSentMessage = await didCommMessageRepository.getAgentMessage(agentContext, {
       associatedRecordId: proofRecord.id,
       messageClass: V1PresentationMessage,
+      role: DidCommMessageRole.Sender,
     })
 
     // Assert

--- a/packages/core/src/modules/credentials/protocol/v2/CredentialFormatCoordinator.ts
+++ b/packages/core/src/modules/credentials/protocol/v2/CredentialFormatCoordinator.ts
@@ -145,6 +145,7 @@ export class CredentialFormatCoordinator<CFs extends CredentialFormatService[]> 
     const proposalMessage = await didCommMessageRepository.getAgentMessage(agentContext, {
       associatedRecordId: credentialRecord.id,
       messageClass: V2ProposeCredentialMessage,
+      role: DidCommMessageRole.Receiver,
     })
 
     // NOTE: We set the credential attributes from the proposal on the record as we've 'accepted' them
@@ -336,6 +337,7 @@ export class CredentialFormatCoordinator<CFs extends CredentialFormatService[]> 
     const offerMessage = await didCommMessageRepository.getAgentMessage(agentContext, {
       associatedRecordId: credentialRecord.id,
       messageClass: V2OfferCredentialMessage,
+      role: DidCommMessageRole.Receiver,
     })
 
     // create message. there are two arrays in each message, one for formats the other for attachments
@@ -496,11 +498,13 @@ export class CredentialFormatCoordinator<CFs extends CredentialFormatService[]> 
     const requestMessage = await didCommMessageRepository.getAgentMessage(agentContext, {
       associatedRecordId: credentialRecord.id,
       messageClass: V2RequestCredentialMessage,
+      role: DidCommMessageRole.Receiver,
     })
 
     const offerMessage = await didCommMessageRepository.findAgentMessage(agentContext, {
       associatedRecordId: credentialRecord.id,
       messageClass: V2OfferCredentialMessage,
+      role: DidCommMessageRole.Sender,
     })
 
     // create message. there are two arrays in each message, one for formats the other for attachments
@@ -569,6 +573,7 @@ export class CredentialFormatCoordinator<CFs extends CredentialFormatService[]> 
     const offerMessage = await didCommMessageRepository.getAgentMessage(agentContext, {
       associatedRecordId: credentialRecord.id,
       messageClass: V2OfferCredentialMessage,
+      role: DidCommMessageRole.Receiver,
     })
 
     for (const formatService of formatServices) {

--- a/packages/core/src/modules/credentials/protocol/v2/V2CredentialProtocol.ts
+++ b/packages/core/src/modules/credentials/protocol/v2/V2CredentialProtocol.ts
@@ -31,7 +31,7 @@ import type {
 
 import { Protocol } from '../../../../agent/models/features/Protocol'
 import { CredoError } from '../../../../error'
-import { DidCommMessageRepository } from '../../../../storage/didcomm'
+import { DidCommMessageRepository, DidCommMessageRole } from '../../../../storage/didcomm'
 import { uuid } from '../../../../utils/uuid'
 import { AckStatus } from '../../../common'
 import { ConnectionService } from '../../../connections'
@@ -190,10 +190,12 @@ export class V2CredentialProtocol<CFs extends CredentialFormatService[] = Creden
       const proposalCredentialMessage = await didCommMessageRepository.findAgentMessage(messageContext.agentContext, {
         associatedRecordId: credentialRecord.id,
         messageClass: V2ProposeCredentialMessage,
+        role: DidCommMessageRole.Receiver,
       })
       const offerCredentialMessage = await didCommMessageRepository.findAgentMessage(messageContext.agentContext, {
         associatedRecordId: credentialRecord.id,
         messageClass: V2OfferCredentialMessage,
+        role: DidCommMessageRole.Sender,
       })
 
       // Assert
@@ -267,6 +269,7 @@ export class V2CredentialProtocol<CFs extends CredentialFormatService[] = Creden
       const proposalMessage = await didCommMessageRepository.getAgentMessage(agentContext, {
         associatedRecordId: credentialRecord.id,
         messageClass: V2ProposeCredentialMessage,
+        role: DidCommMessageRole.Receiver,
       })
 
       formatServices = this.getFormatServicesFromMessage(proposalMessage.formats)
@@ -429,10 +432,12 @@ export class V2CredentialProtocol<CFs extends CredentialFormatService[] = Creden
       const proposeCredentialMessage = await didCommMessageRepository.findAgentMessage(messageContext.agentContext, {
         associatedRecordId: credentialRecord.id,
         messageClass: V2ProposeCredentialMessage,
+        role: DidCommMessageRole.Sender,
       })
       const offerCredentialMessage = await didCommMessageRepository.findAgentMessage(messageContext.agentContext, {
         associatedRecordId: credentialRecord.id,
         messageClass: V2OfferCredentialMessage,
+        role: DidCommMessageRole.Receiver,
       })
 
       credentialRecord.assertProtocolVersion('v2')
@@ -506,6 +511,7 @@ export class V2CredentialProtocol<CFs extends CredentialFormatService[] = Creden
       const offerMessage = await didCommMessageRepository.getAgentMessage(agentContext, {
         associatedRecordId: credentialRecord.id,
         messageClass: V2OfferCredentialMessage,
+        role: DidCommMessageRole.Receiver,
       })
 
       formatServices = this.getFormatServicesFromMessage(offerMessage.formats)
@@ -664,11 +670,13 @@ export class V2CredentialProtocol<CFs extends CredentialFormatService[] = Creden
       const proposalMessage = await didCommMessageRepository.findAgentMessage(messageContext.agentContext, {
         associatedRecordId: credentialRecord.id,
         messageClass: V2ProposeCredentialMessage,
+        role: DidCommMessageRole.Receiver,
       })
 
       const offerMessage = await didCommMessageRepository.findAgentMessage(messageContext.agentContext, {
         associatedRecordId: credentialRecord.id,
         messageClass: V2OfferCredentialMessage,
+        role: DidCommMessageRole.Sender,
       })
 
       // Assert
@@ -752,6 +760,7 @@ export class V2CredentialProtocol<CFs extends CredentialFormatService[] = Creden
       const requestMessage = await didCommMessageRepository.getAgentMessage(agentContext, {
         associatedRecordId: credentialRecord.id,
         messageClass: V2RequestCredentialMessage,
+        role: DidCommMessageRole.Receiver,
       })
 
       formatServices = this.getFormatServicesFromMessage(requestMessage.formats)
@@ -807,10 +816,12 @@ export class V2CredentialProtocol<CFs extends CredentialFormatService[] = Creden
     const requestMessage = await didCommMessageRepository.getAgentMessage(messageContext.agentContext, {
       associatedRecordId: credentialRecord.id,
       messageClass: V2RequestCredentialMessage,
+      role: DidCommMessageRole.Sender,
     })
     const offerMessage = await didCommMessageRepository.findAgentMessage(messageContext.agentContext, {
       associatedRecordId: credentialRecord.id,
       messageClass: V2OfferCredentialMessage,
+      role: DidCommMessageRole.Receiver,
     })
 
     // Assert
@@ -892,11 +903,13 @@ export class V2CredentialProtocol<CFs extends CredentialFormatService[] = Creden
     const requestMessage = await didCommMessageRepository.getAgentMessage(messageContext.agentContext, {
       associatedRecordId: credentialRecord.id,
       messageClass: V2RequestCredentialMessage,
+      role: DidCommMessageRole.Receiver,
     })
 
     const credentialMessage = await didCommMessageRepository.getAgentMessage(messageContext.agentContext, {
       associatedRecordId: credentialRecord.id,
       messageClass: V2IssueCredentialMessage,
+      role: DidCommMessageRole.Sender,
     })
 
     // Assert

--- a/packages/core/src/modules/proofs/protocol/v2/ProofFormatCoordinator.ts
+++ b/packages/core/src/modules/proofs/protocol/v2/ProofFormatCoordinator.ts
@@ -137,6 +137,7 @@ export class ProofFormatCoordinator<PFs extends ProofFormatService[]> {
     const proposalMessage = await didCommMessageRepository.getAgentMessage(agentContext, {
       associatedRecordId: proofRecord.id,
       messageClass: V2ProposePresentationMessage,
+      role: DidCommMessageRole.Receiver,
     })
 
     for (const formatService of formatServices) {
@@ -298,11 +299,13 @@ export class ProofFormatCoordinator<PFs extends ProofFormatService[]> {
     const requestMessage = await didCommMessageRepository.getAgentMessage(agentContext, {
       associatedRecordId: proofRecord.id,
       messageClass: V2RequestPresentationMessage,
+      role: DidCommMessageRole.Receiver,
     })
 
     const proposalMessage = await didCommMessageRepository.findAgentMessage(agentContext, {
       associatedRecordId: proofRecord.id,
       messageClass: V2ProposePresentationMessage,
+      role: DidCommMessageRole.Receiver,
     })
 
     // create message. there are two arrays in each message, one for formats the other for attachments
@@ -373,11 +376,13 @@ export class ProofFormatCoordinator<PFs extends ProofFormatService[]> {
     const requestMessage = await didCommMessageRepository.getAgentMessage(agentContext, {
       associatedRecordId: proofRecord.id,
       messageClass: V2RequestPresentationMessage,
+      role: DidCommMessageRole.Receiver,
     })
 
     const proposalMessage = await didCommMessageRepository.findAgentMessage(agentContext, {
       associatedRecordId: proofRecord.id,
       messageClass: V2ProposePresentationMessage,
+      role: DidCommMessageRole.Receiver,
     })
 
     const credentialsForRequest: Record<string, unknown> = {}
@@ -429,11 +434,13 @@ export class ProofFormatCoordinator<PFs extends ProofFormatService[]> {
     const requestMessage = await didCommMessageRepository.getAgentMessage(agentContext, {
       associatedRecordId: proofRecord.id,
       messageClass: V2RequestPresentationMessage,
+      role: DidCommMessageRole.Receiver,
     })
 
     const proposalMessage = await didCommMessageRepository.findAgentMessage(agentContext, {
       associatedRecordId: proofRecord.id,
       messageClass: V2ProposePresentationMessage,
+      role: DidCommMessageRole.Receiver,
     })
 
     const credentialsForRequest: Record<string, unknown> = {}

--- a/packages/core/src/modules/proofs/protocol/v2/V2ProofProtocol.ts
+++ b/packages/core/src/modules/proofs/protocol/v2/V2ProofProtocol.ts
@@ -33,7 +33,7 @@ import type {
 
 import { Protocol } from '../../../../agent/models'
 import { CredoError } from '../../../../error'
-import { DidCommMessageRepository } from '../../../../storage/didcomm'
+import { DidCommMessageRepository, DidCommMessageRole } from '../../../../storage/didcomm'
 import { uuid } from '../../../../utils/uuid'
 import { AckStatus } from '../../../common'
 import { ConnectionService } from '../../../connections'
@@ -178,10 +178,12 @@ export class V2ProofProtocol<PFs extends ProofFormatService[] = ProofFormatServi
       const lastReceivedMessage = await didCommMessageRepository.findAgentMessage(messageContext.agentContext, {
         associatedRecordId: proofRecord.id,
         messageClass: V2ProposePresentationMessage,
+        role: DidCommMessageRole.Receiver,
       })
       const lastSentMessage = await didCommMessageRepository.findAgentMessage(messageContext.agentContext, {
         associatedRecordId: proofRecord.id,
         messageClass: V2RequestPresentationMessage,
+        role: DidCommMessageRole.Sender,
       })
 
       // Assert
@@ -256,6 +258,7 @@ export class V2ProofProtocol<PFs extends ProofFormatService[] = ProofFormatServi
       const proposalMessage = await didCommMessageRepository.getAgentMessage(agentContext, {
         associatedRecordId: proofRecord.id,
         messageClass: V2ProposePresentationMessage,
+        role: DidCommMessageRole.Receiver,
       })
 
       formatServices = this.getFormatServicesFromMessage(proposalMessage.formats)
@@ -429,11 +432,13 @@ export class V2ProofProtocol<PFs extends ProofFormatService[] = ProofFormatServi
       const lastSentMessage = await didCommMessageRepository.findAgentMessage(messageContext.agentContext, {
         associatedRecordId: proofRecord.id,
         messageClass: V2ProposePresentationMessage,
+        role: DidCommMessageRole.Sender,
       })
 
       const lastReceivedMessage = await didCommMessageRepository.findAgentMessage(messageContext.agentContext, {
         associatedRecordId: proofRecord.id,
         messageClass: V2RequestPresentationMessage,
+        role: DidCommMessageRole.Receiver,
       })
 
       // Assert
@@ -501,6 +506,7 @@ export class V2ProofProtocol<PFs extends ProofFormatService[] = ProofFormatServi
       const requestMessage = await didCommMessageRepository.getAgentMessage(agentContext, {
         associatedRecordId: proofRecord.id,
         messageClass: V2RequestPresentationMessage,
+        role: DidCommMessageRole.Receiver,
       })
 
       formatServices = this.getFormatServicesFromMessage(requestMessage.formats)
@@ -589,6 +595,7 @@ export class V2ProofProtocol<PFs extends ProofFormatService[] = ProofFormatServi
       const requestMessage = await didCommMessageRepository.getAgentMessage(agentContext, {
         associatedRecordId: proofRecord.id,
         messageClass: V2RequestPresentationMessage,
+        role: DidCommMessageRole.Receiver,
       })
 
       formatServices = this.getFormatServicesFromMessage(requestMessage.formats)
@@ -632,6 +639,7 @@ export class V2ProofProtocol<PFs extends ProofFormatService[] = ProofFormatServi
       const requestMessage = await didCommMessageRepository.getAgentMessage(agentContext, {
         associatedRecordId: proofRecord.id,
         messageClass: V2RequestPresentationMessage,
+        role: DidCommMessageRole.Receiver,
       })
 
       formatServices = this.getFormatServicesFromMessage(requestMessage.formats)
@@ -671,11 +679,13 @@ export class V2ProofProtocol<PFs extends ProofFormatService[] = ProofFormatServi
     const lastSentMessage = await didCommMessageRepository.getAgentMessage(messageContext.agentContext, {
       associatedRecordId: proofRecord.id,
       messageClass: V2RequestPresentationMessage,
+      role: DidCommMessageRole.Sender,
     })
 
     const lastReceivedMessage = await didCommMessageRepository.findAgentMessage(messageContext.agentContext, {
       associatedRecordId: proofRecord.id,
       messageClass: V2ProposePresentationMessage,
+      role: DidCommMessageRole.Receiver,
     })
 
     // Assert
@@ -740,6 +750,7 @@ export class V2ProofProtocol<PFs extends ProofFormatService[] = ProofFormatServi
     const presentation = await didCommMessageRepository.getAgentMessage(agentContext, {
       associatedRecordId: proofRecord.id,
       messageClass: V2PresentationMessage,
+      role: DidCommMessageRole.Receiver,
     })
 
     if (!presentation.lastPresentation) {
@@ -786,11 +797,13 @@ export class V2ProofProtocol<PFs extends ProofFormatService[] = ProofFormatServi
     const lastReceivedMessage = await didCommMessageRepository.getAgentMessage(messageContext.agentContext, {
       associatedRecordId: proofRecord.id,
       messageClass: V2RequestPresentationMessage,
+      role: DidCommMessageRole.Receiver,
     })
 
     const lastSentMessage = await didCommMessageRepository.getAgentMessage(messageContext.agentContext, {
       associatedRecordId: proofRecord.id,
       messageClass: V2PresentationMessage,
+      role: DidCommMessageRole.Sender,
     })
 
     // Assert

--- a/packages/core/src/modules/proofs/protocol/v2/handlers/V2PresentationHandler.ts
+++ b/packages/core/src/modules/proofs/protocol/v2/handlers/V2PresentationHandler.ts
@@ -3,7 +3,7 @@ import type { ProofExchangeRecord } from '../../../repository'
 import type { V2ProofProtocol } from '../V2ProofProtocol'
 
 import { getOutboundMessageContext } from '../../../../../agent/getOutboundMessageContext'
-import { DidCommMessageRepository } from '../../../../../storage/didcomm'
+import { DidCommMessageRepository, DidCommMessageRole } from '../../../../../storage/didcomm'
 import { V2PresentationMessage, V2RequestPresentationMessage } from '../messages'
 
 export class V2PresentationHandler implements MessageHandler {
@@ -41,6 +41,7 @@ export class V2PresentationHandler implements MessageHandler {
     const requestMessage = await didCommMessageRepository.getAgentMessage(messageContext.agentContext, {
       associatedRecordId: proofRecord.id,
       messageClass: V2RequestPresentationMessage,
+      role: DidCommMessageRole.Sender,
     })
 
     return getOutboundMessageContext(messageContext.agentContext, {

--- a/packages/core/src/storage/didcomm/DidCommMessageRepository.ts
+++ b/packages/core/src/storage/didcomm/DidCommMessageRepository.ts
@@ -55,26 +55,28 @@ export class DidCommMessageRepository extends Repository<DidCommMessageRecord> {
 
   public async getAgentMessage<MessageClass extends ConstructableAgentMessage = ConstructableAgentMessage>(
     agentContext: AgentContext,
-    { associatedRecordId, messageClass }: GetAgentMessageOptions<MessageClass>
+    { associatedRecordId, messageClass, role }: GetAgentMessageOptions<MessageClass>
   ): Promise<InstanceType<MessageClass>> {
     const record = await this.getSingleByQuery(agentContext, {
       associatedRecordId,
       messageName: messageClass.type.messageName,
       protocolName: messageClass.type.protocolName,
       protocolMajorVersion: String(messageClass.type.protocolMajorVersion),
+      role,
     })
 
     return record.getMessageInstance(messageClass)
   }
   public async findAgentMessage<MessageClass extends ConstructableAgentMessage = ConstructableAgentMessage>(
     agentContext: AgentContext,
-    { associatedRecordId, messageClass }: GetAgentMessageOptions<MessageClass>
+    { associatedRecordId, messageClass, role }: GetAgentMessageOptions<MessageClass>
   ): Promise<InstanceType<MessageClass> | null> {
     const record = await this.findSingleByQuery(agentContext, {
       associatedRecordId,
       messageName: messageClass.type.messageName,
       protocolName: messageClass.type.protocolName,
       protocolMajorVersion: String(messageClass.type.protocolMajorVersion),
+      role,
     })
 
     return record?.getMessageInstance(messageClass) ?? null
@@ -90,4 +92,5 @@ export interface SaveAgentMessageOptions {
 export interface GetAgentMessageOptions<MessageClass extends typeof AgentMessage> {
   associatedRecordId: string
   messageClass: MessageClass
+  role?: DidCommMessageRole
 }


### PR DESCRIPTION
- Added an additional requirement to the query to find an agent message. This was added so you can technically offer a credential, and request a proof, to yourself. No changes in the current behavior.