### PR TITLE
fix: store recipient keys by default

### DIFF
--- a/packages/core/src/modules/connections/__tests__/InMemoryDidRegistry.ts
+++ b/packages/core/src/modules/connections/__tests__/InMemoryDidRegistry.ts
@@ -40,11 +40,6 @@ export class InMemoryDidRegistry implements DidRegistrar, DidResolver {
       did: didDocument.id,
       role: DidDocumentRole.Created,
       didDocument,
-      tags: {
-        // We need to save the recipientKeys, so we can find the associated did
-        // of a key when we receive a message from another connection.
-        recipientKeyFingerprints: didDocument.recipientKeys.map((key) => key.fingerprint),
-      },
     })
     const didRepository = agentContext.dependencyManager.resolve(DidRepository)
     await didRepository.save(agentContext, didRecord)

--- a/packages/core/src/modules/connections/services/ConnectionService.ts
+++ b/packages/core/src/modules/connections/services/ConnectionService.ts
@@ -797,11 +797,6 @@ export class ConnectionService {
       did: peerDid,
       role,
       didDocument,
-      tags: {
-        // We need to save the recipientKeys, so we can find the associated did
-        // of a key when we receive a message from another connection.
-        recipientKeyFingerprints: didDocument.recipientKeys.map((key) => key.fingerprint),
-      },
     })
 
     // Store the unqualified did with the legacy did document in the metadata

