### PR TITLE
feat: add disclosures so you know which fields are disclosed

### DIFF
--- a/packages/core/src/modules/dif-presentation-exchange/DifPresentationExchangeService.ts
+++ b/packages/core/src/modules/dif-presentation-exchange/DifPresentationExchangeService.ts
@@ -93,7 +93,7 @@ export class DifPresentationExchangeService {
         }
 
         // We pick the first matching VC if we are auto-selecting
-        credentials[submission.inputDescriptorId].push(submission.verifiableCredentials[0])
+        credentials[submission.inputDescriptorId].push(submission.verifiableCredentials[0].credentialRecord)
       }
     }
 

--- a/packages/core/src/modules/dif-presentation-exchange/models/DifPexCredentialsForRequest.ts
+++ b/packages/core/src/modules/dif-presentation-exchange/models/DifPexCredentialsForRequest.ts
@@ -1,5 +1,5 @@
 import type { SdJwtVcRecord } from '../../sd-jwt-vc'
-import type { W3cCredentialRecord } from '../../vc'
+import type { ClaimFormat, W3cCredentialRecord } from '../../vc'
 
 export interface DifPexCredentialsForRequest {
   /**
@@ -111,8 +111,24 @@ export interface DifPexCredentialsForRequestSubmissionEntry {
    * If the value is an empty list, it means the input descriptor could
    * not be satisfied.
    */
-  verifiableCredentials: Array<W3cCredentialRecord | SdJwtVcRecord>
+  verifiableCredentials: SubmissionEntryCredential[]
 }
