### PR TITLE
fix: query the record by credential and proof role

### DIFF
--- a/packages/anoncreds/src/protocols/credentials/v1/V1CredentialProtocol.ts
+++ b/packages/anoncreds/src/protocols/credentials/v1/V1CredentialProtocol.ts
@@ -203,9 +203,10 @@ export class V1CredentialProtocol
 
     agentContext.config.logger.debug(`Processing credential proposal with message id ${proposalMessage.id}`)
 
-    let credentialRecord = await this.findByThreadAndConnectionId(
+    let credentialRecord = await this.findByThreadIdConnectionIdAndRole(
       messageContext.agentContext,
       proposalMessage.threadId,
+      CredentialRole.Issuer,
       connection?.id
     )
 
@@ -503,7 +504,12 @@ export class V1CredentialProtocol
 
     agentContext.config.logger.debug(`Processing credential offer with id ${offerMessage.id}`)
 
-    let credentialRecord = await this.findByThreadAndConnectionId(agentContext, offerMessage.threadId, connection?.id)
+    let credentialRecord = await this.findByThreadIdConnectionIdAndRole(
+      agentContext,
+      offerMessage.threadId,
+      CredentialRole.Holder,
+      connection?.id
+    )
 
     const offerAttachment = offerMessage.getOfferAttachmentById(INDY_CREDENTIAL_OFFER_ATTACHMENT_ID)
     if (!offerAttachment) {
@@ -739,7 +745,11 @@ export class V1CredentialProtocol
 
     agentContext.config.logger.debug(`Processing credential request with id ${requestMessage.id}`)
 
-    const credentialRecord = await this.getByThreadAndConnectionId(messageContext.agentContext, requestMessage.threadId)
+    const credentialRecord = await this.getByThreadIdConnectionIdAndRole(
+      messageContext.agentContext,
+      requestMessage.threadId,
+      CredentialRole.Issuer
+    )
     agentContext.config.logger.trace('Credential record found when processing credential request', credentialRecord)
 
     const proposalMessage = await didCommMessageRepository.findAgentMessage(messageContext.agentContext, {
@@ -885,9 +895,10 @@ export class V1CredentialProtocol
     // only depends on the public api, rather than the internal API (this helps with breaking changes)
     const connectionService = agentContext.dependencyManager.resolve(ConnectionService)
 
-    const credentialRecord = await this.getByThreadAndConnectionId(
+    const credentialRecord = await this.getByThreadIdConnectionIdAndRole(
       messageContext.agentContext,
       issueMessage.threadId,
+      CredentialRole.Holder,
       connection?.id
     )
 
@@ -990,9 +1001,10 @@ export class V1CredentialProtocol
     // only depends on the public api, rather than the internal API (this helps with breaking changes)
     const connectionService = agentContext.dependencyManager.resolve(ConnectionService)
 
-    const credentialRecord = await this.getByThreadAndConnectionId(
+    const credentialRecord = await this.getByThreadIdConnectionIdAndRole(
       messageContext.agentContext,
       ackMessage.threadId,
+      CredentialRole.Issuer,
       connection?.id
     )
 
@@ -1029,7 +1041,7 @@ export class V1CredentialProtocol
    *
    */
   public async createProblemReport(
-    agentContext: AgentContext,
+    _agentContext: AgentContext,
     { credentialRecord, description }: CredentialProtocolOptions.CreateCredentialProblemReportOptions
   ): Promise<CredentialProtocolOptions.CredentialProtocolMsgReturnType<ProblemReportMessage>> {
     const message = new V1CredentialProblemReportMessage({

--- a/packages/anoncreds/src/protocols/credentials/v1/V1CredentialProtocol.ts
+++ b/packages/anoncreds/src/protocols/credentials/v1/V1CredentialProtocol.ts
@@ -203,12 +203,11 @@ export class V1CredentialProtocol
 
     agentContext.config.logger.debug(`Processing credential proposal with message id ${proposalMessage.id}`)
 
-    let credentialRecord = await this.findByThreadIdConnectionIdAndRole(
-      messageContext.agentContext,
-      proposalMessage.threadId,
-      CredentialRole.Issuer,
-      connection?.id
-    )
+    let credentialRecord = await this.findByProperties(messageContext.agentContext, {
+      threadId: proposalMessage.threadId,
+      role: CredentialRole.Issuer,
+      connectionId: connection?.id,
+    })
 
     // Credential record already exists, this is a response to an earlier message sent by us
     if (credentialRecord) {
@@ -504,12 +503,11 @@ export class V1CredentialProtocol
 
     agentContext.config.logger.debug(`Processing credential offer with id ${offerMessage.id}`)
 
-    let credentialRecord = await this.findByThreadIdConnectionIdAndRole(
-      agentContext,
-      offerMessage.threadId,
-      CredentialRole.Holder,
-      connection?.id
-    )
+    let credentialRecord = await this.findByProperties(agentContext, {
+      threadId: offerMessage.threadId,
+      role: CredentialRole.Holder,
+      connectionId: connection?.id,
+    })
 
     const offerAttachment = offerMessage.getOfferAttachmentById(INDY_CREDENTIAL_OFFER_ATTACHMENT_ID)
     if (!offerAttachment) {
@@ -745,11 +743,11 @@ export class V1CredentialProtocol
 
     agentContext.config.logger.debug(`Processing credential request with id ${requestMessage.id}`)
 
-    const credentialRecord = await this.getByThreadIdConnectionIdAndRole(
-      messageContext.agentContext,
-      requestMessage.threadId,
-      CredentialRole.Issuer
-    )
+    const credentialRecord = await this.getByProperties(messageContext.agentContext, {
+      threadId: requestMessage.threadId,
+      role: CredentialRole.Issuer,
+    })
+
     agentContext.config.logger.trace('Credential record found when processing credential request', credentialRecord)
 
     const proposalMessage = await didCommMessageRepository.findAgentMessage(messageContext.agentContext, {
@@ -895,12 +893,11 @@ export class V1CredentialProtocol
     // only depends on the public api, rather than the internal API (this helps with breaking changes)
     const connectionService = agentContext.dependencyManager.resolve(ConnectionService)
 
-    const credentialRecord = await this.getByThreadIdConnectionIdAndRole(
-      messageContext.agentContext,
-      issueMessage.threadId,
-      CredentialRole.Holder,
-      connection?.id
-    )
+    const credentialRecord = await this.getByProperties(messageContext.agentContext, {
+      threadId: issueMessage.threadId,
+      role: CredentialRole.Holder,
+      connectionId: connection?.id,
+    })
 
     const requestCredentialMessage = await didCommMessageRepository.findAgentMessage(messageContext.agentContext, {
       associatedRecordId: credentialRecord.id,
@@ -1001,12 +998,12 @@ export class V1CredentialProtocol
     // only depends on the public api, rather than the internal API (this helps with breaking changes)
     const connectionService = agentContext.dependencyManager.resolve(ConnectionService)
 
-    const credentialRecord = await this.getByThreadIdConnectionIdAndRole(
-      messageContext.agentContext,
-      ackMessage.threadId,
-      CredentialRole.Issuer,
-      connection?.id
-    )
+    const credentialRecord = await this.getByProperties(messageContext.agentContext, {
+      threadId: ackMessage.threadId,
+
+      role: CredentialRole.Issuer,
+      connectionId: connection?.id,
+    })
 
     const requestCredentialMessage = await didCommMessageRepository.getAgentMessage(messageContext.agentContext, {
       associatedRecordId: credentialRecord.id,

--- a/packages/anoncreds/src/protocols/credentials/v1/__tests__/V1CredentialProtocolCred.test.ts
+++ b/packages/anoncreds/src/protocols/credentials/v1/__tests__/V1CredentialProtocolCred.test.ts
@@ -132,7 +132,7 @@ const didCommMessageRecord = new DidCommMessageRecord({
 })
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const getAgentMessageMock = async (agentContext: AgentContext, options: { messageClass: any }) => {
+const getAgentMessageMock = async (_agentContext: AgentContext, options: { messageClass: any }) => {
   if (options.messageClass === V1ProposeCredentialMessage) {
     return credentialProposalMessage
   }
@@ -312,7 +312,7 @@ describe('V1CredentialProtocol', () => {
         invalidCredentialStates.map(async (state) => {
           await expect(
             credentialProtocol.acceptOffer(agentContext, { credentialRecord: mockCredentialRecord({ state }) })
-          ).rejects.toThrowError(`Credential record is in invalid state ${state}. Valid states are: ${validState}.`)
+          ).rejects.toThrow(`Credential record is in invalid state ${state}. Valid states are: ${validState}.`)
         })
       )
     })
@@ -347,6 +347,7 @@ describe('V1CredentialProtocol', () => {
       // then
       expect(credentialRepository.getSingleByQuery).toHaveBeenNthCalledWith(1, agentContext, {
         threadId: 'somethreadid',
+        role: CredentialRole.Issuer,
       })
       expect(repositoryUpdateSpy).toHaveBeenCalledTimes(1)
       expect(returnedCredentialRecord.state).toEqual(CredentialState.RequestReceived)
@@ -363,6 +364,7 @@ describe('V1CredentialProtocol', () => {
       // then
       expect(credentialRepository.getSingleByQuery).toHaveBeenNthCalledWith(1, agentContext, {
         threadId: 'somethreadid',
+        role: CredentialRole.Issuer,
       })
       expect(returnedCredentialRecord.state).toEqual(CredentialState.RequestReceived)
     })
@@ -375,7 +377,7 @@ describe('V1CredentialProtocol', () => {
           mockFunction(credentialRepository.getSingleByQuery).mockReturnValue(
             Promise.resolve(mockCredentialRecord({ state }))
           )
-          await expect(credentialProtocol.processRequest(messageContext)).rejects.toThrowError(
+          await expect(credentialProtocol.processRequest(messageContext)).rejects.toThrow(
             `Credential record is in invalid state ${state}. Valid states are: ${validState}.`
           )
         })
@@ -516,6 +518,7 @@ describe('V1CredentialProtocol', () => {
       expect(credentialRepository.getSingleByQuery).toHaveBeenNthCalledWith(1, agentContext, {
         threadId: 'somethreadid',
         connectionId: connection.id,
+        role: CredentialRole.Holder,
       })
 
       expect(didCommMessageRepository.saveAgentMessage).toHaveBeenCalledWith(agentContext, {
@@ -614,7 +617,7 @@ describe('V1CredentialProtocol', () => {
                 connectionId: 'b1e2f039-aa39-40be-8643-6ce2797b5190',
               }),
             })
-          ).rejects.toThrowError(`Credential record is in invalid state ${state}. Valid states are: ${validState}.`)
+          ).rejects.toThrow(`Credential record is in invalid state ${state}. Valid states are: ${validState}.`)
         })
       )
     })
@@ -652,6 +655,7 @@ describe('V1CredentialProtocol', () => {
       expect(credentialRepository.getSingleByQuery).toHaveBeenNthCalledWith(1, agentContext, {
         threadId: 'somethreadid',
         connectionId: connection.id,
+        role: CredentialRole.Issuer,
       })
       expect(repositoryUpdateSpy).toHaveBeenCalledTimes(1)
       const [[, updatedCredentialRecord]] = repositoryUpdateSpy.mock.calls
@@ -746,7 +750,7 @@ describe('V1CredentialProtocol', () => {
       const expected = mockCredentialRecord()
       mockFunction(credentialRepository.getById).mockReturnValue(Promise.resolve(expected))
       const result = await credentialProtocol.getById(agentContext, expected.id)
-      expect(credentialRepository.getById).toBeCalledWith(agentContext, expected.id)
+      expect(credentialRepository.getById).toHaveBeenCalledWith(agentContext, expected.id)
 
       expect(result).toBe(expected)
     })
@@ -754,10 +758,16 @@ describe('V1CredentialProtocol', () => {
     it('getById should return value from credentialRepository.getSingleByQuery', async () => {
       const expected = mockCredentialRecord()
       mockFunction(credentialRepository.getSingleByQuery).mockReturnValue(Promise.resolve(expected))
-      const result = await credentialProtocol.getByThreadAndConnectionId(agentContext, 'threadId', 'connectionId')
-      expect(credentialRepository.getSingleByQuery).toBeCalledWith(agentContext, {
+      const result = await credentialProtocol.getByThreadIdConnectionIdAndRole(
+        agentContext,
+        'threadId',
+        CredentialRole.Issuer,
+        'connectionId'
+      )
+      expect(credentialRepository.getSingleByQuery).toHaveBeenCalledWith(agentContext, {
         threadId: 'threadId',
         connectionId: 'connectionId',
+        role: CredentialRole.Issuer,
       })
 
       expect(result).toBe(expected)
@@ -767,7 +777,7 @@ describe('V1CredentialProtocol', () => {
       const expected = mockCredentialRecord()
       mockFunction(credentialRepository.findById).mockReturnValue(Promise.resolve(expected))
       const result = await credentialProtocol.findById(agentContext, expected.id)
-      expect(credentialRepository.findById).toBeCalledWith(agentContext, expected.id)
+      expect(credentialRepository.findById).toHaveBeenCalledWith(agentContext, expected.id)
 
       expect(result).toBe(expected)
     })
@@ -777,7 +787,7 @@ describe('V1CredentialProtocol', () => {
 
       mockFunction(credentialRepository.getAll).mockReturnValue(Promise.resolve(expected))
       const result = await credentialProtocol.getAll(agentContext)
-      expect(credentialRepository.getAll).toBeCalledWith(agentContext)
+      expect(credentialRepository.getAll).toHaveBeenCalledWith(agentContext)
 
       expect(result).toEqual(expect.arrayContaining(expected))
     })
@@ -787,7 +797,7 @@ describe('V1CredentialProtocol', () => {
 
       mockFunction(credentialRepository.findByQuery).mockReturnValue(Promise.resolve(expected))
       const result = await credentialProtocol.findAllByQuery(agentContext, { state: CredentialState.OfferSent })
-      expect(credentialRepository.findByQuery).toBeCalledWith(agentContext, { state: CredentialState.OfferSent })
+      expect(credentialRepository.findByQuery).toHaveBeenCalledWith(agentContext, { state: CredentialState.OfferSent })
 
       expect(result).toEqual(expect.arrayContaining(expected))
     })

--- a/packages/anoncreds/src/protocols/credentials/v1/__tests__/V1CredentialProtocolCred.test.ts
+++ b/packages/anoncreds/src/protocols/credentials/v1/__tests__/V1CredentialProtocolCred.test.ts
@@ -758,12 +758,13 @@ describe('V1CredentialProtocol', () => {
     it('getById should return value from credentialRepository.getSingleByQuery', async () => {
       const expected = mockCredentialRecord()
       mockFunction(credentialRepository.getSingleByQuery).mockReturnValue(Promise.resolve(expected))
-      const result = await credentialProtocol.getByThreadIdConnectionIdAndRole(
-        agentContext,
-        'threadId',
-        CredentialRole.Issuer,
-        'connectionId'
-      )
+
+      const result = await credentialProtocol.getByProperties(agentContext, {
+        threadId: 'threadId',
+        role: CredentialRole.Issuer,
+        connectionId: 'connectionId',
+      })
+
       expect(credentialRepository.getSingleByQuery).toHaveBeenCalledWith(agentContext, {
         threadId: 'threadId',
         connectionId: 'connectionId',

--- a/packages/anoncreds/src/protocols/proofs/v1/V1ProofProtocol.ts
+++ b/packages/anoncreds/src/protocols/proofs/v1/V1ProofProtocol.ts
@@ -171,7 +171,12 @@ export class V1ProofProtocol extends BaseProofProtocol implements ProofProtocol<
 
     agentContext.config.logger.debug(`Processing presentation proposal with message id ${proposalMessage.id}`)
 
-    let proofRecord = await this.findByThreadAndConnectionId(agentContext, proposalMessage.threadId, connection?.id)
+    let proofRecord = await this.findByThreadIdConnectionIdAndRole(
+      agentContext,
+      proposalMessage.threadId,
+      ProofRole.Verifier,
+      connection?.id
+    )
 
     // Proof record already exists, this is a response to an earlier message sent by us
     if (proofRecord) {
@@ -422,7 +427,12 @@ export class V1ProofProtocol extends BaseProofProtocol implements ProofProtocol<
 
     agentContext.config.logger.debug(`Processing presentation request with id ${proofRequestMessage.id}`)
 
-    let proofRecord = await this.findByThreadAndConnectionId(agentContext, proofRequestMessage.threadId, connection?.id)
+    let proofRecord = await this.findByThreadIdConnectionIdAndRole(
+      agentContext,
+      proofRequestMessage.threadId,
+      ProofRole.Prover,
+      connection?.id
+    )
 
     const requestAttachment = proofRequestMessage.getRequestAttachmentById(INDY_PROOF_REQUEST_ATTACHMENT_ID)
     if (!requestAttachment) {
@@ -760,7 +770,7 @@ export class V1ProofProtocol extends BaseProofProtocol implements ProofProtocol<
     // only depends on the public api, rather than the internal API (this helps with breaking changes)
     const connectionService = agentContext.dependencyManager.resolve(ConnectionService)
 
-    const proofRecord = await this.getByThreadAndConnectionId(agentContext, presentationMessage.threadId)
+    const proofRecord = await this.getByThreadIdConnectionIdAndRole(agentContext, presentationMessage.threadId)
 
     const proposalMessage = await didCommMessageRepository.findAgentMessage(agentContext, {
       associatedRecordId: proofRecord.id,
@@ -887,9 +897,10 @@ export class V1ProofProtocol extends BaseProofProtocol implements ProofProtocol<
     // only depends on the public api, rather than the internal API (this helps with breaking changes)
     const connectionService = agentContext.dependencyManager.resolve(ConnectionService)
 
-    const proofRecord = await this.getByThreadAndConnectionId(
+    const proofRecord = await this.getByThreadIdConnectionIdAndRole(
       agentContext,
       presentationAckMessage.threadId,
+      ProofRole.Prover,
       connection?.id
     )
 
@@ -920,7 +931,7 @@ export class V1ProofProtocol extends BaseProofProtocol implements ProofProtocol<
   }
 
   public async createProblemReport(
-    agentContext: AgentContext,
+    _agentContext: AgentContext,
     { proofRecord, description }: ProofProtocolOptions.CreateProofProblemReportOptions
   ): Promise<ProofProtocolOptions.ProofProtocolMsgReturnType<ProblemReportMessage>> {
     const message = new V1PresentationProblemReportMessage({

--- a/packages/anoncreds/src/protocols/proofs/v1/V1ProofProtocol.ts
+++ b/packages/anoncreds/src/protocols/proofs/v1/V1ProofProtocol.ts
@@ -171,12 +171,11 @@ export class V1ProofProtocol extends BaseProofProtocol implements ProofProtocol<
 
     agentContext.config.logger.debug(`Processing presentation proposal with message id ${proposalMessage.id}`)
 
-    let proofRecord = await this.findByThreadIdConnectionIdAndRole(
-      agentContext,
-      proposalMessage.threadId,
-      ProofRole.Verifier,
-      connection?.id
-    )
+    let proofRecord = await this.findByProperties(agentContext, {
+      threadId: proposalMessage.threadId,
+      role: ProofRole.Verifier,
+      connectionId: connection?.id,
+    })
 
     // Proof record already exists, this is a response to an earlier message sent by us
     if (proofRecord) {
@@ -427,12 +426,11 @@ export class V1ProofProtocol extends BaseProofProtocol implements ProofProtocol<
 
     agentContext.config.logger.debug(`Processing presentation request with id ${proofRequestMessage.id}`)
 
-    let proofRecord = await this.findByThreadIdConnectionIdAndRole(
-      agentContext,
-      proofRequestMessage.threadId,
-      ProofRole.Prover,
-      connection?.id
-    )
+    let proofRecord = await this.findByProperties(agentContext, {
+      threadId: proofRequestMessage.threadId,
+      role: ProofRole.Prover,
+      connectionId: connection?.id,
+    })
 
     const requestAttachment = proofRequestMessage.getRequestAttachmentById(INDY_PROOF_REQUEST_ATTACHMENT_ID)
     if (!requestAttachment) {
@@ -770,7 +768,10 @@ export class V1ProofProtocol extends BaseProofProtocol implements ProofProtocol<
     // only depends on the public api, rather than the internal API (this helps with breaking changes)
     const connectionService = agentContext.dependencyManager.resolve(ConnectionService)
 
-    const proofRecord = await this.getByThreadIdConnectionIdAndRole(agentContext, presentationMessage.threadId)
+    const proofRecord = await this.getByProperties(agentContext, {
+      threadId: presentationMessage.threadId,
+      role: ProofRole.Verifier,
+    })
 
     const proposalMessage = await didCommMessageRepository.findAgentMessage(agentContext, {
       associatedRecordId: proofRecord.id,
@@ -897,12 +898,11 @@ export class V1ProofProtocol extends BaseProofProtocol implements ProofProtocol<
     // only depends on the public api, rather than the internal API (this helps with breaking changes)
     const connectionService = agentContext.dependencyManager.resolve(ConnectionService)
 
-    const proofRecord = await this.getByThreadIdConnectionIdAndRole(
-      agentContext,
-      presentationAckMessage.threadId,
-      ProofRole.Prover,
-      connection?.id
-    )
+    const proofRecord = await this.getByProperties(agentContext, {
+      threadId: presentationAckMessage.threadId,
+      role: ProofRole.Prover,
+      connectionId: connection?.id,
+    })
 
     const lastReceivedMessage = await didCommMessageRepository.getAgentMessage(agentContext, {
       associatedRecordId: proofRecord.id,

--- a/packages/core/src/modules/credentials/protocol/BaseCredentialProtocol.ts
+++ b/packages/core/src/modules/credentials/protocol/BaseCredentialProtocol.ts
@@ -142,12 +142,10 @@ export abstract class BaseCredentialProtocol<CFs extends CredentialFormatService
 
     agentContext.config.logger.debug(`Processing problem report with message id ${credentialProblemReportMessage.id}`)
 
-    const credentialRecord = await this.getByThreadIdConnectionIdAndRole(
-      agentContext,
-      credentialProblemReportMessage.threadId,
-      undefined,
-      connection.id
-    )
+    const credentialRecord = await this.getByProperties(agentContext, {
+      threadId: credentialProblemReportMessage.threadId,
+      connectionId: connection.id,
+    })
 
     // Update record
     credentialRecord.errorMessage = `${credentialProblemReportMessage.description.code}: ${credentialProblemReportMessage.description.en}`
@@ -276,20 +274,21 @@ export abstract class BaseCredentialProtocol<CFs extends CredentialFormatService
   /**
    * Retrieve a credential record by connection id and thread id
    *
-   * @param connectionId The connection id
-   * @param role The role of the record, i.e. holder or issuer
-   * @param threadId The thread id
+   * @param properties Properties to query by
    *
    * @throws {RecordNotFoundError} If no record is found
    * @throws {RecordDuplicateError} If multiple records are found
    * @returns The credential record
    */
-  public getByThreadIdConnectionIdAndRole(
+  public getByProperties(
     agentContext: AgentContext,
-    threadId: string,
-    role?: CredentialRole,
-    connectionId?: string
+    properties: {
+      threadId: string
+      role?: CredentialRole
+      connectionId?: string
+    }
   ): Promise<CredentialExchangeRecord> {
+    const { role, connectionId, threadId } = properties
     const credentialRepository = agentContext.dependencyManager.resolve(CredentialRepository)
 
     return credentialRepository.getSingleByQuery(agentContext, {
@@ -308,12 +307,15 @@ export abstract class BaseCredentialProtocol<CFs extends CredentialFormatService
    *
    * @returns The credential record
    */
-  public findByThreadIdConnectionIdAndRole(
+  public findByProperties(
     agentContext: AgentContext,
-    threadId: string,
-    role?: CredentialRole,
-    connectionId?: string
+    properties: {
+      threadId: string
+      role?: CredentialRole
+      connectionId?: string
+    }
   ): Promise<CredentialExchangeRecord | null> {
+    const { role, connectionId, threadId } = properties
     const credentialRepository = agentContext.dependencyManager.resolve(CredentialRepository)
 
     return credentialRepository.findSingleByQuery(agentContext, {

--- a/packages/core/src/modules/credentials/protocol/BaseCredentialProtocol.ts
+++ b/packages/core/src/modules/credentials/protocol/BaseCredentialProtocol.ts
@@ -23,6 +23,7 @@ import type { Query } from '../../../storage/StorageService'
 import type { ProblemReportMessage } from '../../problem-reports'
 import type { CredentialStateChangedEvent } from '../CredentialEvents'
 import type { CredentialFormatService, ExtractCredentialFormats } from '../formats'
+import type { CredentialRole } from '../models'
 import type { CredentialExchangeRecord } from '../repository'
 
 import { EventEmitter } from '../../../agent/EventEmitter'
@@ -141,9 +142,10 @@ export abstract class BaseCredentialProtocol<CFs extends CredentialFormatService
 
     agentContext.config.logger.debug(`Processing problem report with message id ${credentialProblemReportMessage.id}`)
 
-    const credentialRecord = await this.getByThreadAndConnectionId(
+    const credentialRecord = await this.getByThreadIdConnectionIdAndRole(
       agentContext,
       credentialProblemReportMessage.threadId,
+      undefined,
       connection.id
     )
 
@@ -275,14 +277,17 @@ export abstract class BaseCredentialProtocol<CFs extends CredentialFormatService
    * Retrieve a credential record by connection id and thread id
    *
    * @param connectionId The connection id
+   * @param role The role of the record, i.e. holder or issuer
    * @param threadId The thread id
+   *
    * @throws {RecordNotFoundError} If no record is found
    * @throws {RecordDuplicateError} If multiple records are found
    * @returns The credential record
    */
-  public getByThreadAndConnectionId(
+  public getByThreadIdConnectionIdAndRole(
     agentContext: AgentContext,
     threadId: string,
+    role?: CredentialRole,
     connectionId?: string
   ): Promise<CredentialExchangeRecord> {
     const credentialRepository = agentContext.dependencyManager.resolve(CredentialRepository)
@@ -290,19 +295,23 @@ export abstract class BaseCredentialProtocol<CFs extends CredentialFormatService
     return credentialRepository.getSingleByQuery(agentContext, {
       connectionId,
       threadId,
+      role,
     })
   }
 
   /**
    * Find a credential record by connection id and thread id, returns null if not found
    *
-   * @param connectionId The connection id
    * @param threadId The thread id
+   * @param role The role of the record, i.e. holder or issuer
+   * @param connectionId The connection id
+   *
    * @returns The credential record
    */
-  public findByThreadAndConnectionId(
+  public findByThreadIdConnectionIdAndRole(
     agentContext: AgentContext,
     threadId: string,
+    role?: CredentialRole,
     connectionId?: string
   ): Promise<CredentialExchangeRecord | null> {
     const credentialRepository = agentContext.dependencyManager.resolve(CredentialRepository)
@@ -310,6 +319,7 @@ export abstract class BaseCredentialProtocol<CFs extends CredentialFormatService
     return credentialRepository.findSingleByQuery(agentContext, {
       connectionId,
       threadId,
+      role,
     })
   }
 

--- a/packages/core/src/modules/credentials/protocol/CredentialProtocol.ts
+++ b/packages/core/src/modules/credentials/protocol/CredentialProtocol.ts
@@ -112,12 +112,12 @@ export interface CredentialProtocol<CFs extends CredentialFormatService[] = Cred
     credentialRecord: CredentialExchangeRecord,
     options?: DeleteCredentialOptions
   ): Promise<void>
-  getByThreadAndConnectionId(
+  getByThreadIdConnectionIdAndRole(
     agentContext: AgentContext,
     threadId: string,
     connectionId?: string
   ): Promise<CredentialExchangeRecord>
-  findByThreadAndConnectionId(
+  findByThreadIdConnectionIdAndRole(
     agentContext: AgentContext,
     threadId: string,
     connectionId?: string

--- a/packages/core/src/modules/credentials/protocol/CredentialProtocol.ts
+++ b/packages/core/src/modules/credentials/protocol/CredentialProtocol.ts
@@ -21,6 +21,7 @@ import type { DependencyManager } from '../../../plugins'
 import type { Query } from '../../../storage/StorageService'
 import type { ProblemReportMessage } from '../../problem-reports'
 import type { CredentialFormatService, ExtractCredentialFormats } from '../formats'
+import type { CredentialRole } from '../models'
 import type { CredentialState } from '../models/CredentialState'
 import type { CredentialExchangeRecord } from '../repository'
 
@@ -112,15 +113,21 @@ export interface CredentialProtocol<CFs extends CredentialFormatService[] = Cred
     credentialRecord: CredentialExchangeRecord,
     options?: DeleteCredentialOptions
   ): Promise<void>
-  getByThreadIdConnectionIdAndRole(
+  getByProperties(
     agentContext: AgentContext,
-    threadId: string,
-    connectionId?: string
+    properties: {
+      threadId: string
+      connectionId?: string
+      role?: CredentialRole
+    }
   ): Promise<CredentialExchangeRecord>
-  findByThreadIdConnectionIdAndRole(
+  findByProperties(
     agentContext: AgentContext,
-    threadId: string,
-    connectionId?: string
+    properties: {
+      threadId: string
+      connectionId?: string
+      role?: CredentialRole
+    }
   ): Promise<CredentialExchangeRecord | null>
   update(agentContext: AgentContext, credentialRecord: CredentialExchangeRecord): Promise<void>
 

--- a/packages/core/src/modules/credentials/protocol/v2/V2CredentialProtocol.ts
+++ b/packages/core/src/modules/credentials/protocol/v2/V2CredentialProtocol.ts
@@ -174,9 +174,10 @@ export class V2CredentialProtocol<CFs extends CredentialFormatService[] = Creden
     const didCommMessageRepository = agentContext.dependencyManager.resolve(DidCommMessageRepository)
     const connectionService = agentContext.dependencyManager.resolve(ConnectionService)
 
-    let credentialRecord = await this.findByThreadAndConnectionId(
+    let credentialRecord = await this.findByThreadIdConnectionIdAndRole(
       messageContext.agentContext,
       proposalMessage.threadId,
+      CredentialRole.Issuer,
       connection?.id
     )
 
@@ -416,9 +417,10 @@ export class V2CredentialProtocol<CFs extends CredentialFormatService[] = Creden
     const didCommMessageRepository = agentContext.dependencyManager.resolve(DidCommMessageRepository)
     const connectionService = agentContext.dependencyManager.resolve(ConnectionService)
 
-    let credentialRecord = await this.findByThreadAndConnectionId(
+    let credentialRecord = await this.findByThreadIdConnectionIdAndRole(
       messageContext.agentContext,
       offerMessage.threadId,
+      CredentialRole.Holder,
       connection?.id
     )
 
@@ -658,7 +660,11 @@ export class V2CredentialProtocol<CFs extends CredentialFormatService[] = Creden
 
     agentContext.config.logger.debug(`Processing credential request with id ${requestMessage.id}`)
 
-    let credentialRecord = await this.findByThreadAndConnectionId(messageContext.agentContext, requestMessage.threadId)
+    let credentialRecord = await this.findByThreadIdConnectionIdAndRole(
+      messageContext.agentContext,
+      requestMessage.threadId,
+      CredentialRole.Issuer
+    )
 
     const formatServices = this.getFormatServicesFromMessage(requestMessage.formats)
     if (formatServices.length === 0) {
@@ -807,9 +813,10 @@ export class V2CredentialProtocol<CFs extends CredentialFormatService[] = Creden
 
     agentContext.config.logger.debug(`Processing credential with id ${credentialMessage.id}`)
 
-    const credentialRecord = await this.getByThreadAndConnectionId(
+    const credentialRecord = await this.getByThreadIdConnectionIdAndRole(
       messageContext.agentContext,
       credentialMessage.threadId,
+      CredentialRole.Holder,
       connection?.id
     )
 
@@ -893,9 +900,10 @@ export class V2CredentialProtocol<CFs extends CredentialFormatService[] = Creden
     const didCommMessageRepository = agentContext.dependencyManager.resolve(DidCommMessageRepository)
     const connectionService = agentContext.dependencyManager.resolve(ConnectionService)
 
-    const credentialRecord = await this.getByThreadAndConnectionId(
+    const credentialRecord = await this.getByThreadIdConnectionIdAndRole(
       messageContext.agentContext,
       ackMessage.threadId,
+      CredentialRole.Issuer,
       connection?.id
     )
     credentialRecord.connectionId = connection?.id
@@ -934,7 +942,7 @@ export class V2CredentialProtocol<CFs extends CredentialFormatService[] = Creden
    *
    */
   public async createProblemReport(
-    agentContext: AgentContext,
+    _agentContext: AgentContext,
     { credentialRecord, description }: CreateCredentialProblemReportOptions
   ): Promise<CredentialProtocolMsgReturnType<ProblemReportMessage>> {
     const message = new V2CredentialProblemReportMessage({

--- a/packages/core/src/modules/credentials/protocol/v2/V2CredentialProtocol.ts
+++ b/packages/core/src/modules/credentials/protocol/v2/V2CredentialProtocol.ts
@@ -174,12 +174,11 @@ export class V2CredentialProtocol<CFs extends CredentialFormatService[] = Creden
     const didCommMessageRepository = agentContext.dependencyManager.resolve(DidCommMessageRepository)
     const connectionService = agentContext.dependencyManager.resolve(ConnectionService)
 
-    let credentialRecord = await this.findByThreadIdConnectionIdAndRole(
-      messageContext.agentContext,
-      proposalMessage.threadId,
-      CredentialRole.Issuer,
-      connection?.id
-    )
+    let credentialRecord = await this.findByProperties(messageContext.agentContext, {
+      threadId: proposalMessage.threadId,
+      role: CredentialRole.Issuer,
+      connectionId: connection?.id,
+    })
 
     const formatServices = this.getFormatServicesFromMessage(proposalMessage.formats)
     if (formatServices.length === 0) {
@@ -417,12 +416,11 @@ export class V2CredentialProtocol<CFs extends CredentialFormatService[] = Creden
     const didCommMessageRepository = agentContext.dependencyManager.resolve(DidCommMessageRepository)
     const connectionService = agentContext.dependencyManager.resolve(ConnectionService)
 
-    let credentialRecord = await this.findByThreadIdConnectionIdAndRole(
-      messageContext.agentContext,
-      offerMessage.threadId,
-      CredentialRole.Holder,
-      connection?.id
-    )
+    let credentialRecord = await this.findByProperties(messageContext.agentContext, {
+      threadId: offerMessage.threadId,
+      role: CredentialRole.Holder,
+      connectionId: connection?.id,
+    })
 
     const formatServices = this.getFormatServicesFromMessage(offerMessage.formats)
     if (formatServices.length === 0) {
@@ -660,11 +658,10 @@ export class V2CredentialProtocol<CFs extends CredentialFormatService[] = Creden
 
     agentContext.config.logger.debug(`Processing credential request with id ${requestMessage.id}`)
 
-    let credentialRecord = await this.findByThreadIdConnectionIdAndRole(
-      messageContext.agentContext,
-      requestMessage.threadId,
-      CredentialRole.Issuer
-    )
+    let credentialRecord = await this.findByProperties(messageContext.agentContext, {
+      threadId: requestMessage.threadId,
+      role: CredentialRole.Issuer,
+    })
 
     const formatServices = this.getFormatServicesFromMessage(requestMessage.formats)
     if (formatServices.length === 0) {
@@ -813,12 +810,11 @@ export class V2CredentialProtocol<CFs extends CredentialFormatService[] = Creden
 
     agentContext.config.logger.debug(`Processing credential with id ${credentialMessage.id}`)
 
-    const credentialRecord = await this.getByThreadIdConnectionIdAndRole(
-      messageContext.agentContext,
-      credentialMessage.threadId,
-      CredentialRole.Holder,
-      connection?.id
-    )
+    const credentialRecord = await this.getByProperties(messageContext.agentContext, {
+      threadId: credentialMessage.threadId,
+      role: CredentialRole.Holder,
+      connectionId: connection?.id,
+    })
 
     const requestMessage = await didCommMessageRepository.getAgentMessage(messageContext.agentContext, {
       associatedRecordId: credentialRecord.id,
@@ -900,12 +896,11 @@ export class V2CredentialProtocol<CFs extends CredentialFormatService[] = Creden
     const didCommMessageRepository = agentContext.dependencyManager.resolve(DidCommMessageRepository)
     const connectionService = agentContext.dependencyManager.resolve(ConnectionService)
 
-    const credentialRecord = await this.getByThreadIdConnectionIdAndRole(
-      messageContext.agentContext,
-      ackMessage.threadId,
-      CredentialRole.Issuer,
-      connection?.id
-    )
+    const credentialRecord = await this.getByProperties(messageContext.agentContext, {
+      threadId: ackMessage.threadId,
+      role: CredentialRole.Issuer,
+      connectionId: connection?.id,
+    })
     credentialRecord.connectionId = connection?.id
 
     const requestMessage = await didCommMessageRepository.getAgentMessage(messageContext.agentContext, {

--- a/packages/core/src/modules/credentials/protocol/v2/__tests__/V2CredentialProtocolCred.test.ts
+++ b/packages/core/src/modules/credentials/protocol/v2/__tests__/V2CredentialProtocolCred.test.ts
@@ -160,7 +160,7 @@ const didCommMessageRecord = new DidCommMessageRecord({
 })
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const getAgentMessageMock = async (agentContext: AgentContext, options: GetAgentMessageOptions<any>) => {
+const getAgentMessageMock = async (_agentContext: AgentContext, options: GetAgentMessageOptions<any>) => {
   if (options.messageClass === V2ProposeCredentialMessage) {
     return credentialProposalMessage
   }
@@ -327,7 +327,7 @@ describe('credentialProtocol', () => {
         invalidCredentialStates.map(async (state) => {
           await expect(
             credentialProtocol.acceptOffer(agentContext, { credentialRecord: mockCredentialRecord({ state }) })
-          ).rejects.toThrowError(`Credential record is in invalid state ${state}. Valid states are: ${validState}.`)
+          ).rejects.toThrow(`Credential record is in invalid state ${state}. Valid states are: ${validState}.`)
         })
       )
     })
@@ -350,6 +350,7 @@ describe('credentialProtocol', () => {
       // then
       expect(credentialRepository.findSingleByQuery).toHaveBeenNthCalledWith(1, agentContext, {
         threadId: 'somethreadid',
+        role: CredentialRole.Issuer,
       })
       expect(credentialRepository.update).toHaveBeenCalledTimes(1)
       expect(returnedCredentialRecord.state).toEqual(CredentialState.RequestReceived)
@@ -372,6 +373,7 @@ describe('credentialProtocol', () => {
       // then
       expect(credentialRepository.findSingleByQuery).toHaveBeenNthCalledWith(1, agentContext, {
         threadId: 'somethreadid',
+        role: CredentialRole.Issuer,
       })
       expect(eventListenerMock).toHaveBeenCalled()
       expect(returnedCredentialRecord.state).toEqual(CredentialState.RequestReceived)
@@ -390,7 +392,7 @@ describe('credentialProtocol', () => {
           mockFunction(credentialRepository.findSingleByQuery).mockReturnValue(
             Promise.resolve(mockCredentialRecord({ state }))
           )
-          await expect(credentialProtocol.processRequest(messageContext)).rejects.toThrowError(
+          await expect(credentialProtocol.processRequest(messageContext)).rejects.toThrow(
             `Credential record is in invalid state ${state}. Valid states are: ${validState}.`
           )
         })
@@ -587,7 +589,7 @@ describe('credentialProtocol', () => {
                 connectionId: 'b1e2f039-aa39-40be-8643-6ce2797b5190',
               }),
             })
-          ).rejects.toThrowError(`Credential record is in invalid state ${state}. Valid states are: ${validState}.`)
+          ).rejects.toThrow(`Credential record is in invalid state ${state}. Valid states are: ${validState}.`)
         })
       )
     })
@@ -614,6 +616,7 @@ describe('credentialProtocol', () => {
       expect(credentialRepository.getSingleByQuery).toHaveBeenNthCalledWith(1, agentContext, {
         threadId: 'somethreadid',
         connectionId: '123',
+        role: CredentialRole.Issuer,
       })
 
       expect(returnedCredentialRecord.state).toBe(CredentialState.Done)
@@ -693,7 +696,7 @@ describe('credentialProtocol', () => {
       const expected = mockCredentialRecord()
       mockFunction(credentialRepository.getById).mockReturnValue(Promise.resolve(expected))
       const result = await credentialProtocol.getById(agentContext, expected.id)
-      expect(credentialRepository.getById).toBeCalledWith(agentContext, expected.id)
+      expect(credentialRepository.getById).toHaveBeenCalledWith(agentContext, expected.id)
 
       expect(result).toBe(expected)
     })
@@ -701,9 +704,15 @@ describe('credentialProtocol', () => {
     it('getById should return value from credentialRepository.getSingleByQuery', async () => {
       const expected = mockCredentialRecord()
       mockFunction(credentialRepository.getSingleByQuery).mockReturnValue(Promise.resolve(expected))
-      const result = await credentialProtocol.getByThreadAndConnectionId(agentContext, 'threadId', 'connectionId')
-      expect(credentialRepository.getSingleByQuery).toBeCalledWith(agentContext, {
+      const result = await credentialProtocol.getByThreadIdConnectionIdAndRole(
+        agentContext,
+        'threadId',
+        CredentialRole.Issuer,
+        'connectionId'
+      )
+      expect(credentialRepository.getSingleByQuery).toHaveBeenCalledWith(agentContext, {
         threadId: 'threadId',
+        role: CredentialRole.Issuer,
         connectionId: 'connectionId',
       })
 
@@ -714,7 +723,7 @@ describe('credentialProtocol', () => {
       const expected = mockCredentialRecord()
       mockFunction(credentialRepository.findById).mockReturnValue(Promise.resolve(expected))
       const result = await credentialProtocol.findById(agentContext, expected.id)
-      expect(credentialRepository.findById).toBeCalledWith(agentContext, expected.id)
+      expect(credentialRepository.findById).toHaveBeenCalledWith(agentContext, expected.id)
 
       expect(result).toBe(expected)
     })
@@ -724,7 +733,7 @@ describe('credentialProtocol', () => {
 
       mockFunction(credentialRepository.getAll).mockReturnValue(Promise.resolve(expected))
       const result = await credentialProtocol.getAll(agentContext)
-      expect(credentialRepository.getAll).toBeCalledWith(agentContext)
+      expect(credentialRepository.getAll).toHaveBeenCalledWith(agentContext)
 
       expect(result).toEqual(expect.arrayContaining(expected))
     })
@@ -734,7 +743,7 @@ describe('credentialProtocol', () => {
 
       mockFunction(credentialRepository.findByQuery).mockReturnValue(Promise.resolve(expected))
       const result = await credentialProtocol.findAllByQuery(agentContext, { state: CredentialState.OfferSent })
-      expect(credentialRepository.findByQuery).toBeCalledWith(agentContext, { state: CredentialState.OfferSent })
+      expect(credentialRepository.findByQuery).toHaveBeenCalledWith(agentContext, { state: CredentialState.OfferSent })
 
       expect(result).toEqual(expect.arrayContaining(expected))
     })

--- a/packages/core/src/modules/credentials/protocol/v2/__tests__/V2CredentialProtocolCred.test.ts
+++ b/packages/core/src/modules/credentials/protocol/v2/__tests__/V2CredentialProtocolCred.test.ts
@@ -704,12 +704,13 @@ describe('credentialProtocol', () => {
     it('getById should return value from credentialRepository.getSingleByQuery', async () => {
       const expected = mockCredentialRecord()
       mockFunction(credentialRepository.getSingleByQuery).mockReturnValue(Promise.resolve(expected))
-      const result = await credentialProtocol.getByThreadIdConnectionIdAndRole(
-        agentContext,
-        'threadId',
-        CredentialRole.Issuer,
-        'connectionId'
-      )
+
+      const result = await credentialProtocol.getByProperties(agentContext, {
+        threadId: 'threadId',
+        role: CredentialRole.Issuer,
+        connectionId: 'connectionId',
+      })
+
       expect(credentialRepository.getSingleByQuery).toHaveBeenCalledWith(agentContext, {
         threadId: 'threadId',
         role: CredentialRole.Issuer,

--- a/packages/core/src/modules/proofs/protocol/BaseProofProtocol.ts
+++ b/packages/core/src/modules/proofs/protocol/BaseProofProtocol.ts
@@ -114,12 +114,10 @@ export abstract class BaseProofProtocol<PFs extends ProofFormatService[] = Proof
 
     agentContext.config.logger.debug(`Processing problem report with message id ${proofProblemReportMessage.id}`)
 
-    const proofRecord = await this.getByThreadIdConnectionIdAndRole(
-      agentContext,
-      proofProblemReportMessage.threadId,
-      undefined,
-      connection?.id
-    )
+    const proofRecord = await this.getByProperties(agentContext, {
+      threadId: proofProblemReportMessage.threadId,
+      connectionId: connection?.id,
+    })
 
     // Update record
     proofRecord.errorMessage = `${proofProblemReportMessage.description.code}: ${proofProblemReportMessage.description.en}`
@@ -236,21 +234,22 @@ export abstract class BaseProofProtocol<PFs extends ProofFormatService[] = Proof
   /**
    * Retrieve a proof record by connection id and thread id
    *
-   * @param threadId The thread id
-   * @param role The Role of the record, i.e. prover or verifier
-   * @param connectionId The connection id
+   * @param properties Properties to query by
    *
    * @throws {RecordNotFoundError} If no record is found
    * @throws {RecordDuplicateError} If multiple records are found
    *
    * @returns The proof record
    */
-  public getByThreadIdConnectionIdAndRole(
+  public getByProperties(
     agentContext: AgentContext,
-    threadId: string,
-    role?: ProofRole,
-    connectionId?: string
+    properties: {
+      threadId: string
+      role?: ProofRole
+      connectionId?: string
+    }
   ): Promise<ProofExchangeRecord> {
+    const { threadId, connectionId, role } = properties
     const proofRepository = agentContext.dependencyManager.resolve(ProofRepository)
 
     return proofRepository.getSingleByQuery(agentContext, {
@@ -263,18 +262,19 @@ export abstract class BaseProofProtocol<PFs extends ProofFormatService[] = Proof
   /**
    * Find a proof record by connection id and thread id, returns null if not found
    *
-   * @param threadId The thread id
-   * @param role The Role of the record, i.e. prover or verifier
-   * @param connectionId The connection id
+   * @param properties Properties to query by
    *
    * @returns The proof record
    */
-  public findByThreadIdConnectionIdAndRole(
+  public findByProperties(
     agentContext: AgentContext,
-    threadId: string,
-    role?: ProofRole,
-    connectionId?: string
+    properties: {
+      threadId: string
+      role?: ProofRole
+      connectionId?: string
+    }
   ): Promise<ProofExchangeRecord | null> {
+    const { role, connectionId, threadId } = properties
     const proofRepository = agentContext.dependencyManager.resolve(ProofRepository)
 
     return proofRepository.findSingleByQuery(agentContext, {

--- a/packages/core/src/modules/proofs/protocol/BaseProofProtocol.ts
+++ b/packages/core/src/modules/proofs/protocol/BaseProofProtocol.ts
@@ -25,6 +25,7 @@ import type { Query } from '../../../storage/StorageService'
 import type { ProblemReportMessage } from '../../problem-reports'
 import type { ProofStateChangedEvent } from '../ProofEvents'
 import type { ExtractProofFormats, ProofFormatService } from '../formats'
+import type { ProofRole } from '../models'
 import type { ProofExchangeRecord } from '../repository'
 
 import { EventEmitter } from '../../../agent/EventEmitter'
@@ -113,9 +114,10 @@ export abstract class BaseProofProtocol<PFs extends ProofFormatService[] = Proof
 
     agentContext.config.logger.debug(`Processing problem report with message id ${proofProblemReportMessage.id}`)
 
-    const proofRecord = await this.getByThreadAndConnectionId(
+    const proofRecord = await this.getByThreadIdConnectionIdAndRole(
       agentContext,
       proofProblemReportMessage.threadId,
+      undefined,
       connection?.id
     )
 
@@ -234,15 +236,19 @@ export abstract class BaseProofProtocol<PFs extends ProofFormatService[] = Proof
   /**
    * Retrieve a proof record by connection id and thread id
    *
-   * @param connectionId The connection id
    * @param threadId The thread id
+   * @param role The Role of the record, i.e. prover or verifier
+   * @param connectionId The connection id
+   *
    * @throws {RecordNotFoundError} If no record is found
    * @throws {RecordDuplicateError} If multiple records are found
+   *
    * @returns The proof record
    */
-  public getByThreadAndConnectionId(
+  public getByThreadIdConnectionIdAndRole(
     agentContext: AgentContext,
     threadId: string,
+    role?: ProofRole,
     connectionId?: string
   ): Promise<ProofExchangeRecord> {
     const proofRepository = agentContext.dependencyManager.resolve(ProofRepository)
@@ -250,19 +256,23 @@ export abstract class BaseProofProtocol<PFs extends ProofFormatService[] = Proof
     return proofRepository.getSingleByQuery(agentContext, {
       connectionId,
       threadId,
+      role,
     })
   }
 
   /**
    * Find a proof record by connection id and thread id, returns null if not found
    *
-   * @param connectionId The connection id
    * @param threadId The thread id
+   * @param role The Role of the record, i.e. prover or verifier
+   * @param connectionId The connection id
+   *
    * @returns The proof record
    */
-  public findByThreadAndConnectionId(
+  public findByThreadIdConnectionIdAndRole(
     agentContext: AgentContext,
     threadId: string,
+    role?: ProofRole,
     connectionId?: string
   ): Promise<ProofExchangeRecord | null> {
     const proofRepository = agentContext.dependencyManager.resolve(ProofRepository)
@@ -270,6 +280,7 @@ export abstract class BaseProofProtocol<PFs extends ProofFormatService[] = Proof
     return proofRepository.findSingleByQuery(agentContext, {
       connectionId,
       threadId,
+      role,
     })
   }
 

--- a/packages/core/src/modules/proofs/protocol/ProofProtocol.ts
+++ b/packages/core/src/modules/proofs/protocol/ProofProtocol.ts
@@ -101,12 +101,12 @@ export interface ProofProtocol<PFs extends ProofFormatService[] = ProofFormatSer
   findAllByQuery(agentContext: AgentContext, query: Query<ProofExchangeRecord>): Promise<ProofExchangeRecord[]>
   findById(agentContext: AgentContext, proofExchangeId: string): Promise<ProofExchangeRecord | null>
   delete(agentContext: AgentContext, proofRecord: ProofExchangeRecord, options?: DeleteProofOptions): Promise<void>
-  getByThreadAndConnectionId(
+  getByThreadIdConnectionIdAndRole(
     agentContext: AgentContext,
     threadId: string,
     connectionId?: string
   ): Promise<ProofExchangeRecord>
-  findByThreadAndConnectionId(
+  findByThreadIdConnectionIdAndRole(
     agentContext: AgentContext,
     threadId: string,
     connectionId?: string

--- a/packages/core/src/modules/proofs/protocol/ProofProtocol.ts
+++ b/packages/core/src/modules/proofs/protocol/ProofProtocol.ts
@@ -23,6 +23,7 @@ import type { DependencyManager } from '../../../plugins'
 import type { Query } from '../../../storage/StorageService'
 import type { ProblemReportMessage } from '../../problem-reports'
 import type { ExtractProofFormats, ProofFormatService } from '../formats'
+import type { ProofRole } from '../models'
 import type { ProofState } from '../models/ProofState'
 import type { ProofExchangeRecord } from '../repository'
 
@@ -101,15 +102,21 @@ export interface ProofProtocol<PFs extends ProofFormatService[] = ProofFormatSer
   findAllByQuery(agentContext: AgentContext, query: Query<ProofExchangeRecord>): Promise<ProofExchangeRecord[]>
   findById(agentContext: AgentContext, proofExchangeId: string): Promise<ProofExchangeRecord | null>
   delete(agentContext: AgentContext, proofRecord: ProofExchangeRecord, options?: DeleteProofOptions): Promise<void>
-  getByThreadIdConnectionIdAndRole(
+  getByProperties(
     agentContext: AgentContext,
-    threadId: string,
-    connectionId?: string
+    properties: {
+      threadId: string
+      connectionId?: string
+      role?: ProofRole
+    }
   ): Promise<ProofExchangeRecord>
-  findByThreadIdConnectionIdAndRole(
+  findByProperties(
     agentContext: AgentContext,
-    threadId: string,
-    connectionId?: string
+    properties: {
+      threadId: string
+      connectionId?: string
+      role?: ProofRole
+    }
   ): Promise<ProofExchangeRecord | null>
   update(agentContext: AgentContext, proofRecord: ProofExchangeRecord): Promise<void>
 

--- a/packages/core/src/modules/proofs/protocol/v2/V2ProofProtocol.ts
+++ b/packages/core/src/modules/proofs/protocol/v2/V2ProofProtocol.ts
@@ -162,12 +162,11 @@ export class V2ProofProtocol<PFs extends ProofFormatService[] = ProofFormatServi
     const didCommMessageRepository = agentContext.dependencyManager.resolve(DidCommMessageRepository)
     const connectionService = agentContext.dependencyManager.resolve(ConnectionService)
 
-    let proofRecord = await this.findByThreadIdConnectionIdAndRole(
-      messageContext.agentContext,
-      proposalMessage.threadId,
-      ProofRole.Verifier,
-      connection?.id
-    )
+    let proofRecord = await this.findByProperties(messageContext.agentContext, {
+      threadId: proposalMessage.threadId,
+      role: ProofRole.Verifier,
+      connectionId: connection?.id,
+    })
 
     const formatServices = this.getFormatServicesFromMessage(proposalMessage.formats)
     if (formatServices.length === 0) {
@@ -417,12 +416,11 @@ export class V2ProofProtocol<PFs extends ProofFormatService[] = ProofFormatServi
 
     agentContext.config.logger.debug(`Processing proof request with id ${requestMessage.id}`)
 
-    let proofRecord = await this.findByThreadIdConnectionIdAndRole(
-      messageContext.agentContext,
-      requestMessage.threadId,
-      ProofRole.Prover,
-      connection?.id
-    )
+    let proofRecord = await this.findByProperties(messageContext.agentContext, {
+      threadId: requestMessage.threadId,
+      role: ProofRole.Prover,
+      connectionId: connection?.id,
+    })
 
     const formatServices = this.getFormatServicesFromMessage(requestMessage.formats)
     if (formatServices.length === 0) {
@@ -676,11 +674,10 @@ export class V2ProofProtocol<PFs extends ProofFormatService[] = ProofFormatServi
 
     agentContext.config.logger.debug(`Processing presentation with id ${presentationMessage.id}`)
 
-    const proofRecord = await this.getByThreadIdConnectionIdAndRole(
-      messageContext.agentContext,
-      presentationMessage.threadId,
-      ProofRole.Verifier
-    )
+    const proofRecord = await this.getByProperties(messageContext.agentContext, {
+      threadId: presentationMessage.threadId,
+      role: ProofRole.Verifier,
+    })
 
     const lastSentMessage = await didCommMessageRepository.getAgentMessage(messageContext.agentContext, {
       associatedRecordId: proofRecord.id,
@@ -793,12 +790,11 @@ export class V2ProofProtocol<PFs extends ProofFormatService[] = ProofFormatServi
     const didCommMessageRepository = agentContext.dependencyManager.resolve(DidCommMessageRepository)
     const connectionService = agentContext.dependencyManager.resolve(ConnectionService)
 
-    const proofRecord = await this.getByThreadIdConnectionIdAndRole(
-      messageContext.agentContext,
-      ackMessage.threadId,
-      ProofRole.Prover,
-      connection?.id
-    )
+    const proofRecord = await this.getByProperties(messageContext.agentContext, {
+      threadId: ackMessage.threadId,
+      role: ProofRole.Prover,
+      connectionId: connection?.id,
+    })
     proofRecord.connectionId = connection?.id
 
     const lastReceivedMessage = await didCommMessageRepository.getAgentMessage(messageContext.agentContext, {
@@ -828,7 +824,7 @@ export class V2ProofProtocol<PFs extends ProofFormatService[] = ProofFormatServi
   }
 
   public async createProblemReport(
-    agentContext: AgentContext,
+    _agentContext: AgentContext,
     { description, proofRecord }: CreateProofProblemReportOptions
   ): Promise<ProofProtocolMsgReturnType<ProblemReportMessage>> {
     const message = new V2PresentationProblemReportMessage({

--- a/packages/core/src/modules/proofs/protocol/v2/V2ProofProtocol.ts
+++ b/packages/core/src/modules/proofs/protocol/v2/V2ProofProtocol.ts
@@ -162,9 +162,10 @@ export class V2ProofProtocol<PFs extends ProofFormatService[] = ProofFormatServi
     const didCommMessageRepository = agentContext.dependencyManager.resolve(DidCommMessageRepository)
     const connectionService = agentContext.dependencyManager.resolve(ConnectionService)
 
-    let proofRecord = await this.findByThreadAndConnectionId(
+    let proofRecord = await this.findByThreadIdConnectionIdAndRole(
       messageContext.agentContext,
       proposalMessage.threadId,
+      ProofRole.Verifier,
       connection?.id
     )
 
@@ -416,9 +417,10 @@ export class V2ProofProtocol<PFs extends ProofFormatService[] = ProofFormatServi
 
     agentContext.config.logger.debug(`Processing proof request with id ${requestMessage.id}`)
 
-    let proofRecord = await this.findByThreadAndConnectionId(
+    let proofRecord = await this.findByThreadIdConnectionIdAndRole(
       messageContext.agentContext,
       requestMessage.threadId,
+      ProofRole.Prover,
       connection?.id
     )
 
@@ -674,7 +676,11 @@ export class V2ProofProtocol<PFs extends ProofFormatService[] = ProofFormatServi
 
     agentContext.config.logger.debug(`Processing presentation with id ${presentationMessage.id}`)
 
-    const proofRecord = await this.getByThreadAndConnectionId(messageContext.agentContext, presentationMessage.threadId)
+    const proofRecord = await this.getByThreadIdConnectionIdAndRole(
+      messageContext.agentContext,
+      presentationMessage.threadId,
+      ProofRole.Verifier
+    )
 
     const lastSentMessage = await didCommMessageRepository.getAgentMessage(messageContext.agentContext, {
       associatedRecordId: proofRecord.id,
@@ -787,9 +793,10 @@ export class V2ProofProtocol<PFs extends ProofFormatService[] = ProofFormatServi
     const didCommMessageRepository = agentContext.dependencyManager.resolve(DidCommMessageRepository)
     const connectionService = agentContext.dependencyManager.resolve(ConnectionService)
 
-    const proofRecord = await this.getByThreadAndConnectionId(
+    const proofRecord = await this.getByThreadIdConnectionIdAndRole(
       messageContext.agentContext,
       ackMessage.threadId,
+      ProofRole.Prover,
       connection?.id
     )
     proofRecord.connectionId = connection?.id


### PR DESCRIPTION
- Missed in the last PR regarding issuance to self. We also have to make sure when finding the credential, or proof, exchange record, that the role is correct otherwise we will find multiple instances with the same connection id and thread id.
- Fixed some of the deprecated jest functions (just the ones I came across).