### PR TITLE
fix: allow did document for didcomm without authentication or keyAgreement

### DIFF
--- a/packages/core/src/modules/didcomm/util/matchingEd25519Key.ts
+++ b/packages/core/src/modules/didcomm/util/matchingEd25519Key.ts
@@ -1,7 +1,7 @@
 import type { DidDocument, VerificationMethod } from '../../dids'
 
 import { Key, KeyType } from '../../../crypto'
-import { keyReferenceToKey } from '../../dids'
+import { getKeyFromVerificationMethod } from '../../dids'
 import { convertPublicKeyToX25519 } from '../../dids/domain/key-type/ed25519'
 
 /**
@@ -23,7 +23,7 @@ export function findMatchingEd25519Key(x25519Key: Key, didDocument: DidDocument)
   ]
 
   return allKeyReferences
-    .map((keyReference) => keyReferenceToKey(didDocument, keyReference.id))
+    .map((keyReference) => getKeyFromVerificationMethod(didDocument.dereferenceKey(keyReference.id)))
     .filter((key) => key?.keyType === KeyType.Ed25519)
     .find((keyEd25519) => {
       const keyX25519 = Key.fromPublicKey(convertPublicKeyToX25519(keyEd25519.publicKey), KeyType.X25519)

--- a/packages/core/src/modules/dids/domain/DidDocument.ts
+++ b/packages/core/src/modules/dids/domain/DidDocument.ts
@@ -123,13 +123,14 @@ export class DidDocument {
     return verificationMethod
   }
 
-  public dereferenceKey(keyId: string, allowedPurposes?: DidPurpose[]) {
-    const allPurposes: DidPurpose[] = [
+  public dereferenceKey(keyId: string, allowedPurposes?: DidVerificationMethods[]) {
+    const allPurposes: DidVerificationMethods[] = [
       'authentication',
       'keyAgreement',
       'assertionMethod',
       'capabilityInvocation',
       'capabilityDelegation',
+      'verificationMethod',
     ]
 
     const purposes = allowedPurposes ?? allPurposes
@@ -194,7 +195,9 @@ export class DidDocument {
       } else if (service.type === DidCommV1Service.type) {
         recipientKeys = [
           ...recipientKeys,
-          ...service.recipientKeys.map((recipientKey) => keyReferenceToKey(this, recipientKey)),
+          ...service.recipientKeys.map((recipientKey) =>
+            getKeyFromVerificationMethod(this.dereferenceKey(recipientKey, ['authentication', 'assertionMethod']))
+          ),
         ]
       }
     }
@@ -205,16 +208,6 @@ export class DidDocument {
   public toJSON() {
     return JsonTransformer.toJSON(this)
   }
-}
-
-export function keyReferenceToKey(didDocument: DidDocument, keyId: string) {
-  // FIXME: we allow authentication keys as historically ed25519 keys have been used in did documents
-  // for didcomm. In the future we should update this to only be allowed for IndyAgent and DidCommV1 services
-  // as didcomm v2 doesn't have this issue anymore
-  const verificationMethod = didDocument.dereferenceKey(keyId, ['authentication', 'keyAgreement'])
-  const key = getKeyFromVerificationMethod(verificationMethod)
-
-  return key
 }
 
 /**

--- a/packages/core/src/modules/dids/domain/DidDocument.ts
+++ b/packages/core/src/modules/dids/domain/DidDocument.ts
@@ -196,7 +196,7 @@ export class DidDocument {
         recipientKeys = [
           ...recipientKeys,
           ...service.recipientKeys.map((recipientKey) =>
-            getKeyFromVerificationMethod(this.dereferenceKey(recipientKey, ['authentication', 'assertionMethod']))
+            getKeyFromVerificationMethod(this.dereferenceKey(recipientKey, ['authentication', 'keyAgreement']))
           ),
         ]
       }

--- a/packages/indy-vdr/src/dids/__tests__/IndyVdrIndyDidRegistrar.test.ts
+++ b/packages/indy-vdr/src/dids/__tests__/IndyVdrIndyDidRegistrar.test.ts
@@ -607,7 +607,6 @@ describe('IndyVdrIndyDidRegistrar', () => {
       },
     })
     expect(setEndpointsForDidSpy).not.toHaveBeenCalled()
-    console.log(result)
     expect(JsonTransformer.toJSON(result)).toMatchObject({
       didDocumentMetadata: {},
       didRegistrationMetadata: {},

--- a/packages/indy-vdr/src/dids/__tests__/IndyVdrIndyDidRegistrar.test.ts
+++ b/packages/indy-vdr/src/dids/__tests__/IndyVdrIndyDidRegistrar.test.ts
@@ -607,6 +607,7 @@ describe('IndyVdrIndyDidRegistrar', () => {
       },
     })
     expect(setEndpointsForDidSpy).not.toHaveBeenCalled()
+    console.log(result)
     expect(JsonTransformer.toJSON(result)).toMatchObject({
       didDocumentMetadata: {},
       didRegistrationMetadata: {},


### PR DESCRIPTION
Fixes a bug where if you would use a did document that contains keys not in authentication or keyAgreement, and also want to use it for DIDComm, it would break when the did document would be parsed for DIDComm. The restrictions are now loosened, as it was mostly used to find the matching Ed25519 key for a X25519 key.

