### PR TITLE
feat: allow serving dids from did record

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -2,10 +2,10 @@ name: Continuous Integration
 
 on:
   pull_request:
-    branches: [main, "**-pre"]
+    branches: [main, '**-pre']
     types: [opened, synchronize, reopened, labeled]
   push:
-    branches: [main, "**-pre"]
+    branches: [main, '**-pre']
   workflow_dispatch:
 
 env:
@@ -53,7 +53,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 18
-          cache: "yarn"
+          cache: 'yarn'
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile
@@ -91,7 +91,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-          cache: "yarn"
+          cache: 'yarn'
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile
@@ -128,7 +128,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-          cache: "yarn"
+          cache: 'yarn'
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile
@@ -175,7 +175,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 18
-          cache: "yarn"
+          cache: 'yarn'
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile
@@ -211,8 +211,8 @@ jobs:
         with:
           commit-message: |
             chore(release): v${{ steps.new-version.outputs.version }}
-          author: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
-          committer: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
+          author: 'github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>'
+          committer: 'github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>'
           branch: lerna-release
           signoff: true
           title: |

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -103,7 +103,7 @@ jobs:
       - run: mv coverage/coverage-final.json coverage/${{ matrix.shard }}.json
       - uses: actions/upload-artifact@v4
         with:
-          name: coverage-artifacts-${{ matrix.shard }}
+          name: coverage-artifacts
           path: coverage/${{ matrix.shard }}.json
           overwrite: true
 
@@ -140,7 +140,7 @@ jobs:
       - run: mv coverage/coverage-final.json coverage/e2e.json
       - uses: actions/upload-artifact@v4
         with:
-          name: coverage-e2e
+          name: coverage-artifcats
           path: coverage/e2e.json
           overwrite: true
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -2,10 +2,10 @@ name: Continuous Integration
 
 on:
   pull_request:
-    branches: [main, '**-pre']
+    branches: [main, "**-pre"]
     types: [opened, synchronize, reopened, labeled]
   push:
-    branches: [main, '**-pre']
+    branches: [main, "**-pre"]
   workflow_dispatch:
 
 env:
@@ -53,7 +53,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 18
-          cache: 'yarn'
+          cache: "yarn"
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile
@@ -91,7 +91,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-          cache: 'yarn'
+          cache: "yarn"
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile
@@ -103,7 +103,7 @@ jobs:
       - run: mv coverage/coverage-final.json coverage/${{ matrix.shard }}.json
       - uses: actions/upload-artifact@v4
         with:
-          name: coverage-artifacts
+          name: coverage-artifacts-${{ matrix.shard }}
           path: coverage/${{ matrix.shard }}.json
           overwrite: true
 
@@ -128,7 +128,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-          cache: 'yarn'
+          cache: "yarn"
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile
@@ -140,7 +140,7 @@ jobs:
       - run: mv coverage/coverage-final.json coverage/e2e.json
       - uses: actions/upload-artifact@v4
         with:
-          name: coverage-artifacts
+          name: coverage-e2e
           path: coverage/e2e.json
           overwrite: true
 
@@ -175,7 +175,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 18
-          cache: 'yarn'
+          cache: "yarn"
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile
@@ -211,8 +211,8 @@ jobs:
         with:
           commit-message: |
             chore(release): v${{ steps.new-version.outputs.version }}
-          author: 'github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>'
-          committer: 'github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>'
+          author: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
+          committer: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
           branch: lerna-release
           signoff: true
           title: |

--- a/packages/anoncreds/src/anoncreds-rs/__tests__/AnonCredsRsHolderService.test.ts
+++ b/packages/anoncreds/src/anoncreds-rs/__tests__/AnonCredsRsHolderService.test.ts
@@ -19,6 +19,7 @@ import {
   W3cCredentialSubject,
   W3cCredentialsModuleConfig,
   W3cJsonLdVerifiableCredential,
+  DidRepository,
 } from '@credo-ts/core'
 import { anoncreds } from '@hyperledger/anoncreds-nodejs'
 import { Subject } from 'rxjs'
@@ -90,7 +91,7 @@ const agentContext = getAgentContext({
       }),
     ],
     [InjectionSymbols.Logger, testLogger],