+
+export type SubmissionEntryCredential =
+  | {
+      type: ClaimFormat.SdJwtVc
+      credentialRecord: SdJwtVcRecord
+
+      /**
+       * The payload that will be disclosed, including always disclosed attributes
+       * and disclosures for the presentation definition
+       */
+      disclosedPayload: Record<string, unknown>
+    }
+  | {
+      type: ClaimFormat.JwtVc | ClaimFormat.LdpVc
+      credentialRecord: W3cCredentialRecord
+    }
 
 /**
  * Mapping of selected credentials for an input descriptor

--- a/packages/openid4vc/tests/openid4vc.e2e.test.ts
+++ b/packages/openid4vc/tests/openid4vc.e2e.test.ts
@@ -418,8 +418,11 @@ describe('OpenId4Vc', () => {
             {
               verifiableCredentials: [
                 {
-                  credential: {
-                    type: ['VerifiableCredential', 'OpenBadgeCredential'],
+                  type: ClaimFormat.JwtVc,
+                  credentialRecord: {
+                    credential: {
+                      type: ['VerifiableCredential', 'OpenBadgeCredential'],
+                    },
                   },
                 },
               ],
@@ -441,8 +444,11 @@ describe('OpenId4Vc', () => {
             {
               verifiableCredentials: [
                 {
-                  credential: {
-                    type: ['VerifiableCredential', 'UniversityDegreeCredential'],
+                  type: ClaimFormat.JwtVc,
+                  credentialRecord: {
+                    credential: {
+                      type: ['VerifiableCredential', 'UniversityDegreeCredential'],
+                    },
                   },
                 },
               ],
@@ -659,17 +665,37 @@ describe('OpenId4Vc', () => {
       authorizationRequest
     )
 
-    expect(resolvedAuthorizationRequest.presentationExchange?.credentialsForRequest).toMatchObject({
+    expect(resolvedAuthorizationRequest.presentationExchange?.credentialsForRequest).toEqual({
       areRequirementsSatisfied: true,
+      name: undefined,
+      purpose: undefined,
       requirements: [
         {
+          isRequirementSatisfied: true,
+          needsCount: 1,
+          rule: 'pick',
           submissionEntry: [
             {
+              name: undefined,
+              purpose: undefined,
+              inputDescriptorId: 'OpenBadgeCredentialDescriptor',
               verifiableCredentials: [
                 {
-                  // FIXME: because we have the record, we don't know which fields will be disclosed
-                  // Can we temp-assign these to the record?
-                  compactSdJwtVc: signedSdJwtVc.compact,
+                  type: ClaimFormat.SdJwtVc,
+                  credentialRecord: expect.objectContaining({
+                    compactSdJwtVc: signedSdJwtVc.compact,
+                  }),
+                  // Name is NOT in here
+                  disclosedPayload: {
+                    cnf: {
+                      kid: 'did:key:z6MkpGR4gs4Rc3Zph4vj8wRnjnAxgAPSxcR8MAVKutWspQzc#z6MkpGR4gs4Rc3Zph4vj8wRnjnAxgAPSxcR8MAVKutWspQzc',
+                    },
+                    degree: 'bachelor',
+                    iat: expect.any(Number),
+                    iss: 'did:key:z6MkrzQPBr4pyqC776KKtrz13SchM5ePPbssuPuQZb5t4uKQ',
+                    university: 'innsbruck',
+                    vct: 'OpenBadgeCredential',
+                  },
                 },
               ],
             },
@@ -747,19 +773,46 @@ describe('OpenId4Vc', () => {
     expect(presentation.payload).not.toHaveProperty('university')
     expect(presentation.payload).not.toHaveProperty('name')
 
-    expect(presentationExchange).toMatchObject({
+    expect(presentationExchange).toEqual({
       definition: presentationDefinition,
       submission: {
         definition_id: 'OpenBadgeCredential',
+        descriptor_map: [
+          {
+            format: 'vc+sd-jwt',
+            id: 'OpenBadgeCredentialDescriptor',
+            path: '$',
+          },
+        ],
+        id: expect.any(String),
       },
       presentations: [
         {
+          compact: expect.any(String),
+          header: {
+            alg: 'EdDSA',
+            kid: '#z6MkrzQPBr4pyqC776KKtrz13SchM5ePPbssuPuQZb5t4uKQ',
+            typ: 'vc+sd-jwt',
+          },
           payload: {
+            _sd: [expect.any(String), expect.any(String)],
+            _sd_alg: 'sha-256',
+            cnf: {
+              kid: 'did:key:z6MkpGR4gs4Rc3Zph4vj8wRnjnAxgAPSxcR8MAVKutWspQzc#z6MkpGR4gs4Rc3Zph4vj8wRnjnAxgAPSxcR8MAVKutWspQzc',
+            },
+            iat: expect.any(Number),
+            iss: 'did:key:z6MkrzQPBr4pyqC776KKtrz13SchM5ePPbssuPuQZb5t4uKQ',
             vct: 'OpenBadgeCredential',
             degree: 'bachelor',
           },
           // university SHOULD be disclosed
           prettyClaims: {
+            cnf: {
+              kid: 'did:key:z6MkpGR4gs4Rc3Zph4vj8wRnjnAxgAPSxcR8MAVKutWspQzc#z6MkpGR4gs4Rc3Zph4vj8wRnjnAxgAPSxcR8MAVKutWspQzc',
+            },
+            iat: expect.any(Number),
+            iss: 'did:key:z6MkrzQPBr4pyqC776KKtrz13SchM5ePPbssuPuQZb5t4uKQ',
+            vct: 'OpenBadgeCredential',
             degree: 'bachelor',
             university: 'innsbruck',
           },


### PR DESCRIPTION
This adds a new field `dislocedPayload` to the return value of credentials for PEX so you know which fields will be disclosed in an SD-JWT VC. 

It is a breaking change as the value is now not a credential record, but an object with a record. However as we mark experimental features (of which SD-JWT, PEX and OpenID4VC are marked as experimental) as not following semver, I think it's OK to do this. This way we can keep improving the API between 0.5 - 0.6 without having to make a ton of new breaking release. Of course we want to minimze them, but in this case it's worth the tradoff IMO.

  