### PR TITLE
fix: node-ffi-napi-compatibility

### DIFF
--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -23,9 +23,7 @@ jobs:
       - name: Setup NodeJS
         uses: actions/setup-node@v4
         with:
-          # Node 18.20 and 20.13 broke ffi-napi
-          # https://github.com/nodejs/node/issues/52240
-          node-version: 18.19
+          node-version: 18
           cache: 'yarn'
           registry-url: 'https://registry.npmjs.org/'
 
@@ -70,9 +68,7 @@ jobs:
       - name: Setup NodeJS
         uses: actions/setup-node@v4
         with:
-          # Node 18.20 and 20.13 broke ffi-napi
-          # https://github.com/nodejs/node/issues/52240
-          node-version: 18.19
+          node-version: 18
           cache: 'yarn'
           registry-url: 'https://registry.npmjs.org/'
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -77,7 +77,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [18.20.0, 20.12]
+        node-version: [18, 20]
         # Each shard runs a set of the tests
         # Make sure to UPDATE THE TEST command with the total length of
         # the shards if you change this!!
@@ -114,7 +114,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [18.20.0, 20.12]
+        node-version: [18, 20]
 
     steps:
       - name: Checkout credo

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -52,9 +52,7 @@ jobs:
       - name: Setup NodeJS
         uses: actions/setup-node@v4
         with:
-          # Node 18.20 and 20.13 broke ffi-napi
-          # https://github.com/nodejs/node/issues/52240
-          node-version: 18.19
+          node-version: 18
           cache: 'yarn'
 
       - name: Install dependencies
@@ -79,9 +77,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Node 18.20 and 20.12 broke ffi-napi
-        # https://github.com/nodejs/node/issues/52240
-        node-version: [18.19, 20.11]
+        node-version: [18, 20]
         # Each shard runs a set of the tests
         # Make sure to UPDATE THE TEST command with the total length of
         # the shards if you change this!!
@@ -180,9 +176,7 @@ jobs:
       - name: Setup NodeJS
         uses: actions/setup-node@v4
         with:
-          # Node 18.20 and 20.13 broke ffi-napi
-          # https://github.com/nodejs/node/issues/52240
-          node-version: 18.19
+          node-version: 18
           cache: 'yarn'
 
       - name: Install dependencies

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Setup NodeJS
         uses: actions/setup-node@v4
         with:
-          node-version: 18.20
+          node-version: 18
           cache: 'yarn'
 
       - name: Install dependencies
@@ -77,7 +77,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [18.20, 20.12]
+        node-version: [18.20.0, 20.12]
         # Each shard runs a set of the tests
         # Make sure to UPDATE THE TEST command with the total length of
         # the shards if you change this!!
@@ -114,7 +114,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [18.20, 20.12]
+        node-version: [18.20.0, 20.12]
 
     steps:
       - name: Checkout credo

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Setup NodeJS
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 18.20
           cache: 'yarn'
 
       - name: Install dependencies
@@ -77,7 +77,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [18, 20]
+        node-version: [18.20, 20.12]
         # Each shard runs a set of the tests
         # Make sure to UPDATE THE TEST command with the total length of
         # the shards if you change this!!
@@ -114,9 +114,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Node 18.20 and 20.12 broke ffi-napi
-        # https://github.com/nodejs/node/issues/52240
-        node-version: [18.19, 20.11]
+        node-version: [18.20, 20.12]
 
     steps:
       - name: Checkout credo

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20.11
+FROM node:21
 
 # Set working directory
 WORKDIR /www

--- a/demo-openid/package.json
+++ b/demo-openid/package.json
@@ -15,9 +15,9 @@
     "refresh": "rm -rf ./node_modules ./yarn.lock && yarn"
   },
   "dependencies": {
-    "@hyperledger/anoncreds-nodejs": "^0.2.1",
-    "@hyperledger/aries-askar-nodejs": "^0.2.0",
-    "@hyperledger/indy-vdr-nodejs": "^0.2.0",
+    "@hyperledger/anoncreds-nodejs": "^0.2.2",
+    "@hyperledger/aries-askar-nodejs": "^0.2.1",
+    "@hyperledger/indy-vdr-nodejs": "^0.2.2",
     "express": "^4.18.1",
     "inquirer": "^8.2.5"
   },