--- a/packages/core/src/modules/connections/services/DidRotateService.ts
+++ b/packages/core/src/modules/connections/services/DidRotateService.ts
@@ -194,8 +194,6 @@ export class DidRotateService {
       did: didDocument.id,
       didDocument,
       tags: {
-        recipientKeyFingerprints: didDocument.recipientKeys.map((key) => key.fingerprint),
-
         // For did:peer, store any alternative dids (like short form did:peer:4),
         // it may have in order to relate any message referencing it
         alternativeDids: isValidPeerDid(didDocument.id) ? getAlternativeDidsForPeerDid(didDocument.id) : undefined,

--- a/packages/core/src/modules/dids/DidsApi.ts
+++ b/packages/core/src/modules/dids/DidsApi.ts
@@ -157,7 +157,6 @@ export class DidsApi {
     if (existingDidRecord) {
       existingDidRecord.didDocument = didDocument
       existingDidRecord.setTags({
-        recipientKeyFingerprints: didDocument.recipientKeys.map((key) => key.fingerprint),
         alternativeDids: isValidPeerDid(didDocument.id) ? getAlternativeDidsForPeerDid(did) : undefined,
       })
 
@@ -170,7 +169,6 @@ export class DidsApi {
       did,
       didDocument,
       tags: {
-        recipientKeyFingerprints: didDocument.recipientKeys.map((key) => key.fingerprint),
         alternativeDids: isValidPeerDid(didDocument.id) ? getAlternativeDidsForPeerDid(did) : undefined,
       },
     })

--- a/packages/core/src/modules/dids/__tests__/peer-did.test.ts
+++ b/packages/core/src/modules/dids/__tests__/peer-did.test.ts
@@ -141,11 +141,6 @@ describe('peer dids', () => {
       // It is important to take the did document from the PeerDid class
       // as it will have the id property
       didDocument: didDocument,
-      tags: {
-        // We need to save the recipientKeys, so we can find the associated did
-        // of a key when we receive a message from another connection.
-        recipientKeyFingerprints: didDocument.recipientKeys.map((key) => key.fingerprint),
-      },
     })
 
     await didRepository.save(agentContext, didDocumentRecord)

--- a/packages/core/src/modules/dids/repository/DidRecord.ts
+++ b/packages/core/src/modules/dids/repository/DidRecord.ts
@@ -30,6 +30,11 @@ export interface CustomDidTags extends TagsBase {
 }
 
 type DefaultDidTags = {
+  // We set the recipientKeyFingeprints as a default tag, if the did record has a did document
+  // If the did record does not have a did document, we can't calculate it, and it needs to be
+  // handled by the creator of the did record
+  recipientKeyFingerprints?: string[]
+
   role: DidDocumentRole
   method: string
   legacyUnqualifiedDid?: string
@@ -75,6 +80,11 @@ export class DidRecord extends BaseRecord<DefaultDidTags, CustomDidTags, DidReco
       legacyUnqualifiedDid: legacyDid?.unqualifiedDid,
       did: this.did,
       methodSpecificIdentifier: did.id,
+
+      // Calucate if we have a did document, otherwise use the already present recipient keys
+      recipientKeyFingerprints: this.didDocument
+        ? this.didDocument.recipientKeys.map((recipientKey) => recipientKey.fingerprint)
+        : this._tags.recipientKeyFingerprints,
     }
   }
 }

--- a/packages/core/src/modules/dids/repository/DidRecord.ts
+++ b/packages/core/src/modules/dids/repository/DidRecord.ts
@@ -81,7 +81,7 @@ export class DidRecord extends BaseRecord<DefaultDidTags, CustomDidTags, DidReco
       did: this.did,
       methodSpecificIdentifier: did.id,
 
-      // Calucate if we have a did document, otherwise use the already present recipient keys
+      // Calculate if we have a did document, otherwise use the already present recipient keys
       recipientKeyFingerprints: this.didDocument
         ? this.didDocument.recipientKeys.map((recipientKey) => recipientKey.fingerprint)
         : this._tags.recipientKeyFingerprints,

--- a/packages/core/src/storage/migration/__tests__/__snapshots__/0.1.test.ts.snap
+++ b/packages/core/src/storage/migration/__tests__/__snapshots__/0.1.test.ts.snap
@@ -1462,11 +1462,7 @@ exports[`UpdateAssistant | v0.1 - v0.2 should correctly update the connection re
     },
     "type": "DidRecord",
     "value": {
-      "_tags": {
-        "recipientKeyFingerprints": [
-          "z6MktCZAQNGvWb4WHAjwBqPtXhZdDYorbSJkGW9vj1uhw1HD",
-        ],
-      },
+      "_tags": {},
       "createdAt": "2022-04-30T13:02:21.608Z",
       "did": "did:peer:1zQmP96nW6vbNjzwPt19z1NYqhnAfgnAFqfLHcktkmdUFzhT",
       "didDocument": {
@@ -1536,11 +1532,7 @@ exports[`UpdateAssistant | v0.1 - v0.2 should correctly update the connection re
     },
     "type": "DidRecord",
     "value": {
-      "_tags": {
-        "recipientKeyFingerprints": [
-          "z6Mko31DNE3gqMRZj1JNhv2BHb1caQshcd9njgKkEQXsgFRp",
-        ],
-      },
+      "_tags": {},
       "createdAt": "2022-04-30T13:02:21.646Z",
       "did": "did:peer:1zQmPbGa8KDwyjcw9UgwCCgJMV7jU5kKCyvBuwFVc88WxA56",
       "didDocument": {
@@ -1610,11 +1602,7 @@ exports[`UpdateAssistant | v0.1 - v0.2 should correctly update the connection re
     },
     "type": "DidRecord",
     "value": {
-      "_tags": {
-        "recipientKeyFingerprints": [
-          "z6Mkw81EsWQioXYC9YJ7uKHCRh6LTN7sfD9sJbSPBGXmUpzC",
-        ],
-      },
+      "_tags": {},
       "createdAt": "2022-04-30T13:02:21.577Z",
       "did": "did:peer:1zQmRAfQ6J5qk4qcbHyoStFVkhusazLT9xQcFhdC9dhhQ1cJ",
       "didDocument": {
@@ -1684,11 +1672,7 @@ exports[`UpdateAssistant | v0.1 - v0.2 should correctly update the connection re
     },
     "type": "DidRecord",
     "value": {
-      "_tags": {
-        "recipientKeyFingerprints": [
-          "z6Mkt1tsp15cnDD7wBCFgehiR2SxHX1aPxt4sueE24twH9Bd",
-        ],
-      },
+      "_tags": {},
       "createdAt": "2022-04-30T13:02:21.628Z",
       "did": "did:peer:1zQmSMBVNMDrh7fyE8bkAmk1ZatshjinpsEqPA3nx8JYjuKb",
       "didDocument": {
@@ -1758,11 +1742,7 @@ exports[`UpdateAssistant | v0.1 - v0.2 should correctly update the connection re
     },
     "type": "DidRecord",
     "value": {
-      "_tags": {
-        "recipientKeyFingerprints": [
-          "z6Mkwc6efk75y4Y1agRx4NGpvtrpKxtKvMfgBEdQkHBwU8Xu",
-        ],
-      },
+      "_tags": {},
       "createdAt": "2022-04-30T13:02:21.608Z",
       "did": "did:peer:1zQmXYj3nNwsF37WXXdb8XkCAtsTCBpJJbsLKPPGfi2PWCTU",
       "didDocument": {
@@ -1832,11 +1812,7 @@ exports[`UpdateAssistant | v0.1 - v0.2 should correctly update the connection re
     },
     "type": "DidRecord",
     "value": {
-      "_tags": {
-        "recipientKeyFingerprints": [
-          "z6MkvW9GxjjUdL9qpaj2qQW6YBhCjZY7Zkzrks3cgpJaRjxR",
-        ],
-      },
+      "_tags": {},
       "createdAt": "2022-04-20T13:02:21.646Z",
       "did": "did:peer:1zQmZ2tdw35SaLncSHhf9zBv3e9QmJmLErZRSLsDdYowPHXy",
       "didDocument": {
@@ -1906,11 +1882,7 @@ exports[`UpdateAssistant | v0.1 - v0.2 should correctly update the connection re
     },
     "type": "DidRecord",
     "value": {
-      "_tags": {
-        "recipientKeyFingerprints": [
-          "z6MktpVtPC5j91aycGPT5pceiu8EGKDzM5RLwqAZBuCgxw4V",
-        ],
-      },
+      "_tags": {},
       "createdAt": "2022-04-30T13:02:21.641Z",
       "did": "did:peer:1zQma8LpnJ22GxQdyASV5jP6psacAGtJ6ytk4pVayYp4erRf",
       "didDocument": {
@@ -1980,11 +1952,7 @@ exports[`UpdateAssistant | v0.1 - v0.2 should correctly update the connection re
     },
     "type": "DidRecord",
     "value": {
-      "_tags": {
-        "recipientKeyFingerprints": [
-          "z6MkwXNXTehVH7YijDmN1PtaXaSaCniTyaVepmY1EJgS15xq",
-        ],
-      },
+      "_tags": {},
       "createdAt": "2022-04-30T13:02:21.646Z",
       "did": "did:peer:1zQmadmBfngrYSWhYYxZ24fpW29iwhKhQ6CB6euLabbSK6ga",
       "didDocument": {
@@ -2054,11 +2022,7 @@ exports[`UpdateAssistant | v0.1 - v0.2 should correctly update the connection re
     },
     "type": "DidRecord",
     "value": {
-      "_tags": {
-        "recipientKeyFingerprints": [
-          "z6MkjmCrDWJVf8H2pCHcu11UDs4jb6FVu8nn5yQW24rrgez6",
-        ],
-      },
+      "_tags": {},
       "createdAt": "2022-04-30T13:02:21.628Z",
       "did": "did:peer:1zQmc3BZoTinpVaG3oZ4PmRVN4JMdNZGCmPkS6smmTNLnvEZ",
       "didDocument": {
@@ -2128,11 +2092,7 @@ exports[`UpdateAssistant | v0.1 - v0.2 should correctly update the connection re
     },
     "type": "DidRecord",
     "value": {
-      "_tags": {
-        "recipientKeyFingerprints": [
-          "z6MkjDJL4X7YGoH6gjamhZR2NzowPZqtJfX5kPuNuWiVdjMr",
-        ],
-      },
+      "_tags": {},
       "createdAt": "2022-04-30T13:02:21.641Z",
       "did": "did:peer:1zQmcXZepLE55VGCMELEFjMd4nKrzp3GGyRR3r3MYermagui",
       "didDocument": {
@@ -2202,11 +2162,7 @@ exports[`UpdateAssistant | v0.1 - v0.2 should correctly update the connection re
     },
     "type": "DidRecord",
     "value": {
-      "_tags": {
-        "recipientKeyFingerprints": [
-          "z6MkvcgxQSsX5WA8vcBokLZ46znnhRBH6aKAGYnonEUfUnQV",
-        ],
-      },
+      "_tags": {},
       "createdAt": "2022-04-30T13:02:21.635Z",
       "did": "did:peer:1zQmduuYkxRKJuVyvDqttdd9eDfBwDnF1DAU5FFQo4whx7Uw",
       "didDocument": {
@@ -2276,11 +2232,7 @@ exports[`UpdateAssistant | v0.1 - v0.2 should correctly update the connection re
     },
     "type": "DidRecord",
     "value": {
-      "_tags": {
-        "recipientKeyFingerprints": [
-          "z6MkfiPMPxCQeSDZGMkCvm1Y2rBoPsmw4ZHMv71jXtcWRRiM",
-        ],
-      },
+      "_tags": {},
       "createdAt": "2022-04-30T13:02:21.577Z",
       "did": "did:peer:1zQmeHpGaZ48DnAP2k3KntXB1vmd8MgLEdcb4EQzqWJDHcbX",
       "didDocument": {
@@ -2350,11 +2302,7 @@ exports[`UpdateAssistant | v0.1 - v0.2 should correctly update the connection re
     },
     "type": "DidRecord",
     "value": {
-      "_tags": {
-        "recipientKeyFingerprints": [
-          "z6MkuWTEmH1mUo6W96zSWyH612hFHowRzNEscPYBL2CCMyC2",
-        ],
-      },
+      "_tags": {},
       "createdAt": "2022-04-30T13:02:21.653Z",
       "did": "did:peer:1zQmfDAtfDZcK4trJBsvVTXrBx9uaLCHSUZH9X2LFaAd3JKv",
       "didDocument": {

--- a/packages/core/src/storage/migration/updates/0.1-0.2/__tests__/connection.test.ts
+++ b/packages/core/src/storage/migration/updates/0.1-0.2/__tests__/connection.test.ts
@@ -234,12 +234,12 @@ describe('0.1-0.2 | Connection', () => {
             didDocumentString: JSON.stringify(legacyDidPeerR1xKJw17sUoXhejEpugMYJ),
           },
         },
-        _tags: {
-          recipientKeyFingerprints: [
-            'z6MksYU4MHtfmNhNm1uGMvANr9j4CBv2FymjiJtRgA36bSVH',
-            'z6MksYU4MHtfmNhNm1uGMvANr9j4CBv2FymjiJtRgA36bSVH',
-          ],
-        },
+      })
+      expect(didRecord.getTags()).toMatchObject({
+        recipientKeyFingerprints: [
+          'z6MksYU4MHtfmNhNm1uGMvANr9j4CBv2FymjiJtRgA36bSVH',
+          'z6MksYU4MHtfmNhNm1uGMvANr9j4CBv2FymjiJtRgA36bSVH',
+        ],
       })
 
       expect(theirDidRecord.toJSON()).toMatchObject({
@@ -253,12 +253,12 @@ describe('0.1-0.2 | Connection', () => {
             didDocumentString: JSON.stringify(legacyDidPeer4kgVt6CidfKgo1MoWMqsQX),
           },
         },
-        _tags: {
-          recipientKeyFingerprints: [
-            'z6MkjKUBV9DDUj7cgW8UbDJZhPcHCH8up26Lrr8YqkAS4wcb',
-            'z6MkjKUBV9DDUj7cgW8UbDJZhPcHCH8up26Lrr8YqkAS4wcb',
-          ],
-        },
+      })
+      expect(theirDidRecord.getTags()).toMatchObject({
+        recipientKeyFingerprints: [
+          'z6MkjKUBV9DDUj7cgW8UbDJZhPcHCH8up26Lrr8YqkAS4wcb',
+          'z6MkjKUBV9DDUj7cgW8UbDJZhPcHCH8up26Lrr8YqkAS4wcb',
+        ],
       })
     })
 

--- a/packages/core/src/storage/migration/updates/0.1-0.2/connection.ts
+++ b/packages/core/src/storage/migration/updates/0.1-0.2/connection.ts
@@ -179,9 +179,6 @@ export async function extractDidDocument<Agent extends BaseAgent>(agent: Agent, 
         role: DidDocumentRole.Created,
         didDocument: newOurDidDocument,
         createdAt: connectionRecord.createdAt,
-        tags: {
-          recipientKeyFingerprints: newOurDidDocument.recipientKeys.map((key) => key.fingerprint),
-        },
       })
 
       ourDidRecord.metadata.set(DidRecordMetadataKeys.LegacyDid, {
@@ -231,9 +228,6 @@ export async function extractDidDocument<Agent extends BaseAgent>(agent: Agent, 
         role: DidDocumentRole.Received,
         didDocument: newTheirDidDocument,
         createdAt: connectionRecord.createdAt,
-        tags: {
-          recipientKeyFingerprints: newTheirDidDocument.recipientKeys.map((key) => key.fingerprint),
-        },
       })
 
       theirDidRecord.metadata.set(DidRecordMetadataKeys.LegacyDid, {

--- a/packages/indy-vdr/src/dids/IndyVdrIndyDidRegistrar.ts
+++ b/packages/indy-vdr/src/dids/IndyVdrIndyDidRegistrar.ts
@@ -196,9 +196,7 @@ export class IndyVdrIndyDidRegistrar implements DidRegistrar {
     const didRecord = new DidRecord({
       did,
       role: DidDocumentRole.Created,
-      tags: {
-        recipientKeyFingerprints: didDocument.recipientKeys.map((key: Key) => key.fingerprint),
-      },
+      didDocument,
     })
 
     const didRepository = agentContext.dependencyManager.resolve(DidRepository)

--- a/packages/indy-vdr/src/dids/__tests__/IndyVdrIndyDidRegistrar.test.ts
+++ b/packages/indy-vdr/src/dids/__tests__/IndyVdrIndyDidRegistrar.test.ts
@@ -730,13 +730,13 @@ describe('IndyVdrIndyDidRegistrar', () => {
     expect(saveCalled).toHaveBeenCalledTimes(1)
     const [saveEvent] = saveCalled.mock.calls[0]
 
+    expect(saveEvent.payload.record.getTags()).toMatchObject({
+      recipientKeyFingerprints: ['z6LSrH6AdsQeZuKKmG6Ehx7abEQZsVg2psR2VU536gigUoAe'],
+    })
     expect(saveEvent.payload.record).toMatchObject({
       did: 'did:indy:pool1:B6xaJg1c2xU3D9ppCtt1CZ',
       role: DidDocumentRole.Created,
-      _tags: {
-        recipientKeyFingerprints: ['z6LSrH6AdsQeZuKKmG6Ehx7abEQZsVg2psR2VU536gigUoAe'],
-      },
-      didDocument: undefined,
+      didDocument: expect.any(DidDocument),
     })
   })
 


### PR DESCRIPTION
When integrating the new `invitationDid` with a `did:cheqd` DID, I noticed that DIDComm wouldn't work because the recipientKeyFingerprints weren't added.

To make it easier, it is now calculated in the did record if the did document is provided, and I've also updated the `did:indy` registrar to store the did document. It's very expensive to resolve these documents, and this will allow us in a future update to shortcut did docs created by us to first look for the local record.

But for now, it makes it easy to use any kind of did with DIDComm.