### PR TITLE
fix: access token can only be used for offer

### DIFF
--- a/packages/openid4vc/src/openid4vc-issuer/router/accessTokenEndpoint.ts
+++ b/packages/openid4vc/src/openid4vc-issuer/router/accessTokenEndpoint.ts
@@ -5,7 +5,6 @@ import type { NextFunction, Response, Router } from 'express'
 
 import { getJwkFromKey, CredoError, JwsService, JwtPayload, getJwkClassFromKeyType, Key } from '@credo-ts/core'
 import {
-  PRE_AUTH_CODE_LITERAL,
   GrantTypes,
   PRE_AUTHORIZED_CODE_REQUIRED_ERROR,
   TokenError,
@@ -118,17 +117,6 @@ export function handleTokenRequest(config: OpenId4VciAccessTokenEndpointConfig) 
     const openId4VcIssuerService = agentContext.dependencyManager.resolve(OpenId4VcIssuerService)
     const issuerMetadata = openId4VcIssuerService.getIssuerMetadata(agentContext, issuer)
     const accessTokenSigningKey = Key.fromFingerprint(issuer.accessTokenPublicKeyFingerprint)
-
-    const preAuthorizedCode = body[PRE_AUTH_CODE_LITERAL] as string | undefined
-    if (!preAuthorizedCode) {
-      return sendErrorResponse(
-        response,
-        agentContext.config.logger,
-        400,
-        TokenErrorResponse.invalid_request,
-        'Pre-authorized code is required'
-      )
-    }
 
     try {
       const accessTokenResponse = await createAccessTokenResponse(request.body, {

--- a/packages/openid4vc/src/openid4vc-issuer/router/verifyAccessToken.ts
+++ b/packages/openid4vc/src/openid4vc-issuer/router/verifyAccessToken.ts
@@ -2,7 +2,6 @@ import type { OpenId4VcIssuerRecord } from '../repository'
 import type { AgentContext } from '@credo-ts/core'
 
 import { CredoError, JwsService, Jwt } from '@credo-ts/core'
-import { PRE_AUTH_CODE_LITERAL } from '@sphereon/oid4vci-common'
 
 import { OpenId4VcIssuerService } from '../OpenId4VcIssuerService'
 
@@ -43,11 +42,11 @@ export async function verifyAccessToken(
     throw new CredoError('Access token was not issued by the expected issuer')
   }
 
-  if (typeof accessToken.payload.additionalClaims[PRE_AUTH_CODE_LITERAL] !== 'string') {
-    throw new CredoError('No pre-authorized code present in access token')
+  if (typeof accessToken.payload.additionalClaims.preAuthorizedCode !== 'string') {
+    throw new CredoError('No preAuthorizedCode present in access token')
   }
 
   return {
-    preAuthorizedCode: accessToken.payload.additionalClaims[PRE_AUTH_CODE_LITERAL],
+    preAuthorizedCode: accessToken.payload.additionalClaims.preAuthorizedCode,
   }
 }

--- a/packages/openid4vc/src/openid4vc-issuer/router/verifyAccessToken.ts
+++ b/packages/openid4vc/src/openid4vc-issuer/router/verifyAccessToken.ts
@@ -2,6 +2,7 @@ import type { OpenId4VcIssuerRecord } from '../repository'
 import type { AgentContext } from '@credo-ts/core'
 
 import { CredoError, JwsService, Jwt } from '@credo-ts/core'
+import { PRE_AUTH_CODE_LITERAL } from '@sphereon/oid4vci-common'
 
 import { OpenId4VcIssuerService } from '../OpenId4VcIssuerService'
 
@@ -40,5 +41,13 @@ export async function verifyAccessToken(
 
   if (accessToken.payload.iss !== issuerMetadata.issuerUrl) {
     throw new CredoError('Access token was not issued by the expected issuer')
+  }
+
+  if (typeof accessToken.payload.additionalClaims[PRE_AUTH_CODE_LITERAL] !== 'string') {
+    throw new CredoError('No pre-authorized code present in access token')
+  }
+
+  return {
+    preAuthorizedCode: accessToken.payload.additionalClaims[PRE_AUTH_CODE_LITERAL],
   }
 }


### PR DESCRIPTION
Ensures that the access token can only be used for the issuance session it was created for, and not for other issuance sessions. This is recommend according to OID4VCI spec.