--- a/demo/package.json
+++ b/demo/package.json
@@ -14,9 +14,9 @@
     "refresh": "rm -rf ./node_modules ./yarn.lock && yarn"
   },
   "dependencies": {
-    "@hyperledger/indy-vdr-nodejs": "^0.2.0",
-    "@hyperledger/anoncreds-nodejs": "^0.2.1",
-    "@hyperledger/aries-askar-nodejs": "^0.2.0",
+    "@hyperledger/indy-vdr-nodejs": "^0.2.2",
+    "@hyperledger/anoncreds-nodejs": "^0.2.2",
+    "@hyperledger/aries-askar-nodejs": "^0.2.1",
     "inquirer": "^8.2.5"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,8 @@
     "ws": "^8.13.0"
   },
   "resolutions": {
-    "@types/node": "18.18.8"
+    "@types/node": "18.18.8",
+    "@2060.io/ffi-napi": "4.0.9"
   },
   "engines": {
     "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "next-version-bump": "ts-node ./scripts/get-next-bump.ts"
   },
   "devDependencies": {
-    "@hyperledger/aries-askar-nodejs": "^0.2.0",
+    "@hyperledger/aries-askar-nodejs": "^0.2.1",
     "@types/bn.js": "^5.1.5",
     "@types/cors": "^2.8.10",
     "@types/eslint": "^8.21.2",
@@ -65,8 +65,7 @@
     "ws": "^8.13.0"
   },
   "resolutions": {
-    "@types/node": "18.18.8",
-    "@2060.io/ffi-napi": "4.0.9"
+    "@types/node": "18.18.8"
   },
   "engines": {
     "node": ">=18"

--- a/packages/anoncreds/package.json
+++ b/packages/anoncreds/package.json
@@ -34,13 +34,13 @@
   },
   "devDependencies": {
     "@credo-ts/node": "0.5.1",
-    "@hyperledger/anoncreds-nodejs": "^0.2.1",
-    "@hyperledger/anoncreds-shared": "^0.2.1",
+    "@hyperledger/anoncreds-nodejs": "^0.2.2",
+    "@hyperledger/anoncreds-shared": "^0.2.2",
     "rimraf": "^4.4.0",
     "rxjs": "^7.8.0",
     "typescript": "~4.9.5"
   },
   "peerDependencies": {
-    "@hyperledger/anoncreds-shared": "^0.2.1"
+    "@hyperledger/anoncreds-shared": "^0.2.2"
   }
 }

--- a/packages/askar/package.json
+++ b/packages/askar/package.json
@@ -32,8 +32,8 @@
     "tsyringe": "^4.8.0"
   },
   "devDependencies": {
-    "@hyperledger/aries-askar-nodejs": "^0.2.0",
-    "@hyperledger/aries-askar-shared": "^0.2.0",
+    "@hyperledger/aries-askar-nodejs": "^0.2.1",
+    "@hyperledger/aries-askar-shared": "^0.2.1",
     "@types/bn.js": "^5.1.0",
     "@types/ref-array-di": "^1.2.6",
     "@types/ref-struct-di": "^1.1.10",
@@ -42,6 +42,6 @@
     "typescript": "~4.9.5"
   },
   "peerDependencies": {
-    "@hyperledger/aries-askar-shared": "^0.2.0"
+    "@hyperledger/aries-askar-shared": "^0.2.1"
   }
 }

--- a/packages/indy-sdk-to-askar-migration/package.json
+++ b/packages/indy-sdk-to-askar-migration/package.json
@@ -30,12 +30,12 @@
     "@credo-ts/node": "0.5.1"
   },
   "devDependencies": {
-    "@hyperledger/aries-askar-nodejs": "^0.2.0",
-    "@hyperledger/aries-askar-shared": "^0.2.0",
+    "@hyperledger/aries-askar-nodejs": "^0.2.1",
+    "@hyperledger/aries-askar-shared": "^0.2.1",
     "rimraf": "^4.4.0",
     "typescript": "~4.9.5"
   },
   "peerDependencies": {
-    "@hyperledger/aries-askar-shared": "^0.2.0"
+    "@hyperledger/aries-askar-shared": "^0.2.1"
   }
 }

