### PR TITLE
fix: express import in react native

### DIFF
--- a/.changeset/rude-kangaroos-tease.md
+++ b/.changeset/rude-kangaroos-tease.md
@@ -1,0 +1,5 @@
+---
+"@credo-ts/openid4vc": patch
+---
+
+Fix an issue where `express` was being bundled in React Native applications even though the `OpenId4VcIssuerModule` and `OpenId4VcVerifierModule` were not used, causing runtime errors.

--- a/packages/openid4vc/src/shared/router/express.native.ts
+++ b/packages/openid4vc/src/shared/router/express.native.ts
@@ -1,0 +1,5 @@
+export function importExpress() {
+  throw new Error(
+    "Express cannot be imported in React Native. This is probably because you are trying to use the 'OpenId4VcIssuerModule' or the 'OpenId4VcVerifierModule'."
+  )
+}


### PR DESCRIPTION
Custom express.native.ts file will prevent React Native from bundling the `express` dependency. If at runtime express is imported it will throw an error, this will only be the case if you try to use the issuer or verifier modules in React Native (which are not supported in RN)

Fixes #1943 