### PR TITLE
fix(anoncreds): migration script credential id

### DIFF
--- a/packages/anoncreds/src/updates/0.4-0.5/__tests__/w3cCredentialRecordMigration.test.ts
+++ b/packages/anoncreds/src/updates/0.4-0.5/__tests__/w3cCredentialRecordMigration.test.ts
@@ -282,7 +282,7 @@ async function testMigration(
     threadId: 'threadId',
     credentials: [
       {
-        credentialRecordId: anonCredsRecord.id,
+        credentialRecordId: anonCredsRecord.credentialId,
         credentialRecordType: 'anoncreds',
       },
     ],

--- a/packages/anoncreds/src/updates/0.4-0.5/__tests__/w3cCredentialRecordMigration.test.ts
+++ b/packages/anoncreds/src/updates/0.4-0.5/__tests__/w3cCredentialRecordMigration.test.ts
@@ -324,7 +324,7 @@ async function testMigration(
   expect(anonCredsRepo.delete).toHaveBeenCalledTimes(1)
   expect(credentialExchangeRepo.findByQuery).toHaveBeenCalledTimes(1)
   expect(credentialExchangeRepo.findByQuery).toHaveBeenCalledWith(agent.context, {
-    credentialIds: [anonCredsRecord.id],
+    credentialIds: [anonCredsRecord.credentialId],
   })
   expect(credentialExchangeRepo.update).toHaveBeenCalledTimes(1)
   expect(credentialExchangeRepo.update).toHaveBeenCalledWith(

--- a/packages/anoncreds/src/updates/0.4-0.5/anonCredsCredentialRecord.ts
+++ b/packages/anoncreds/src/updates/0.4-0.5/anonCredsCredentialRecord.ts
@@ -141,13 +141,13 @@ async function migrateLegacyToW3cCredential(agentContext: AgentContext, legacyRe
   // Find the credential exchange record bound to this anoncreds credential and update it to point to the newly created w3c record
   const credentialExchangeRepository = agentContext.dependencyManager.resolve(CredentialRepository)
   const [relatedCredentialExchangeRecord] = await credentialExchangeRepository.findByQuery(agentContext, {
-    credentialIds: [legacyRecord.id],
+    credentialIds: [legacyRecord.credentialId],
   })
 
   if (relatedCredentialExchangeRecord) {
     // Replace the related binding by the new one
     const credentialBindingIndex = relatedCredentialExchangeRecord.credentials.findIndex(
-      (binding) => binding.credentialRecordId === legacyRecord.id
+      (binding) => binding.credentialRecordId === legacyRecord.credentialId
     )
     if (credentialBindingIndex !== -1) {
       relatedCredentialExchangeRecord.credentials[credentialBindingIndex] = {


### PR DESCRIPTION
Unfortunately we were looking for the wrong id when migrating Credential Exchange records that were bound to legacy AnonCreds credentials, as they are referenced by their `credentialId` instead of framework's record `id`.