### PR TITLE
ci: update indy-pool image

### DIFF
--- a/network/indy-pool.dockerfile
+++ b/network/indy-pool.dockerfile
@@ -1,48 +1,9 @@
-FROM ubuntu:16.04
+FROM bcgovimages/von-image:node-1.12-6
 
-ARG uid=1000
+USER root
 
 # Install environment
-RUN apt-get update -y && apt-get install -y \
-	git \
-	wget \
-	python3.5 \
-	python3-pip \
-	python-setuptools \
-	python3-nacl \
-	apt-transport-https \
-	ca-certificates \
-	supervisor \
-	gettext-base \
-	software-properties-common
-
-RUN pip3 install -U \
-	pip==9.0.3 \
-	setuptools
-
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys CE7709D068DB5E88 || \
-	apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys CE7709D068DB5E88
-ARG indy_stream=stable
-RUN echo "deb https://repo.sovrin.org/deb xenial $indy_stream" >> /etc/apt/sources.list
-RUN add-apt-repository "deb https://repo.sovrin.org/sdk/deb xenial $indy_stream"
-
-RUN useradd -ms /bin/bash -u $uid indy
-
-ARG indy_plenum_ver=1.12.1
-ARG indy_node_ver=1.12.1
-ARG python3_indy_crypto_ver=0.4.5
-ARG indy_crypto_ver=0.4.5
-ARG python3_pyzmq_ver=18.1.0
-
-RUN apt-get update -y && apt-get install -y \
-	python3-pyzmq=${python3_pyzmq_ver} \
-	indy-plenum=${indy_plenum_ver} \
-	indy-node=${indy_node_ver} \
-	python3-indy-crypto=${python3_indy_crypto_ver} \
-	libindy-crypto=${indy_crypto_ver} \
-	vim \
-	libindy \
-	indy-cli
+RUN apt-get update -y && apt-get install -y supervisor
 
 # It is imporatnt the the lines are not indented. Some autformatters
 # Indent the supervisord parameters. THIS WILL BREAK THE SETUP
@@ -90,11 +51,9 @@ stderr_logfile=/tmp/node4.log\n"\
 
 USER indy
 
-RUN awk '{if (index($1, "NETWORK_NAME") != 0) {print("NETWORK_NAME = \"sandbox\"")} else print($0)}' /etc/indy/indy_config.py> /tmp/indy_config.py
-RUN mv /tmp/indy_config.py /etc/indy/indy_config.py
+COPY --chown=indy:indy network/indy_config.py /etc/indy/indy_config.py
 
 ARG pool_ip=127.0.0.1
-
 RUN generate_indy_pool_transactions --nodes 4 --clients 5 --nodeNum 1 2 3 4 --ips="$pool_ip,$pool_ip,$pool_ip,$pool_ip"
 
 COPY network/add-did.sh /usr/bin/add-did
@@ -105,4 +64,4 @@ COPY network/indy-cli-config.json /etc/indy/indy-cli-config.json
 
 EXPOSE 9701 9702 9703 9704 9705 9706 9707 9708
 
-CMD ["/usr/bin/supervisord"] 
+CMD ["/usr/bin/supervisord"]


### PR DESCRIPTION
Recently, CI started failing in E2E tests due to some missing dependencies. Here we are updating indy-pool image to the latest one by BC Gov, that is more up to date and seems to work great for our purposes.