### PR TITLE
fix(oob): only reuse connection if enabled

### DIFF
--- a/packages/core/src/modules/oob/OutOfBandApi.ts
+++ b/packages/core/src/modules/oob/OutOfBandApi.ts
@@ -618,7 +618,7 @@ export class OutOfBandApi {
       return { outOfBandRecord, connectionRecord }
     } else if (messages) {
       this.logger.debug('Out of band message contains only request messages.')
-      if (existingConnection) {
+      if (existingConnection && reuseConnection) {
         this.logger.debug('Connection already exists.', { connectionId: existingConnection.id })
         await this.emitWithConnection(outOfBandRecord, existingConnection, messages)
       } else {


### PR DESCRIPTION
If only messages were attached and an existing connection, but reuseConnection was false, it would still use the existing connection.