--- a/packages/indy-vdr/package.json
+++ b/packages/indy-vdr/package.json
@@ -28,8 +28,8 @@
     "@credo-ts/core": "0.5.1"
   },
   "devDependencies": {
-    "@hyperledger/indy-vdr-nodejs": "^0.2.0",
-    "@hyperledger/indy-vdr-shared": "^0.2.0",
+    "@hyperledger/indy-vdr-nodejs": "^0.2.2",
+    "@hyperledger/indy-vdr-shared": "^0.2.2",
     "@stablelib/ed25519": "^1.0.2",
     "@types/ref-array-di": "^1.2.6",
     "@types/ref-struct-di": "^1.1.10",
@@ -38,6 +38,6 @@
     "typescript": "~4.9.5"
   },
   "peerDependencies": {
-    "@hyperledger/indy-vdr-shared": "^0.2.0"
+    "@hyperledger/indy-vdr-shared": "^0.2.2"
   }
 }

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -24,7 +24,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@2060.io/ffi-napi": "^4.0.8",
+    "@2060.io/ffi-napi": "^4.0.9",
     "@2060.io/ref-napi": "^3.0.6",
     "@credo-ts/core": "0.5.1",
     "@types/express": "^4.17.15",

--- a/samples/extension-module/package.json
+++ b/samples/extension-module/package.json
@@ -24,6 +24,6 @@
     "@credo-ts/askar": "*",
     "class-validator": "0.14.1",
     "rxjs": "^7.8.0",
-    "@hyperledger/aries-askar-nodejs": "^0.2.0"
+    "@hyperledger/aries-askar-nodejs": "^0.2.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@2060.io/ffi-napi@4.0.8", "@2060.io/ffi-napi@^4.0.8":
-  version "4.0.8"
-  resolved "https://registry.yarnpkg.com/@2060.io/ffi-napi/-/ffi-napi-4.0.8.tgz#ec3424d9ec979491b41b8d82514ae82a647da8b0"
-  integrity sha512-sONRKLtxFKN5PXuZaa41b/kTN+R5qAh6PAL15/fnafnvAKQ5WBoxRIy8xRh8jo9mydywtt4IrWtatB93w0+3cA==
+"@2060.io/ffi-napi@4.0.8", "@2060.io/ffi-napi@4.0.9", "@2060.io/ffi-napi@^4.0.9":
+  version "4.0.9"
+  resolved "https://registry.yarnpkg.com/@2060.io/ffi-napi/-/ffi-napi-4.0.9.tgz#194fca2132932ba02e62d716c786d20169b20b8d"
+  integrity sha512-JfVREbtkJhMXSUpya3JCzDumdjeZDCKv4PemiWK+pts5CYgdoMidxeySVlFeF5pHqbBpox4I0Be7sDwAq4N0VQ==
   dependencies:
     "@2060.io/ref-napi" "^3.0.6"
     debug "^4.1.1"
@@ -10934,16 +10934,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -11017,7 +11008,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -11030,13 +11021,6 @@ strip-ansi@^5.0.0, strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -11957,7 +11941,7 @@ wordwrapjs@^4.0.0:
     reduce-flatten "^2.0.0"
     typical "^5.2.0"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -11970,15 +11954,6 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-"@2060.io/ffi-napi@4.0.8", "@2060.io/ffi-napi@4.0.9", "@2060.io/ffi-napi@^4.0.9":
+"@2060.io/ffi-napi@^4.0.9":
   version "4.0.9"
   resolved "https://registry.yarnpkg.com/@2060.io/ffi-napi/-/ffi-napi-4.0.9.tgz#194fca2132932ba02e62d716c786d20169b20b8d"
   integrity sha512-JfVREbtkJhMXSUpya3JCzDumdjeZDCKv4PemiWK+pts5CYgdoMidxeySVlFeF5pHqbBpox4I0Be7sDwAq4N0VQ==
@@ -14,7 +14,7 @@
     node-gyp-build "^4.2.1"
     ref-struct-di "^1.1.0"
 
-"@2060.io/ref-napi@3.0.6", "@2060.io/ref-napi@^3.0.6":
+"@2060.io/ref-napi@^3.0.6":
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/@2060.io/ref-napi/-/ref-napi-3.0.6.tgz#32b1a257cada096f95345fd7abae746385ecc5dd"
   integrity sha512-8VAIXLdKL85E85jRYpPcZqATBL6fGnC/XjBGNeSgRSMJtrAMSmfRksqIq5AmuZkA2eeJXMWCiN6UQOUdozcymg==
@@ -1203,59 +1203,59 @@
   resolved "https://registry.yarnpkg.com/@hutson/parse-repository-url/-/parse-repository-url-3.0.2.tgz#98c23c950a3d9b6c8f0daed06da6c3af06981340"
   integrity sha512-H9XAx3hc0BQHY6l+IFSWHDySypcXsvsuLhgYLUGywmJ5pswRVQJUHpOsobnLYp2ZUaUlKiKDrgWWhosOwAEM8Q==
 
