### PR TITLE
fix: stopped recvRequest from receiving outbound messages

### DIFF
--- a/packages/drpc/src/DrpcApi.ts
+++ b/packages/drpc/src/DrpcApi.ts
@@ -12,6 +12,7 @@ import {
 } from '@credo-ts/core'
 
 import { DrpcRequestHandler, DrpcResponseHandler } from './handlers'
+import { DrpcRole } from './models'
 import { DrpcService } from './services'
 
 @injectable()
@@ -109,7 +110,7 @@ export class DrpcApi {
         removeListener: () => void
       }) => {
         const request = drpcMessageRecord.request
-        if (request) {
+        if (request && drpcMessageRecord.role === DrpcRole.Server) {
           removeListener()
           resolve({
             sendResponse: async (response: DrpcResponse) => {


### PR DESCRIPTION
Previously the drpc method `recvRequest` would receive messages that had just been send by the agent. This is a quick fix to ensure the method on receives incoming requests from other agents