### PR TITLE
fix: unsubscribe from emitter after pickup completion

### DIFF
--- a/packages/core/src/modules/discover-features/DiscoverFeaturesApi.ts
+++ b/packages/core/src/modules/discover-features/DiscoverFeaturesApi.ts
@@ -8,7 +8,7 @@ import type { DiscoverFeaturesService } from './services'
 import type { Feature } from '../../agent/models'
 
 import { firstValueFrom, of, ReplaySubject, Subject } from 'rxjs'
-import { catchError, filter, map, takeUntil, timeout } from 'rxjs/operators'
+import { catchError, filter, first, map, takeUntil, timeout } from 'rxjs/operators'
 
 import { AgentContext } from '../../agent'
 import { EventEmitter } from '../../agent/EventEmitter'
@@ -120,6 +120,8 @@ export class DiscoverFeaturesApi<
           filter((e) => e.payload.connection?.id === connection.id),
           // Return disclosures
           map((e) => e.payload.disclosures),
+          // Only wait for first event that matches the criteria
+          first(),
           // If we don't have an answer in timeoutMs miliseconds (no response, not supported, etc...) error
           timeout({
             first: options.awaitDisclosuresTimeoutMs ?? 7000,

--- a/packages/core/src/modules/message-pickup/MessagePickupApi.ts
+++ b/packages/core/src/modules/message-pickup/MessagePickupApi.ts
@@ -16,7 +16,7 @@ import type { V1MessagePickupProtocol, V2MessagePickupProtocol } from './protoco
 import type { MessagePickupProtocol } from './protocol/MessagePickupProtocol'
 import type { MessagePickupRepository } from './storage/MessagePickupRepository'
 
-import { ReplaySubject, Subject, filter, firstValueFrom, takeUntil, timeout } from 'rxjs'
+import { ReplaySubject, Subject, filter, first, firstValueFrom, takeUntil, timeout } from 'rxjs'
 
 import { AgentContext } from '../../agent'
 import { EventEmitter } from '../../agent/EventEmitter'
@@ -222,7 +222,6 @@ export class MessagePickupApi<MPPs extends MessagePickupProtocol[] = [V1MessageP
     const replaySubject = new ReplaySubject(1)
 
     if (options.awaitCompletion) {
-      // Listen for response to our feature query
       this.eventEmitter
         .observable<MessagePickupCompletedEvent>(MessagePickupEventTypes.MessagePickupCompleted)
         .pipe(
@@ -230,6 +229,8 @@ export class MessagePickupApi<MPPs extends MessagePickupProtocol[] = [V1MessageP
           takeUntil(this.stop$),
           // filter by connection id
           filter((e) => e.payload.connection.id === connectionRecord.id),
+          // Only wait for first event that matches the criteria
+          first(),
           // If we don't receive all messages within timeoutMs miliseconds (no response, not supported, etc...) error
           timeout({
             first: options.awaitCompletionTimeoutMs ?? 10000,


### PR DESCRIPTION
Under React Native, when testing Message Pickup V2 live mode for long periods I found out some warnings stating that there were too many subscribers for agent event emitter. 

After inspecting a bit the code of `MessagePickupApi` I saw we forgot to add a `first()` operator so it only waits for the first `MessagePickupCompleted` event and then unsubscribes automatically. Same thing happened to `DiscoverFeaturesApi` so here I added the same thing.