### PR TITLE
feat(tenants): return value from withTenatnAgent

### DIFF
--- a/packages/tenants/src/TenantsApi.ts
+++ b/packages/tenants/src/TenantsApi.ts
@@ -52,16 +52,17 @@ export class TenantsApi<AgentModules extends ModulesMap = DefaultAgentModules> {
     return tenantAgent
   }
 
-  public async withTenantAgent(
+  public async withTenantAgent<ReturnValue>(
     options: GetTenantAgentOptions,
-    withTenantAgentCallback: WithTenantAgentCallback<AgentModules>
-  ): Promise<void> {
+    withTenantAgentCallback: WithTenantAgentCallback<AgentModules, ReturnValue>
+  ): Promise<ReturnValue> {
     this.logger.debug(`Getting tenant agent for tenant '${options.tenantId}' in with tenant agent callback`)
     const tenantAgent = await this.getTenantAgent(options)
 
     try {
       this.logger.debug(`Calling tenant agent callback for tenant '${options.tenantId}'`)
-      await withTenantAgentCallback(tenantAgent)
+      const result = await withTenantAgentCallback(tenantAgent)
+      return result
     } catch (error) {
       this.logger.error(`Error in tenant agent callback for tenant '${options.tenantId}'`, { error })
       throw error

--- a/packages/tenants/src/TenantsApiOptions.ts
+++ b/packages/tenants/src/TenantsApiOptions.ts
@@ -6,9 +6,9 @@ export interface GetTenantAgentOptions {
   tenantId: string
 }
 
-export type WithTenantAgentCallback<AgentModules extends ModulesMap> = (
+export type WithTenantAgentCallback<AgentModules extends ModulesMap, Return> = (
   tenantAgent: TenantAgent<AgentModules>
-) => Promise<void>
+) => Promise<Return>
 
 export interface CreateTenantOptions {
   config: Omit<TenantConfig, 'walletConfig'>

--- a/packages/tenants/tests/tenants.test.ts
+++ b/packages/tenants/tests/tenants.test.ts
@@ -125,6 +125,22 @@ describe('Tenants E2E', () => {
     )
   })
 
+  test('withTenantAgent returns value from callback', async () => {
+    const tenantRecord = await agent1.modules.tenants.createTenant({
+      config: {
+        label: 'Tenant 2',
+      },
+    })
+
+    const result = await agent1.modules.tenants.withTenantAgent({ tenantId: tenantRecord.id }, async () => {
+      return {
+        hello: 'world',
+      }
+    })
+
+    expect(result).toEqual({ hello: 'world' })
+  })
+
   test('create a connection between two tenants within the same agent', async () => {
     // Create tenants
     const tenantRecord1 = await agent1.modules.tenants.createTenant({


### PR DESCRIPTION
Has been boterhing me a lot, as it makes the function a lot more complex to use and thus I used `getTenantAgent`, but this way it's easer to use `withTenantAgent,` which always makes sure the session is closed