### PR TITLE
fix: set created at for anoncreds records

### DIFF
--- a/packages/anoncreds/src/repository/AnonCredsCredentialDefinitionPrivateRecord.ts
+++ b/packages/anoncreds/src/repository/AnonCredsCredentialDefinitionPrivateRecord.ts
@@ -6,6 +6,7 @@ export interface AnonCredsCredentialDefinitionPrivateRecordProps {
   id?: string
   credentialDefinitionId: string
   value: Record<string, unknown>
+  createdAt?: Date
 }
 
 export type DefaultAnonCredsCredentialDefinitionPrivateTags = {
@@ -29,6 +30,7 @@ export class AnonCredsCredentialDefinitionPrivateRecord extends BaseRecord<
       this.id = props.id ?? utils.uuid()
       this.credentialDefinitionId = props.credentialDefinitionId
       this.value = props.value
+      this.createdAt = props.createdAt ?? new Date()
     }
   }
 

--- a/packages/anoncreds/src/repository/AnonCredsCredentialDefinitionRecord.ts
+++ b/packages/anoncreds/src/repository/AnonCredsCredentialDefinitionRecord.ts
@@ -15,6 +15,7 @@ export interface AnonCredsCredentialDefinitionRecordProps {
   credentialDefinitionId: string
   credentialDefinition: AnonCredsCredentialDefinition
   methodName: string
+  createdAt?: Date
 }
 
 export type DefaultAnonCredsCredentialDefinitionTags = {
@@ -52,6 +53,7 @@ export class AnonCredsCredentialDefinitionRecord extends BaseRecord<
 
     if (props) {
       this.id = props.id ?? utils.uuid()
+      this.createdAt = props.createdAt ?? new Date()
       this.credentialDefinitionId = props.credentialDefinitionId
       this.credentialDefinition = props.credentialDefinition
       this.methodName = props.methodName

--- a/packages/anoncreds/src/repository/AnonCredsKeyCorrectnessProofRecord.ts
+++ b/packages/anoncreds/src/repository/AnonCredsKeyCorrectnessProofRecord.ts
@@ -6,6 +6,7 @@ export interface AnonCredsKeyCorrectnessProofRecordProps {
   id?: string
   credentialDefinitionId: string
   value: Record<string, unknown>
+  createdAt?: Date
 }
 
 export type DefaultAnonCredsKeyCorrectnessProofPrivateTags = {
@@ -29,6 +30,7 @@ export class AnonCredsKeyCorrectnessProofRecord extends BaseRecord<
       this.id = props.id ?? utils.uuid()
       this.credentialDefinitionId = props.credentialDefinitionId
       this.value = props.value
+      this.createdAt = props.createdAt ?? new Date()
     }
   }
 

--- a/packages/anoncreds/src/repository/AnonCredsRevocationRegistryDefinitionRecord.ts
+++ b/packages/anoncreds/src/repository/AnonCredsRevocationRegistryDefinitionRecord.ts
@@ -8,6 +8,7 @@ export interface AnonCredsRevocationRegistryDefinitionRecordProps {
   id?: string
   revocationRegistryDefinitionId: string
   revocationRegistryDefinition: AnonCredsRevocationRegistryDefinition
+  createdAt?: Date
 }
 
 export type DefaultAnonCredsRevocationRegistryDefinitionTags = {
@@ -33,6 +34,7 @@ export class AnonCredsRevocationRegistryDefinitionRecord extends BaseRecord<
       this.id = props.id ?? utils.uuid()
       this.revocationRegistryDefinitionId = props.revocationRegistryDefinitionId
       this.revocationRegistryDefinition = props.revocationRegistryDefinition
+      this.createdAt = props.createdAt ?? new Date()
     }
   }
 

--- a/packages/anoncreds/src/repository/AnonCredsSchemaRecord.ts
+++ b/packages/anoncreds/src/repository/AnonCredsSchemaRecord.ts
@@ -11,6 +11,7 @@ export interface AnonCredsSchemaRecordProps {
   schemaId: string
   schema: AnonCredsSchema
   methodName: string
+  createdAt?: Date
 }
 
 export type DefaultAnonCredsSchemaTags = {
@@ -48,6 +49,7 @@ export class AnonCredsSchemaRecord extends BaseRecord<
 
     if (props) {
       this.id = props.id ?? utils.uuid()
+      this.createdAt = props.createdAt ?? new Date()
       this.schema = props.schema
       this.schemaId = props.schemaId
       this.methodName = props.methodName


### PR DESCRIPTION
In testing some migrations internally we noticed that anoncreds records did not have createdAt properties (even though the types do have it).

This fixes it for new records, but we probably need to do a migration for 0.6 -- setting it to updateAt (very low chance it will be set as most anoncreds records are static), and otherwise to the current time. 