-    [DidResolverService, new DidResolverService(testLogger, new DidsModuleConfig())],
+    [DidResolverService, new DidResolverService(testLogger, new DidsModuleConfig(), {} as unknown as DidRepository)],
     [W3cCredentialsModuleConfig, new W3cCredentialsModuleConfig()],
     [SignatureSuiteToken, 'default'],
   ],

--- a/packages/anoncreds/src/anoncreds-rs/__tests__/AnonCredsRsHolderService.test.ts
+++ b/packages/anoncreds/src/anoncreds-rs/__tests__/AnonCredsRsHolderService.test.ts
@@ -7,6 +7,7 @@ import type {
   AnonCredsSchema,
   AnonCredsSelectedCredentials,
 } from '@credo-ts/anoncreds'
+import type { DidRepository } from '@credo-ts/core'
 import type { JsonObject } from '@hyperledger/anoncreds-shared'
 
 import {
@@ -19,7 +20,6 @@ import {
   W3cCredentialSubject,
   W3cCredentialsModuleConfig,
   W3cJsonLdVerifiableCredential,
-  DidRepository,
 } from '@credo-ts/core'
 import { anoncreds } from '@hyperledger/anoncreds-nodejs'
 import { Subject } from 'rxjs'

--- a/packages/anoncreds/src/anoncreds-rs/__tests__/AnonCredsRsServices.test.ts
+++ b/packages/anoncreds/src/anoncreds-rs/__tests__/AnonCredsRsServices.test.ts
@@ -1,6 +1,7 @@
 import type { AnonCredsProofRequest } from '@credo-ts/anoncreds'
 
 import {
+  DidRepository,
   DidResolverService,
   DidsModuleConfig,
   InjectionSymbols,
@@ -67,7 +68,7 @@ const agentContext = getAgentContext({
     ],
 
     [InjectionSymbols.Logger, testLogger],
-    [DidResolverService, new DidResolverService(testLogger, new DidsModuleConfig())],
+    [DidResolverService, new DidResolverService(testLogger, new DidsModuleConfig(), {} as unknown as DidRepository)],
     [W3cCredentialsModuleConfig, new W3cCredentialsModuleConfig()],
     [SignatureSuiteToken, 'default'],
   ],

--- a/packages/anoncreds/src/anoncreds-rs/__tests__/AnonCredsRsServices.test.ts
+++ b/packages/anoncreds/src/anoncreds-rs/__tests__/AnonCredsRsServices.test.ts
@@ -1,7 +1,7 @@
 import type { AnonCredsProofRequest } from '@credo-ts/anoncreds'
+import type { DidRepository } from '@credo-ts/core'
 
 import {
-  DidRepository,
   DidResolverService,
   DidsModuleConfig,
   InjectionSymbols,

--- a/packages/anoncreds/src/formats/__tests__/legacy-indy-format-services.test.ts
+++ b/packages/anoncreds/src/formats/__tests__/legacy-indy-format-services.test.ts
@@ -15,6 +15,7 @@ import {
   DidsModuleConfig,
   ProofRole,
   CredentialRole,
+  DidRepository,
 } from '@credo-ts/core'
 import { Subject } from 'rxjs'
 
@@ -91,7 +92,7 @@ const agentContext = getAgentContext({
     [AnonCredsIssuerServiceSymbol, anonCredsIssuerService],
     [AnonCredsHolderServiceSymbol, anonCredsHolderService],
     [AnonCredsVerifierServiceSymbol, anonCredsVerifierService],
-    [DidResolverService, new DidResolverService(testLogger, new DidsModuleConfig())],
+    [DidResolverService, new DidResolverService(testLogger, new DidsModuleConfig(), {} as unknown as DidRepository)],
     [AnonCredsRegistryService, new AnonCredsRegistryService()],
     [AnonCredsModuleConfig, anonCredsModuleConfig],
     [AnonCredsLinkSecretRepository, anonCredsLinkSecretRepository],

--- a/packages/anoncreds/src/formats/__tests__/legacy-indy-format-services.test.ts
+++ b/packages/anoncreds/src/formats/__tests__/legacy-indy-format-services.test.ts
@@ -1,4 +1,5 @@
 import type { AnonCredsCredentialRequest } from '../../models'
+import type { DidRepository } from '@credo-ts/core'
 
 import {
   CredentialState,
@@ -15,7 +16,6 @@ import {
   DidsModuleConfig,
   ProofRole,
   CredentialRole,
-  DidRepository,
 } from '@credo-ts/core'
 import { Subject } from 'rxjs'
 

--- a/packages/anoncreds/src/updates/0.4-0.5/__tests__/w3cCredentialRecordMigration.test.ts
+++ b/packages/anoncreds/src/updates/0.4-0.5/__tests__/w3cCredentialRecordMigration.test.ts
@@ -1,4 +1,4 @@
-import type { Wallet } from '@credo-ts/core'
+import type { DidRepository, Wallet } from '@credo-ts/core'
 
 import {
   CredentialState,
@@ -76,7 +76,7 @@ const agentContext = getAgentContext({
     [InjectionSymbols.FileSystem, new agentDependencies.FileSystem()],
     [InjectionSymbols.StorageService, inMemoryStorageService],
     [AnonCredsRegistryService, new AnonCredsRegistryService()],
-    [DidResolverService, new DidResolverService(testLogger, new DidsModuleConfig())],
+    [DidResolverService, new DidResolverService(testLogger, new DidsModuleConfig(), {} as unknown as DidRepository)],
     [InjectionSymbols.Logger, testLogger],
     [W3cCredentialsModuleConfig, new W3cCredentialsModuleConfig()],
     [AnonCredsModuleConfig, anonCredsModuleConfig],

--- a/packages/anoncreds/tests/anoncreds-flow.test.ts
+++ b/packages/anoncreds/tests/anoncreds-flow.test.ts
@@ -1,5 +1,5 @@
 import type { AnonCredsCredentialRequest } from '@credo-ts/anoncreds'
-import type { Wallet } from '@credo-ts/core'
+import type { DidRepository, Wallet } from '@credo-ts/core'
 
 import {
   CredentialRole,
@@ -78,7 +78,7 @@ const agentContext = getAgentContext({
     [AnonCredsHolderServiceSymbol, anonCredsHolderService],
     [AnonCredsVerifierServiceSymbol, anonCredsVerifierService],
     [InjectionSymbols.Logger, testLogger],
-    [DidResolverService, new DidResolverService(testLogger, new DidsModuleConfig())],
+    [DidResolverService, new DidResolverService(testLogger, new DidsModuleConfig(), {} as unknown as DidRepository)],
     [AnonCredsRegistryService, new AnonCredsRegistryService()],
     [AnonCredsModuleConfig, anonCredsModuleConfig],
     [W3cCredentialsModuleConfig, new W3cCredentialsModuleConfig()],

--- a/packages/anoncreds/tests/data-integrity-flow-anoncreds.test.ts
+++ b/packages/anoncreds/tests/data-integrity-flow-anoncreds.test.ts
@@ -1,4 +1,4 @@
-import type { DataIntegrityCredentialRequest } from '@credo-ts/core'
+import type { DataIntegrityCredentialRequest, DidRepository } from '@credo-ts/core'
 
 import {
   ProofRole,
@@ -91,7 +91,7 @@ const agentContext = getAgentContext({
     [AnonCredsVerifierServiceSymbol, anonCredsVerifierService],
     [InjectionSymbols.Logger, testLogger],
     [DidsModuleConfig, didsModuleConfig],
-    [DidResolverService, new DidResolverService(testLogger, didsModuleConfig)],
+    [DidResolverService, new DidResolverService(testLogger, didsModuleConfig, {} as unknown as DidRepository)],
     [AnonCredsRegistryService, new AnonCredsRegistryService()],
     [AnonCredsModuleConfig, anonCredsModuleConfig],
     [W3cCredentialsModuleConfig, new W3cCredentialsModuleConfig()],

--- a/packages/anoncreds/tests/data-integrity-flow-w3c.test.ts
+++ b/packages/anoncreds/tests/data-integrity-flow-w3c.test.ts
@@ -20,6 +20,7 @@ import {
   W3cCredentialSubject,
   W3cCredentialsModuleConfig,
   CredentialRole,
+  DidRepository,
 } from '@credo-ts/core'
 import { Subject } from 'rxjs'
 
@@ -80,7 +81,7 @@ const agentContext = getAgentContext({
     [AnonCredsVerifierServiceSymbol, anonCredsVerifierService],
     [InjectionSymbols.Logger, testLogger],
     [DidsModuleConfig, didsModuleConfig],
-    [DidResolverService, new DidResolverService(testLogger, didsModuleConfig)],
+    [DidResolverService, new DidResolverService(testLogger, didsModuleConfig, {} as unknown as DidRepository)],
     [AnonCredsRegistryService, new AnonCredsRegistryService()],
     [AnonCredsModuleConfig, anonCredsModuleConfig],
     [W3cCredentialsModuleConfig, new W3cCredentialsModuleConfig()],

--- a/packages/anoncreds/tests/data-integrity-flow-w3c.test.ts
+++ b/packages/anoncreds/tests/data-integrity-flow-w3c.test.ts
@@ -1,4 +1,5 @@
 import type { CreateDidKidVerificationMethodReturn } from '../../core/tests'
+import type { DidRepository } from '@credo-ts/core'
 
 import {
   AgentContext,
@@ -20,7 +21,6 @@ import {
   W3cCredentialSubject,
   W3cCredentialsModuleConfig,
   CredentialRole,
-  DidRepository,
 } from '@credo-ts/core'
 import { Subject } from 'rxjs'
 

--- a/packages/anoncreds/tests/data-integrity-flow.test.ts
+++ b/packages/anoncreds/tests/data-integrity-flow.test.ts
@@ -20,6 +20,7 @@ import {
   W3cCredentialSubject,
   W3cCredentialsModuleConfig,
   CredentialRole,
+  DidRepository,
 } from '@credo-ts/core'
 import { Subject } from 'rxjs'
 
@@ -80,7 +81,7 @@ const agentContext = getAgentContext({
     [AnonCredsVerifierServiceSymbol, anonCredsVerifierService],
     [InjectionSymbols.Logger, testLogger],
     [DidsModuleConfig, didsModuleConfig],
-    [DidResolverService, new DidResolverService(testLogger, didsModuleConfig)],
+    [DidResolverService, new DidResolverService(testLogger, didsModuleConfig, {} as unknown as DidRepository)],
     [AnonCredsRegistryService, new AnonCredsRegistryService()],
     [AnonCredsModuleConfig, anonCredsModuleConfig],
     [W3cCredentialsModuleConfig, new W3cCredentialsModuleConfig()],

--- a/packages/anoncreds/tests/data-integrity-flow.test.ts
+++ b/packages/anoncreds/tests/data-integrity-flow.test.ts
@@ -1,4 +1,5 @@
 import type { CreateDidKidVerificationMethodReturn } from '../../core/tests'
+import type { DidRepository } from '@credo-ts/core'
 
 import {
   AgentContext,
@@ -20,7 +21,6 @@ import {
   W3cCredentialSubject,
   W3cCredentialsModuleConfig,
   CredentialRole,
-  DidRepository,
 } from '@credo-ts/core'
 import { Subject } from 'rxjs'
 

--- a/packages/anoncreds/tests/indy-flow.test.ts
+++ b/packages/anoncreds/tests/indy-flow.test.ts
@@ -1,5 +1,5 @@
 import type { AnonCredsCredentialRequest } from '@credo-ts/anoncreds'
-import type { Wallet } from '@credo-ts/core'
+import type { DidRepository, Wallet } from '@credo-ts/core'
 
 import {
   CredentialRole,
@@ -71,7 +71,7 @@ const agentContext = getAgentContext({
     [AnonCredsHolderServiceSymbol, anonCredsHolderService],
     [AnonCredsVerifierServiceSymbol, anonCredsVerifierService],
     [AnonCredsRegistryService, new AnonCredsRegistryService()],
-    [DidResolverService, new DidResolverService(testLogger, new DidsModuleConfig())],
+    [DidResolverService, new DidResolverService(testLogger, new DidsModuleConfig(), {} as unknown as DidRepository)],
     [InjectionSymbols.Logger, testLogger],
     [W3cCredentialsModuleConfig, new W3cCredentialsModuleConfig()],
     [AnonCredsModuleConfig, anonCredsModuleConfig],

--- a/packages/cheqd/src/dids/CheqdDidResolver.ts
+++ b/packages/cheqd/src/dids/CheqdDidResolver.ts
@@ -20,6 +20,7 @@ import { filterResourcesByNameAndType, getClosestResourceVersion, renderResource
 export class CheqdDidResolver implements DidResolver {
   public readonly supportedMethods = ['cheqd']
   public readonly allowsCaching = true
+  public readonly allowsLocalDidRecord = true
 
   public async resolve(agentContext: AgentContext, did: string, parsed: ParsedDid): Promise<DidResolutionResult> {
     const didDocumentMetadata = {}

--- a/packages/cheqd/tests/cheqd-did-registrar.e2e.test.ts
+++ b/packages/cheqd/tests/cheqd-did-registrar.e2e.test.ts
@@ -132,7 +132,9 @@ describe('Cheqd DID registrar', () => {
     expect(deactivateResult.didState.didDocument?.toJSON()).toMatchObject(didDocument.toJSON())
     expect(deactivateResult.didState.state).toEqual('finished')
 
-    const resolvedDocument = await agent.dids.resolve(did)
+    const resolvedDocument = await agent.dids.resolve(did, {
+      useLocalCreatedDidRecord: false,
+    })
     expect(resolvedDocument.didDocumentMetadata.deactivated).toBe(true)
   })
 

--- a/packages/cheqd/tests/cheqd-did-resolver.e2e.test.ts
+++ b/packages/cheqd/tests/cheqd-did-resolver.e2e.test.ts
@@ -77,7 +77,9 @@ describe('Cheqd DID resolver', () => {
   })
 
   it('should resolve a did:cheqd did from local testnet', async () => {
-    const resolveResult = await resolverAgent.dids.resolve(did)
+    const resolveResult = await resolverAgent.dids.resolve(did, {
+      useLocalCreatedDidRecord: false,
+    })
     expect(JsonTransformer.toJSON(resolveResult)).toMatchObject({
       didDocument: {
         '@context': ['https://www.w3.org/ns/did/v1', 'https://w3id.org/security/suites/ed25519-2020/v1'],
@@ -105,7 +107,9 @@ describe('Cheqd DID resolver', () => {
   })
 
   it('should getClosestResourceVersion', async () => {
-    const didResult = await resolverAgent.dids.resolve(did)
+    const didResult = await resolverAgent.dids.resolve(did, {
+      useLocalCreatedDidRecord: false,
+    })
 
     const inFuture = new Date(Date.now() + 1000 * 60 * 60 * 24 * 365 * 10) // 10 years in future
 

--- a/packages/core/src/modules/dids/__tests__/peer-did.test.ts
+++ b/packages/core/src/modules/dids/__tests__/peer-did.test.ts
@@ -55,7 +55,8 @@ describe('peer dids', () => {
 
     didResolverService = new DidResolverService(
       config.logger,
-      new DidsModuleConfig({ resolvers: [new PeerDidResolver()] })
+      new DidsModuleConfig({ resolvers: [new PeerDidResolver()] }),
+      {} as unknown as DidRepository
     )
   })
 

--- a/packages/core/src/modules/dids/domain/DidResolver.ts
+++ b/packages/core/src/modules/dids/domain/DidResolver.ts
@@ -10,7 +10,7 @@ export interface DidResolver {
    * a did record to resolve the did document.
    *
    * @default false
-   * @todo make required in 0.5.0
+   * @todo make required in 0.6.0
    */
   readonly allowsLocalDidRecord?: boolean
 

--- a/packages/core/src/modules/dids/domain/DidResolver.ts
+++ b/packages/core/src/modules/dids/domain/DidResolver.ts
@@ -5,6 +5,15 @@ export interface DidResolver {
   readonly supportedMethods: string[]
   readonly allowsCaching: boolean
 
+  /**
+   * Whether the resolver allows using a local created did document from
+   * a did record to resolve the did document.
+   *
+   * @default false
+   * @todo make required in 0.5.0
+   */
+  readonly allowsLocalDidRecord?: boolean
+
   resolve(
     agentContext: AgentContext,
     did: string,

--- a/packages/core/src/modules/dids/methods/jwk/JwkDidResolver.ts
+++ b/packages/core/src/modules/dids/methods/jwk/JwkDidResolver.ts
@@ -12,6 +12,12 @@ export class JwkDidResolver implements DidResolver {
    */
   public readonly allowsCaching = false
 
+  /**
+   * Easier to calculate for resolving than serving the local did document. Record also doesn't
+   * have a did document
+   */
+  public readonly allowsLocalDidRecord = false
+
   public async resolve(agentContext: AgentContext, did: string): Promise<DidResolutionResult> {
     const didDocumentMetadata = {}
 

--- a/packages/core/src/modules/dids/methods/key/KeyDidResolver.ts
+++ b/packages/core/src/modules/dids/methods/key/KeyDidResolver.ts
@@ -12,6 +12,12 @@ export class KeyDidResolver implements DidResolver {
    */
   public readonly allowsCaching = false
 
+  /**
+   * Easier to calculate for resolving than serving the local did document. Record also doesn't
+   * have a did document
+   */
+  public readonly allowsLocalDidRecord = false
+
   public async resolve(agentContext: AgentContext, did: string): Promise<DidResolutionResult> {
     const didDocumentMetadata = {}
 

--- a/packages/core/src/modules/dids/methods/peer/PeerDidResolver.ts
+++ b/packages/core/src/modules/dids/methods/peer/PeerDidResolver.ts
@@ -19,6 +19,12 @@ export class PeerDidResolver implements DidResolver {
    */
   public readonly allowsCaching = false
 
+  /**
+   * Did peer records are often server from local did doucment, but it's easier to handle it in
+   * the peer did resolver.
+   */
+  public readonly allowsLocalDidRecord = false
+
   public async resolve(agentContext: AgentContext, did: string): Promise<DidResolutionResult> {
     const didRepository = agentContext.dependencyManager.resolve(DidRepository)
 

--- a/packages/core/src/modules/dids/methods/web/WebDidResolver.ts
+++ b/packages/core/src/modules/dids/methods/web/WebDidResolver.ts
@@ -12,6 +12,7 @@ export class WebDidResolver implements DidResolver {
   public readonly supportedMethods
 
   public readonly allowsCaching = true
+  public readonly allowsLocalDidRecord = true
 
   // FIXME: Would be nice if we don't have to provide a did resolver instance
   private _resolverInstance = new Resolver()

--- a/packages/core/src/modules/dids/services/DidRegistrarService.ts
+++ b/packages/core/src/modules/dids/services/DidRegistrarService.ts
@@ -15,14 +15,22 @@ import { inject, injectable } from '../../../plugins'
 import { DidsModuleConfig } from '../DidsModuleConfig'
 import { tryParseDid } from '../domain/parse'
 
+import { DidResolverService } from './DidResolverService'
+
 @injectable()
 export class DidRegistrarService {
   private logger: Logger
   private didsModuleConfig: DidsModuleConfig
+  private didResolverService: DidResolverService
 
-  public constructor(@inject(InjectionSymbols.Logger) logger: Logger, didsModuleConfig: DidsModuleConfig) {
+  public constructor(
+    @inject(InjectionSymbols.Logger) logger: Logger,
+    didsModuleConfig: DidsModuleConfig,
+    didResolverService: DidResolverService
+  ) {
     this.logger = logger
     this.didsModuleConfig = didsModuleConfig
+    this.didResolverService = didResolverService
   }
 
   public async create<CreateOptions extends DidCreateOptions = DidCreateOptions>(
@@ -110,6 +118,9 @@ export class DidRegistrarService {
       }
     }
 
+    // Invalidate cache before updating
+    await this.didResolverService.invalidateCacheForDid(agentContext, options.did)
+
     return await registrar.update(agentContext, options)
   }
 
@@ -146,6 +157,9 @@ export class DidRegistrarService {
         },
       }
     }
+
+    // Invalidate cache before deactivating
+    await this.didResolverService.invalidateCacheForDid(agentContext, options.did)
 
     return await registrar.deactivate(agentContext, options)
   }

--- a/packages/core/src/modules/dids/services/__tests__/DidRegistrarService.test.ts
+++ b/packages/core/src/modules/dids/services/__tests__/DidRegistrarService.test.ts
@@ -1,4 +1,5 @@
 import type { DidDocument, DidRegistrar } from '../../domain'
+import type { DidResolverService } from '../DidResolverService'
 
 import { getAgentConfig, getAgentContext, mockFunction } from '../../../../../tests/helpers'
 import { DidsModuleConfig } from '../../DidsModuleConfig'
@@ -14,11 +15,16 @@ const didRegistrarMock = {
   deactivate: jest.fn(),
 } as DidRegistrar
 
+const didResolverMock = {
+  invalidateCacheForDid: jest.fn(),
+} as unknown as DidResolverService
+
 const didRegistrarService = new DidRegistrarService(
   agentConfig.logger,
   new DidsModuleConfig({
     registrars: [didRegistrarMock],
-  })
+  }),
+  didResolverMock
 )
 
 describe('DidResolverService', () => {
@@ -119,6 +125,7 @@ describe('DidResolverService', () => {
       const result = await didRegistrarService.update(agentContext, { did: 'did:key:xxxx', didDocument })
       expect(result).toEqual(returnValue)
 
+      expect(didResolverMock.invalidateCacheForDid).toHaveBeenCalledTimes(1)
       expect(didRegistrarMock.update).toHaveBeenCalledTimes(1)
       expect(didRegistrarMock.update).toHaveBeenCalledWith(agentContext, { did: 'did:key:xxxx', didDocument })
     })
@@ -170,6 +177,7 @@ describe('DidResolverService', () => {
       const result = await didRegistrarService.deactivate(agentContext, { did: 'did:key:xxxx' })
       expect(result).toEqual(returnValue)
 
+      expect(didResolverMock.invalidateCacheForDid).toHaveBeenCalledTimes(1)
       expect(didRegistrarMock.deactivate).toHaveBeenCalledTimes(1)
       expect(didRegistrarMock.deactivate).toHaveBeenCalledWith(agentContext, { did: 'did:key:xxxx' })
     })

--- a/packages/core/src/modules/dids/types.ts
+++ b/packages/core/src/modules/dids/types.ts
@@ -13,6 +13,18 @@ export interface DidResolutionOptions extends DIDResolutionOptions {
   useCache?: boolean
 
   /**
+   * Whether to resolve the did from a local created did document in a DidRecord.
+   * Cache has precendence over local records, as they're often fater. Records
+   * served from DidRecords will not be added to the cache.
+   *
+   * The resolver must have enabled `allowsLocalDidRecord` (default false) to use this
+   * feature.
+   *
+   * @default true
+   */
+  useLocalCreatedDidRecord?: boolean
+
+  /**
    * Whether to persist the did document in the cache.
    *
    * @default true
@@ -29,7 +41,16 @@ export interface DidResolutionOptions extends DIDResolutionOptions {
 
 export interface DidResolutionMetadata extends DIDResolutionMetadata {
   message?: string
+
+  /**
+   * Whether the did document was served from the cache
+   */
   servedFromCache?: boolean
+
+  /**
+   * Whether the did document was served from a local did record
+   */
+  servedFromDidRecord?: boolean
 }
 
 export interface DidResolutionResult {

--- a/packages/core/src/modules/dif-presentation-exchange/utils/credentialSelection.ts
+++ b/packages/core/src/modules/dif-presentation-exchange/utils/credentialSelection.ts
@@ -7,7 +7,7 @@ import type {
 import type { IPresentationDefinition, SelectResults, SubmissionRequirementMatch, PEX } from '@sphereon/pex'
 import type { InputDescriptorV1, InputDescriptorV2, SubmissionRequirement } from '@sphereon/pex-models'
 
-import { decodeSdJwt, decodeSdJwtSync, getClaimsSync } from '@sd-jwt/decode'
+import { decodeSdJwtSync, getClaimsSync } from '@sd-jwt/decode'
 import { Rules } from '@sphereon/pex-models'
 import { default as jp } from 'jsonpath'
 

--- a/packages/core/src/modules/vc/jwt-vc/__tests__/W3cJwtCredentialService.test.ts
+++ b/packages/core/src/modules/vc/jwt-vc/__tests__/W3cJwtCredentialService.test.ts
@@ -6,7 +6,7 @@ import { JwaSignatureAlgorithm } from '../../../../crypto/jose/jwa'
 import { getJwkFromKey } from '../../../../crypto/jose/jwk'
 import { CredoError, ClassValidationError } from '../../../../error'
 import { JsonTransformer } from '../../../../utils'
-import { DidJwk, DidKey, DidsModuleConfig } from '../../../dids'
+import { DidJwk, DidKey, DidRepository, DidsModuleConfig } from '../../../dids'
 import { CREDENTIALS_CONTEXT_V1_URL } from '../../constants'
 import { ClaimFormat, W3cCredential, W3cPresentation } from '../../models'
 import { W3cJwtCredentialService } from '../W3cJwtCredentialService'
@@ -29,6 +29,7 @@ const agentContext = getAgentContext({
   registerInstances: [
     [InjectionSymbols.Logger, testLogger],
     [DidsModuleConfig, new DidsModuleConfig()],
+    [DidRepository, {} as unknown as DidRepository],
   ],
   agentConfig: config,
 })

--- a/packages/core/tests/oob.test.ts
+++ b/packages/core/tests/oob.test.ts
@@ -26,7 +26,7 @@ import { JsonEncoder, JsonTransformer } from '../src/utils'
 import { TestMessage } from './TestMessage'
 import { getInMemoryAgentOptions, waitForCredentialRecord } from './helpers'
 
-import { AgentEventTypes, CredoError, AutoAcceptCredential, CredentialState, PeerDidNumAlgo } from '@credo-ts/core'
+import { AgentEventTypes, CredoError, AutoAcceptCredential, CredentialState } from '@credo-ts/core'
 
 const faberAgentOptions = getInMemoryAgentOptions(
   'Faber Agent OOB',

--- a/packages/indy-vdr/src/dids/IndyVdrIndyDidResolver.ts
+++ b/packages/indy-vdr/src/dids/IndyVdrIndyDidResolver.ts
@@ -10,6 +10,7 @@ export class IndyVdrIndyDidResolver implements DidResolver {
   public readonly supportedMethods = ['indy']
 
   public readonly allowsCaching = true
+  public readonly allowsLocalDidRecord = true
 
   public async resolve(agentContext: AgentContext, did: string): Promise<DidResolutionResult> {
     const didDocumentMetadata = {}

--- a/packages/indy-vdr/tests/indy-vdr-indy-did-resolver.e2e.test.ts
+++ b/packages/indy-vdr/tests/indy-vdr-indy-did-resolver.e2e.test.ts
@@ -76,7 +76,9 @@ describe('indy-vdr DID Resolver E2E', () => {
     const { did } = await createDidOnLedger(agent, `did:indy:pool:localtest:${unqualifiedSubmitterDid}`)
 
     // DID created. Now resolve it
-    const didResult = await agent.dids.resolve(did)
+    const didResult = await agent.dids.resolve(did, {
+      useLocalCreatedDidRecord: false,
+    })
     expect(JsonTransformer.toJSON(didResult)).toMatchObject({
       didDocument: {
         '@context': [


### PR DESCRIPTION
It's a bit weird that for DIDs we created we have to resolve them from the ledger quite often. We already introduced using a cache, which mainly resolved the issue where we would resolve a did multiple times in a session. 

This will help with keeping things fast and local when working with did documents locally (e.g. signing credentials, etc..). We also noticed that some blockchains need some time to process did documents, and that it prevents you from already using the key in a did document. So using the local did record can speed things up quite a lot.

We will have to make improvements still to e.g. the cheqd anoncreds resolver as that bypasses this layer (which is good as it needs metadata from the resolver). But there may be some additional optimizations we can do to keep signing completely local (which has significant impact on performance).

In v0.6.0 we can make the property `allowsLocalDidRecord` on a did resolver required. For now it defaults to false (to not break existing logic) and have enabled it for all remote dids (so did:key, and did:jwk, did:peer are always served from the resolver as it's computed a lot of the times)
