### PR TITLE
fix: export ParsedMessageType

### DIFF
--- a/.changeset/big-baboons-poke.md
+++ b/.changeset/big-baboons-poke.md
@@ -1,0 +1,5 @@
+---
+'@credo-ts/core': patch
+---
+
+Fix a build issue where the types would reference source code not available in the published NPM package

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -80,7 +80,12 @@ export * from './logger'
 export * from './error'
 export * from './wallet/error'
 export { VersionString } from './utils/version'
-export { parseMessageType, IsValidMessageType, replaceLegacyDidSovPrefix } from './utils/messageType'
+export {
+  type ParsedMessageType,
+  parseMessageType,
+  IsValidMessageType,
+  replaceLegacyDidSovPrefix,
+} from './utils/messageType'
 export type { Constructor, Constructable } from './utils/mixins'
 export * from './agent/Events'
 export * from './crypto'


### PR DESCRIPTION
this should fix the issue that was raised in the Discord.

I think it would be interesting to look at supporting ESM soon, as more and more bundlers / tools are supporting it and it can help us with a bit more 'stable' builds as we have to do less transforming, and thus TS will mostly strip types, rather than transform the imports to requires.