-"@hyperledger/anoncreds-nodejs@^0.2.1":
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/@hyperledger/anoncreds-nodejs/-/anoncreds-nodejs-0.2.1.tgz#7dbde3e878758371e4d44542daa7f54ecf48f38e"
-  integrity sha512-wfQEVSqYHq6mQFTLRMVayyi8kbHlz3RGEIe10JOQSHCw4ZCTifQ1XuVajSwOj8ykNYwxuckcfNikJtJScs7l+w==
+"@hyperledger/anoncreds-nodejs@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@hyperledger/anoncreds-nodejs/-/anoncreds-nodejs-0.2.2.tgz#5344427c554fc7280efe22f2061e3a26023fdd84"
+  integrity sha512-qRMSSyERwjAVCPlHjCAY3OJno4DNIJ0uLi+g6ek7HrFVich3X6Kzr0ng/MSiDKmTBXyGiip1zDIBABA8y3yNGg==
   dependencies:
-    "@2060.io/ffi-napi" "4.0.8"
-    "@2060.io/ref-napi" "3.0.6"
-    "@hyperledger/anoncreds-shared" "0.2.1"
+    "@2060.io/ffi-napi" "^4.0.9"
+    "@2060.io/ref-napi" "^3.0.6"
+    "@hyperledger/anoncreds-shared" "0.2.2"
     "@mapbox/node-pre-gyp" "^1.0.11"
     ref-array-di "1.2.2"
     ref-struct-di "1.1.1"
 
-"@hyperledger/anoncreds-shared@0.2.1", "@hyperledger/anoncreds-shared@^0.2.1":
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/@hyperledger/anoncreds-shared/-/anoncreds-shared-0.2.1.tgz#7a8be78473e8cdd33b73ccdf2e9b838226aef0f9"
-  integrity sha512-QpkmsiDBto4B3MS7+tJKn8DHCuhaZuzPKy+SoSAIH8wrjBmQ4NQqzMBZXs0z0JnNr1egkIFR3HIFsIu9ayK20g==
+"@hyperledger/anoncreds-shared@0.2.2", "@hyperledger/anoncreds-shared@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@hyperledger/anoncreds-shared/-/anoncreds-shared-0.2.2.tgz#492995d076448d682a828312bbba58314e943c4a"
+  integrity sha512-dfYpqbAkqtHJkRkuGmWdJruHfLegLUIbu/dSAWnz5dMRKd8ad8rEnQkwRnockQZ/pc7QDr8kxfG6bT2YDGZeMw==
 
-"@hyperledger/aries-askar-nodejs@^0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@hyperledger/aries-askar-nodejs/-/aries-askar-nodejs-0.2.0.tgz#7a0b469184f0682d0e31955e29d091956f662273"
-  integrity sha512-d73D2zK1f1cM5y8MFp4BK+NvkquujDlRr91THpxkuRwmLf407gibOY3G4OdGIkL1kQtorGM5c5U0/qMzW+8E1Q==
+"@hyperledger/aries-askar-nodejs@^0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@hyperledger/aries-askar-nodejs/-/aries-askar-nodejs-0.2.1.tgz#3473786a4d758ebf39a6b855386a9fa3577033d5"
+  integrity sha512-RSBa+onshUSIJlVyGBzndZtcw2KPb8mgnYIio9z0RquKgGitufc0ymNiL2kLKWNjk2gET20jAUHijhlE4ssk5A==
   dependencies:
-    "@2060.io/ffi-napi" "4.0.8"
-    "@2060.io/ref-napi" "3.0.6"
-    "@hyperledger/aries-askar-shared" "0.2.0"
+    "@2060.io/ffi-napi" "^4.0.9"
+    "@2060.io/ref-napi" "^3.0.6"
+    "@hyperledger/aries-askar-shared" "0.2.1"
     "@mapbox/node-pre-gyp" "^1.0.10"
     node-cache "^5.1.2"
     ref-array-di "^1.2.2"
     ref-struct-di "^1.1.1"
 
