### PR TITLE
fix: query the record by credential and proof role

### DIFF
--- a/packages/anoncreds/src/protocols/credentials/v1/V1CredentialProtocol.ts
+++ b/packages/anoncreds/src/protocols/credentials/v1/V1CredentialProtocol.ts
@@ -203,10 +203,11 @@ export class V1CredentialProtocol
 
     agentContext.config.logger.debug(`Processing credential proposal with message id ${proposalMessage.id}`)
 
-    let credentialRecord = await this.findByThreadAndConnectionId(
+    let credentialRecord = await this.findByThreadIdConnectionIdAndRole(
       messageContext.agentContext,
       proposalMessage.threadId,
-      connection?.id
+      connection?.id,
+      CredentialRole.Issuer
     )
 
     // Credential record already exists, this is a response to an earlier message sent by us
@@ -503,7 +504,12 @@ export class V1CredentialProtocol
 
     agentContext.config.logger.debug(`Processing credential offer with id ${offerMessage.id}`)
 
-    let credentialRecord = await this.findByThreadAndConnectionId(agentContext, offerMessage.threadId, connection?.id)
+    let credentialRecord = await this.findByThreadIdConnectionIdAndRole(
+      agentContext,
+      offerMessage.threadId,
+      connection?.id,
+      CredentialRole.Holder
+    )
 
     const offerAttachment = offerMessage.getOfferAttachmentById(INDY_CREDENTIAL_OFFER_ATTACHMENT_ID)
     if (!offerAttachment) {

--- a/packages/anoncreds/src/protocols/proofs/v1/V1ProofProtocol.ts
+++ b/packages/anoncreds/src/protocols/proofs/v1/V1ProofProtocol.ts
@@ -171,7 +171,12 @@ export class V1ProofProtocol extends BaseProofProtocol implements ProofProtocol<
 
     agentContext.config.logger.debug(`Processing presentation proposal with message id ${proposalMessage.id}`)
 
-    let proofRecord = await this.findByThreadAndConnectionId(agentContext, proposalMessage.threadId, connection?.id)
+    let proofRecord = await this.findByThreadIdConnectionIdAndRole(
+      agentContext,
+      proposalMessage.threadId,
+      connection?.id,
+      ProofRole.Verifier
+    )
 
     // Proof record already exists, this is a response to an earlier message sent by us
     if (proofRecord) {
@@ -422,7 +427,12 @@ export class V1ProofProtocol extends BaseProofProtocol implements ProofProtocol<
 
     agentContext.config.logger.debug(`Processing presentation request with id ${proofRequestMessage.id}`)
 
-    let proofRecord = await this.findByThreadAndConnectionId(agentContext, proofRequestMessage.threadId, connection?.id)
+    let proofRecord = await this.findByThreadIdConnectionIdAndRole(
+      agentContext,
+      proofRequestMessage.threadId,
+      connection?.id,
+      ProofRole.Prover
+    )
 
     const requestAttachment = proofRequestMessage.getRequestAttachmentById(INDY_PROOF_REQUEST_ATTACHMENT_ID)
     if (!requestAttachment) {

--- a/packages/core/src/modules/credentials/protocol/BaseCredentialProtocol.ts
+++ b/packages/core/src/modules/credentials/protocol/BaseCredentialProtocol.ts
@@ -23,6 +23,7 @@ import type { Query } from '../../../storage/StorageService'
 import type { ProblemReportMessage } from '../../problem-reports'
 import type { CredentialStateChangedEvent } from '../CredentialEvents'
 import type { CredentialFormatService, ExtractCredentialFormats } from '../formats'
+import type { CredentialRole } from '../models'
 import type { CredentialExchangeRecord } from '../repository'
 
 import { EventEmitter } from '../../../agent/EventEmitter'
@@ -296,20 +297,23 @@ export abstract class BaseCredentialProtocol<CFs extends CredentialFormatService
   /**
    * Find a credential record by connection id and thread id, returns null if not found
    *
-   * @param connectionId The connection id
    * @param threadId The thread id
+   * @param connectionId The connection id
+   * @param role The role required, i.e. issuer of holder
    * @returns The credential record
    */
-  public findByThreadAndConnectionId(
+  public findByThreadIdConnectionIdAndRole(
     agentContext: AgentContext,
     threadId: string,
-    connectionId?: string
+    connectionId?: string,
+    role?: CredentialRole
   ): Promise<CredentialExchangeRecord | null> {
     const credentialRepository = agentContext.dependencyManager.resolve(CredentialRepository)
 
     return credentialRepository.findSingleByQuery(agentContext, {
       connectionId,
       threadId,
+      role,
     })
   }
 

--- a/packages/core/src/modules/credentials/protocol/CredentialProtocol.ts
+++ b/packages/core/src/modules/credentials/protocol/CredentialProtocol.ts
@@ -117,7 +117,7 @@ export interface CredentialProtocol<CFs extends CredentialFormatService[] = Cred
     threadId: string,
     connectionId?: string
   ): Promise<CredentialExchangeRecord>
-  findByThreadAndConnectionId(
+  findByThreadIdConnectionIdAndRole(
     agentContext: AgentContext,
     threadId: string,
     connectionId?: string

--- a/packages/core/src/modules/credentials/protocol/v2/V2CredentialProtocol.ts
+++ b/packages/core/src/modules/credentials/protocol/v2/V2CredentialProtocol.ts
@@ -174,10 +174,11 @@ export class V2CredentialProtocol<CFs extends CredentialFormatService[] = Creden
     const didCommMessageRepository = agentContext.dependencyManager.resolve(DidCommMessageRepository)
     const connectionService = agentContext.dependencyManager.resolve(ConnectionService)
 
-    let credentialRecord = await this.findByThreadAndConnectionId(
+    let credentialRecord = await this.findByThreadIdConnectionIdAndRole(
       messageContext.agentContext,
       proposalMessage.threadId,
-      connection?.id
+      connection?.id,
+      CredentialRole.Issuer
     )
 
     const formatServices = this.getFormatServicesFromMessage(proposalMessage.formats)
@@ -416,10 +417,11 @@ export class V2CredentialProtocol<CFs extends CredentialFormatService[] = Creden
     const didCommMessageRepository = agentContext.dependencyManager.resolve(DidCommMessageRepository)
     const connectionService = agentContext.dependencyManager.resolve(ConnectionService)
 
-    let credentialRecord = await this.findByThreadAndConnectionId(
+    let credentialRecord = await this.findByThreadIdConnectionIdAndRole(
       messageContext.agentContext,
       offerMessage.threadId,
-      connection?.id
+      connection?.id,
+      CredentialRole.Holder
     )
 
     const formatServices = this.getFormatServicesFromMessage(offerMessage.formats)
@@ -658,7 +660,11 @@ export class V2CredentialProtocol<CFs extends CredentialFormatService[] = Creden
 
     agentContext.config.logger.debug(`Processing credential request with id ${requestMessage.id}`)
 
-    let credentialRecord = await this.findByThreadAndConnectionId(messageContext.agentContext, requestMessage.threadId)
+    let credentialRecord = await this.findByThreadIdConnectionIdAndRole(
+      messageContext.agentContext,
+      requestMessage.threadId,
+      CredentialRole.Issuer
+    )
 
     const formatServices = this.getFormatServicesFromMessage(requestMessage.formats)
     if (formatServices.length === 0) {

--- a/packages/core/src/modules/credentials/protocol/v2/__tests__/V2CredentialProtocolCred.test.ts
+++ b/packages/core/src/modules/credentials/protocol/v2/__tests__/V2CredentialProtocolCred.test.ts
@@ -327,7 +327,7 @@ describe('credentialProtocol', () => {
         invalidCredentialStates.map(async (state) => {
           await expect(
             credentialProtocol.acceptOffer(agentContext, { credentialRecord: mockCredentialRecord({ state }) })
-          ).rejects.toThrowError(`Credential record is in invalid state ${state}. Valid states are: ${validState}.`)
+          ).rejects.toThrow(`Credential record is in invalid state ${state}. Valid states are: ${validState}.`)
         })
       )
     })
@@ -350,6 +350,8 @@ describe('credentialProtocol', () => {
       // then
       expect(credentialRepository.findSingleByQuery).toHaveBeenNthCalledWith(1, agentContext, {
         threadId: 'somethreadid',
+        connectionId: 'issuer',
+        role: undefined,
       })
       expect(credentialRepository.update).toHaveBeenCalledTimes(1)
       expect(returnedCredentialRecord.state).toEqual(CredentialState.RequestReceived)
@@ -372,6 +374,8 @@ describe('credentialProtocol', () => {
       // then
       expect(credentialRepository.findSingleByQuery).toHaveBeenNthCalledWith(1, agentContext, {
         threadId: 'somethreadid',
+        connectionId: 'issuer',
+        role: undefined,
       })
       expect(eventListenerMock).toHaveBeenCalled()
       expect(returnedCredentialRecord.state).toEqual(CredentialState.RequestReceived)

--- a/packages/core/src/modules/proofs/protocol/BaseProofProtocol.ts
+++ b/packages/core/src/modules/proofs/protocol/BaseProofProtocol.ts
@@ -25,6 +25,7 @@ import type { Query } from '../../../storage/StorageService'
 import type { ProblemReportMessage } from '../../problem-reports'
 import type { ProofStateChangedEvent } from '../ProofEvents'
 import type { ExtractProofFormats, ProofFormatService } from '../formats'
+import type { ProofRole } from '../models'
 import type { ProofExchangeRecord } from '../repository'
 
 import { EventEmitter } from '../../../agent/EventEmitter'
@@ -256,20 +257,23 @@ export abstract class BaseProofProtocol<PFs extends ProofFormatService[] = Proof
   /**
    * Find a proof record by connection id and thread id, returns null if not found
    *
-   * @param connectionId The connection id
    * @param threadId The thread id
+   * @param connectionId The connection id
+   * @param role The role of the proof record, i.e. verifier or prover
    * @returns The proof record
    */
-  public findByThreadAndConnectionId(
+  public findByThreadIdConnectionIdAndRole(
     agentContext: AgentContext,
     threadId: string,
-    connectionId?: string
+    connectionId?: string,
+    role?: ProofRole
   ): Promise<ProofExchangeRecord | null> {
     const proofRepository = agentContext.dependencyManager.resolve(ProofRepository)
 
     return proofRepository.findSingleByQuery(agentContext, {
       connectionId,
       threadId,
+      role,
     })
   }
 

--- a/packages/core/src/modules/proofs/protocol/ProofProtocol.ts
+++ b/packages/core/src/modules/proofs/protocol/ProofProtocol.ts
@@ -106,7 +106,7 @@ export interface ProofProtocol<PFs extends ProofFormatService[] = ProofFormatSer
     threadId: string,
     connectionId?: string
   ): Promise<ProofExchangeRecord>
-  findByThreadAndConnectionId(
+  findByThreadIdConnectionIdAndRole(
     agentContext: AgentContext,
     threadId: string,
     connectionId?: string

--- a/packages/core/src/modules/proofs/protocol/v2/V2ProofProtocol.ts
+++ b/packages/core/src/modules/proofs/protocol/v2/V2ProofProtocol.ts
@@ -162,10 +162,11 @@ export class V2ProofProtocol<PFs extends ProofFormatService[] = ProofFormatServi
     const didCommMessageRepository = agentContext.dependencyManager.resolve(DidCommMessageRepository)
     const connectionService = agentContext.dependencyManager.resolve(ConnectionService)
 
-    let proofRecord = await this.findByThreadAndConnectionId(
+    let proofRecord = await this.findByThreadIdConnectionIdAndRole(
       messageContext.agentContext,
       proposalMessage.threadId,
-      connection?.id
+      connection?.id,
+      ProofRole.Verifier
     )
 
     const formatServices = this.getFormatServicesFromMessage(proposalMessage.formats)
@@ -416,10 +417,11 @@ export class V2ProofProtocol<PFs extends ProofFormatService[] = ProofFormatServi
 
     agentContext.config.logger.debug(`Processing proof request with id ${requestMessage.id}`)
 
-    let proofRecord = await this.findByThreadAndConnectionId(
+    let proofRecord = await this.findByThreadIdConnectionIdAndRole(
       messageContext.agentContext,
       requestMessage.threadId,
-      connection?.id
+      connection?.id,
+      ProofRole.Prover
     )
 
     const formatServices = this.getFormatServicesFromMessage(requestMessage.formats)


### PR DESCRIPTION
- Missed in the last PR regarding issuance to self. We also have to make sure when finding the credential, or proof, exchange record, that the role is correct otherwise we will find multiple instances with the same connection id and thread id.
