### PR TITLE
fix: unqualified indy revRegDefId in migration

### DIFF
--- a/packages/anoncreds/src/models/exchange.ts
+++ b/packages/anoncreds/src/models/exchange.ts
@@ -52,6 +52,8 @@ export interface AnonCredsCredential {
   values: Record<string, AnonCredsCredentialValue>
   signature: unknown
   signature_correctness_proof: unknown
+  rev_reg?: unknown
+  witness?: unknown
 }
 
 export interface AnonCredsProof {

--- a/packages/anoncreds/src/updates/0.4-0.5/__tests__/w3cCredentialRecordMigration.test.ts
+++ b/packages/anoncreds/src/updates/0.4-0.5/__tests__/w3cCredentialRecordMigration.test.ts
@@ -294,7 +294,7 @@ async function testMigration(
   const anonCredsRecord = new AnonCredsCredentialRecord({
     credential: {
       schema_id: schemaId,
-      cred_def_id: credentialDefinitionState.credentialDefinitionId,
+      cred_def_id: credentialDefinitionId,
       values: {
         name: {
           raw: 'John',

--- a/packages/anoncreds/src/updates/0.4-0.5/__tests__/w3cCredentialRecordMigration.test.ts
+++ b/packages/anoncreds/src/updates/0.4-0.5/__tests__/w3cCredentialRecordMigration.test.ts
@@ -149,6 +149,16 @@ describe('0.4-0.5 | AnonCredsRecord', () => {
       })
     })
 
+    it('revocable credential with did:indy (sovrin) identifier', async () => {
+      await testMigration(agent, {
+        issuerId: 'did:indy:sovrin:7Tqg6BwSSWapxgUDm9KKgg',
+        schemaIssuerId: 'did:indy:sovrin:7Tqg6BwSSWapxgUDm9KKgf',
+        schemaId: 'did:indy:sovrin:LjgpST2rjsoxYegQDRm7EL/anoncreds/v0/SCHEMA/Employee Credential/1.0.0',
+        indyNamespace: 'sovrin',
+        revocable: true,
+      })
+    })
+
     it('credential with unqualified did:indy (bcovrin:test) identifiers', async () => {
       await testMigration(agent, {
         issuerId: getUnQualifiedDidIndyDid('did:indy:bcovrin:test:SDqTzbVuCowusqGBNbNDjH'),
@@ -157,6 +167,18 @@ describe('0.4-0.5 | AnonCredsRecord', () => {
           'did:indy:bcovrin:test:SDqTzbVuCowusqGBNbNDjG/anoncreds/v0/SCHEMA/Employee Credential/1.0.0'
         ),
         indyNamespace: 'bcovrin:test',
+      })
+    })
+
+    it('revocable credential with unqualified did:indy (bcovrin:test) identifiers', async () => {
+      await testMigration(agent, {
+        issuerId: getUnQualifiedDidIndyDid('did:indy:bcovrin:test:SDqTzbVuCowusqGBNbNDjH'),
+        schemaIssuerId: getUnQualifiedDidIndyDid('did:indy:bcovrin:test:SDqTzbVuCowusqGBNbNDjG'),
+        schemaId: getUnQualifiedDidIndyDid(
+          'did:indy:bcovrin:test:SDqTzbVuCowusqGBNbNDjG/anoncreds/v0/SCHEMA/Employee Credential/1.0.0'
+        ),
+        indyNamespace: 'bcovrin:test',
+        revocable: true,
       })
     })
 
@@ -196,15 +218,16 @@ async function testMigration(
     schemaId: string
     indyNamespace?: string
     shouldBeInCache?: 'indy' | 'sov'
+    revocable?: boolean
   }
 ) {
-  const { issuerId, schemaIssuerId, schemaId, indyNamespace } = options
+  const { issuerId, schemaIssuerId, schemaId, indyNamespace, revocable } = options
 
-  const registry = await agentContext.dependencyManager
+  const registry = agentContext.dependencyManager
     .resolve(AnonCredsRegistryService)
     .getRegistryForIdentifier(agentContext, issuerId)
 
-  const registerCredentialDefinitionReturn = await registry.registerCredentialDefinition(agentContext, {
+  const { credentialDefinitionState } = await registry.registerCredentialDefinition(agentContext, {
     credentialDefinition: {
       schemaId: indyNamespace ? getQualifiedDidIndyDid(schemaId, indyNamespace) : schemaId,
       type: 'CL',
@@ -229,13 +252,49 @@ async function testMigration(
     options: {},
   })
 
-  if (!registerCredentialDefinitionReturn.credentialDefinitionState.credentialDefinitionId)
+  if (!credentialDefinitionState.credentialDefinitionId)
     throw new CredoError('Registering Credential Definition Failed')
+
+  // We'll use unqualified form in case the inputs are unqualified as well
+  const credentialDefinitionId =
+    indyNamespace && isUnqualifiedIndyDid(issuerId)
+      ? getUnQualifiedDidIndyDid(credentialDefinitionState.credentialDefinitionId)
+      : credentialDefinitionState.credentialDefinitionId
+  let revocationRegistryDefinitionId: string | undefined
+
+  if (revocable) {
+    const { revocationRegistryDefinitionState } = await registry.registerRevocationRegistryDefinition(agentContext, {
+      revocationRegistryDefinition: {
+        credDefId: credentialDefinitionState.credentialDefinitionId,
+        issuerId: indyNamespace ? getQualifiedDidIndyDid(issuerId, indyNamespace) : issuerId,
+        revocDefType: 'CL_ACCUM',
+        value: {
+          publicKeys: {
+            accumKey: {
+              z: 'ab81257c-be63-4051-9e21-c7d384412f64',
+            },
+          },
+          maxCredNum: 100,
+          tailsHash: 'ab81257c-be63-4051-9e21-c7d384412f64',
+          tailsLocation: 'http://localhost:7200/tails',
+        },
+        tag: 'TAG',
+      },
+      options: {},
+    })
+    if (!revocationRegistryDefinitionState.revocationRegistryDefinitionId)
+      throw new CredoError('Registering Revocation Registry Definition Failed')
+
+    revocationRegistryDefinitionId =
+      indyNamespace && isUnqualifiedIndyDid(issuerId)
+        ? getUnQualifiedDidIndyDid(revocationRegistryDefinitionState.revocationRegistryDefinitionId)
+        : revocationRegistryDefinitionState.revocationRegistryDefinitionId
+  }
 
   const anonCredsRecord = new AnonCredsCredentialRecord({
     credential: {
       schema_id: schemaId,
-      cred_def_id: registerCredentialDefinitionReturn.credentialDefinitionState.credentialDefinitionId,
+      cred_def_id: credentialDefinitionState.credentialDefinitionId,
       values: {
         name: {
           raw: 'John',
@@ -256,10 +315,23 @@ async function testMigration(
         se: '22707379000451320101568757017184696744124237924783723059712360528872398590682272715197914336834321599243107036831239336605987281577690130807752876870302232265860540101807563741012022740942625464987934377354684266599492895835685698819662114798915664525092894122648542269399563759087759048742378622062870244156257780544523627249100818371255142174054148531811440128609220992508274170196108004985441276737673328642493312249112077836369109453214857237693701603680205115444482751700483514317558743227403858290707747986550689265796031162549838465391957776237071049436590886476581821857234951536091662216488995258175202055258',
         c: '86499530658088050169174214946559930902913340880816576251403968391737698128027',
       },
-      rev_reg_id: undefined,
+      rev_reg: revocable
+        ? {
+            accum:
+              '2 1ECC5AB3496DF286013468F9DC94FA57D2E0CB65809130F49493884DA849D88A 2 20F3F79A24E29B3DF958FA5471B68CAF2FBBAF8E3D3A1F8F17BC5E410242A1BE 2 071C3E27F50B72EB048E530E0A07AC87B5578A63678803D009A9D40E5D3E41B8 2 0E9330E77B1A56DE5C70C8D9B02658CF571F4465EA489A7CEA12CFDA1A311AF5 2 095E45DDF417D05FB10933FFC63D474548B7FFFF7888802F07FFFFFF7D07A8A8 1 0000000000000000000000000000000000000000000000000000000000000000',
+          }
+        : undefined,
+      witness: revocable
+        ? {
+            omega:
+              '2 024D139F10D86B41FDFE98064B5794D0AFEE6183192A7CC2007803532F38CDB9 2 0AC11C34FDEDCA60FFD23E4FC37C9FAFB29737990D6B7E81190AA8C1BF654034 2 04CCBF871DA8BAB94769B08CBE777E83994F121F8BE1F64D3DE90EC6E2401EA9 2 1539F896A2C98798624E2AE12A0D2941EE898570BE3F0F40E59928008F95C969 2 095E45DDF417D05FB10933FFC63D474548B7FFFF7888802F07FFFFFF7D07A8A8 1 0000000000000000000000000000000000000000000000000000000000000000',
+          }
+        : undefined,
+
+      rev_reg_id: revocable ? revocationRegistryDefinitionId : undefined,
     },
     credentialId: 'myCredentialId',
-    credentialRevocationId: undefined,
+    credentialRevocationId: revocable ? '1' : undefined,
     linkSecretId: 'linkSecretId',
     issuerId,
     schemaIssuerId,
@@ -286,6 +358,13 @@ async function testMigration(
         credentialRecordType: 'anoncreds',
       },
     ],
+    tags: {
+      credentialDefinitionId,
+      issuerId,
+      revocationRegistryId: revocationRegistryDefinitionId,
+      schemaId,
+      schemaIssuerId,
+    },
   })
 
   mockFunction(credentialExchangeRepo.findByQuery).mockResolvedValue([initialCredentialExchangeRecord])
@@ -333,6 +412,16 @@ async function testMigration(
       credentials: [{ credentialRecordType: 'w3c', credentialRecordId: w3cCredentialRecord.id }],
     })
   )
+
+  if (revocable) {
+    // TODO
+    expect(credentialExchangeRepo.update).toHaveBeenCalledWith(
+      agent.context,
+      expect.objectContaining({
+        credentials: [{ credentialRecordType: 'w3c', credentialRecordId: w3cCredentialRecord.id }],
+      })
+    )
+  }
 
   if (unqualifiedDidIndyDid && options.shouldBeInCache) {
     expect(inMemoryLruCache.get).toHaveReturnedWith({ indyNamespace })


### PR DESCRIPTION
Sadly, the fix done in 0.5.3 for Indy credentials migration was not enough for some Indy revocable credentials, since it is failing to apply qualified/unqualified revocation registry identifier tags into Credential Exchange record and, therefore, not effectively updating its bindings to the W3C credential.

This happens, for instance, when migrating from 0.4.2 to 0.5.3 the credentials received in [BCGov Showcase](https://digital.gov.bc.ca/digital-trust/showcase/) and attempting to delete the credentials associated to a credential exchange. 

Fixes #1882

cc @wadeking98 @bryce-mcmath 