-"@hyperledger/aries-askar-shared@0.2.0", "@hyperledger/aries-askar-shared@^0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@hyperledger/aries-askar-shared/-/aries-askar-shared-0.2.0.tgz#9291733f8fa1e3039dfe36e1fabca1819b93bd1b"
-  integrity sha512-A6bHbTwTtV1YT3XphNFltX34DCBtj7qPyip4R+WAQFnus5286a2xsppNvl5OAPMAxgKjQTdyFBqcYaNRc0lqIQ==
+"@hyperledger/aries-askar-shared@0.2.1", "@hyperledger/aries-askar-shared@^0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@hyperledger/aries-askar-shared/-/aries-askar-shared-0.2.1.tgz#0c01abe47fd53dd1629ee41af51c9d9d42f7f86f"
+  integrity sha512-7d8tiqq27dxFl7+0Cf2I40IzzDoRU9aEolyPyvfdLGbco6NAtWB4CV8AzgY11EZ7/ou4RirJxfP9hBjgYBo1Ag==
   dependencies:
     buffer "^6.0.3"
 
-"@hyperledger/indy-vdr-nodejs@^0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@hyperledger/indy-vdr-nodejs/-/indy-vdr-nodejs-0.2.0.tgz#c5fd2c211d5a2b2a0637efa6b9636b208d919c06"
-  integrity sha512-yv+p0mU9NBUgmUDJijNgxtLonhzhDP54wRl4Mfn/s/ZyzLbEQakswmqa2sX0mYQDTLG14iq5uEN6d0eRzUtDeg==
+"@hyperledger/indy-vdr-nodejs@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@hyperledger/indy-vdr-nodejs/-/indy-vdr-nodejs-0.2.2.tgz#f1f5ed1b9c34103703882dbc6c10fe480d33b0e6"
+  integrity sha512-mc0iKuHCtKuOV0sMnGOTVWnQrpfBMS+1tIRyob+CvGCvwC2llGo3Hu5AvgPcR9nqCo/wJ0LoKBo66dYYb0uZbw==
   dependencies:
-    "@2060.io/ffi-napi" "4.0.8"
-    "@2060.io/ref-napi" "3.0.6"
-    "@hyperledger/indy-vdr-shared" "0.2.0"
+    "@2060.io/ffi-napi" "^4.0.9"
+    "@2060.io/ref-napi" "^3.0.6"
+    "@hyperledger/indy-vdr-shared" "0.2.2"
     "@mapbox/node-pre-gyp" "^1.0.10"
     ref-array-di "^1.2.2"
     ref-struct-di "^1.1.1"
 
-"@hyperledger/indy-vdr-shared@0.2.0", "@hyperledger/indy-vdr-shared@^0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@hyperledger/indy-vdr-shared/-/indy-vdr-shared-0.2.0.tgz#4781e38bffe69366e694e8d025a8d017b8a1cb5b"
-  integrity sha512-/aPzpzb6Wks7poRSercSp6f3mFOBoQmxSIyo50XO6ci/Jfa4ZGuV8y8YWU2SJktsdz4TtL5YJxt2WVfOus9bEQ==
+"@hyperledger/indy-vdr-shared@0.2.2", "@hyperledger/indy-vdr-shared@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@hyperledger/indy-vdr-shared/-/indy-vdr-shared-0.2.2.tgz#9ca8b56cd89ab18792d129a0358b641e211274e3"
+  integrity sha512-9425MHU3K+/ahccCRjOIX3Z/51gqxvp3Nmyujyqlx9cd7PWG2Rianx7iNWecFBkdAEqS0DfHsb6YqqH39YZp/A==
 
 "@isaacs/cliui@^8.0.2":
   version "8.0.2"


### PR DESCRIPTION
Trying to re-gain compatibliity with latest node versions (18.20, 20.12, 21.6) by using a patched version of `@2060.io/ffi-napi`. The issue was caused by an experimental feature in N-API (see [this commit](https://github.com/nodejs/node/commit/7a216d5fd6331c98c117ef471d0c971c8d97f757)), which was enabled when compiling ffi-napi because it had `NAPI_EXPERIMENTAL` flag set (originally this was needed until the release of [node 12.17](https://github.com/node-ffi-napi/node-ffi-napi/blob/1e7bbb170462f5f0880350cc4a518a2755b9337f/src/ffi.cc#L2), but the flag wasn't removed since the repo was not being maintained after that).

Given that `@hyperledger/aries-askar-nodejs`, `@hyperledger/indy-vdr-nodejs` and `@hyperledger/anoncreds` had pinned previous version of ffi-napi, I think we'll need to do a new minor release of those modules before merging this, since at the moment we need to pin this new version in `resolutions`.