### PR TITLE
fix(anoncreds): unqualified revocation registry processing

### DIFF
--- a/packages/anoncreds/src/utils/indyIdentifiers.ts
+++ b/packages/anoncreds/src/utils/indyIdentifiers.ts
@@ -262,8 +262,9 @@ export function getQualifiedDidIndyDid(identifier: string, namespace: string): s
     const credentialDefinitionId = `did:indy:${namespace}:${namespaceIdentifier}/anoncreds/v0/CLAIM_DEF/${schemaSeqNo}/${tag}`
     return credentialDefinitionId
   } else if (isUnqualifiedRevocationRegistryId(identifier)) {
-    const { namespaceIdentifier, schemaSeqNo, revocationRegistryTag } = parseIndyRevocationRegistryId(identifier)
-    const revocationRegistryId = `did:indy:${namespace}:${namespaceIdentifier}/anoncreds/v0/REV_REG_DEF/${schemaSeqNo}/${revocationRegistryTag}`
+    const { namespaceIdentifier, schemaSeqNo, credentialDefinitionTag, revocationRegistryTag } =
+      parseIndyRevocationRegistryId(identifier)
+    const revocationRegistryId = `did:indy:${namespace}:${namespaceIdentifier}/anoncreds/v0/REV_REG_DEF/${schemaSeqNo}/${credentialDefinitionTag}/${revocationRegistryTag}`
     return revocationRegistryId
   } else if (isUnqualifiedIndyDid(identifier)) {
     return `did:indy:${namespace}:${identifier}`

--- a/packages/anoncreds/src/utils/w3cAnonCredsUtils.ts
+++ b/packages/anoncreds/src/utils/w3cAnonCredsUtils.ts
@@ -3,7 +3,7 @@ import type { W3cAnonCredsCredentialMetadata } from './metadata'
 import type { AnonCredsCredentialInfo, AnonCredsSchema } from '../models'
 import type { AnonCredsCredentialRecord } from '../repository'
 import type { StoreCredentialOptions } from '../services'
-import type { DefaultW3cCredentialTags } from '@credo-ts/core'
+import type { DefaultW3cCredentialTags, W3cCredentialSubject } from '@credo-ts/core'
 
 import { CredoError, W3cCredentialRecord, utils } from '@credo-ts/core'
 
@@ -163,7 +163,8 @@ export function getStoreCredentialOptions(
 }
 
 export function getW3cRecordAnonCredsTags(options: {
-  w3cCredentialRecord: W3cCredentialRecord
+  credentialSubject: W3cCredentialSubject
+  issuerId: string
   schemaId: string
   schema: Omit<AnonCredsSchema, 'attrNames'>
   credentialDefinitionId: string
@@ -173,7 +174,8 @@ export function getW3cRecordAnonCredsTags(options: {
   methodName: string
 }) {
   const {
-    w3cCredentialRecord,
+    credentialSubject,
+    issuerId,
     schema,
     schemaId,
     credentialDefinitionId,
@@ -182,8 +184,6 @@ export function getW3cRecordAnonCredsTags(options: {
     linkSecretId,
     methodName,
   } = options
-
-  const issuerId = w3cCredentialRecord.credential.issuerId
 
   const anonCredsCredentialRecordTags: AnonCredsCredentialTags = {
     anonCredsLinkSecretId: linkSecretId,
@@ -206,12 +206,8 @@ export function getW3cRecordAnonCredsTags(options: {
     }),
   }
 
-  if (Array.isArray(w3cCredentialRecord.credential.credentialSubject)) {
-    throw new CredoError('Credential subject must be an object, not an array.')
-  }
-
   const values = mapAttributeRawValuesToAnonCredsCredentialValues(
-    (w3cCredentialRecord.credential.credentialSubject.claims as AnonCredsClaimRecord) ?? {}
+    (credentialSubject.claims as AnonCredsClaimRecord) ?? {}
   )
 
   for (const [key, value] of Object.entries(values)) {


### PR DESCRIPTION
I ran into issues issues while receiving legacy Indy credentials with revocation support, e.g. receiving the following error when using [BC Digital Trust Showcase](https://digital.gov.bc.ca/digital-trust/showcase/dashboard):

> CredoError: QEquAHkM35w4XVT3Ku5yat:4:QEquAHkM35w4XVT3Ku5yat:3:CL:567943:student_card:CL_ACCUM:dd6cecd9-a71b-4af4-a8f6-26a3fee2e073 is not a valid did:indy did\n    at parseIndyDid at getUnQualifiedDidIndyDid at getW3cRecordAnonCredsTags


I found that record metadata was populated with `revocationRegistryId` from the W3C credential object, which in this case would be an unqualified identifier. As `getUnQualifiedDidIndyDid` expected a qualified identifier, this fails. In addition, the utility method `getQualifiedDidIndyDid` was not taking into account credentialDefinitionTag while generating the identifier, resulting also in an error.

In this PR this is fixed by explicitly specifying the `revocationRegistryId` when calling `AnonCredsRsHolderService.storeW3cCredential` rather than taking it from the W3C credential. I'm not sure if this is the most elegant solution though, so any suggestion on that will be more than appreciated.

Another a bit controversial thing I changed here is to delay the `w3cCredentialService.storeCredential()` call to the last minute, in order to prevent any possible error to be thrown that could leave a `W3cCredentialRecord` without tags and metadata.