### PR TITLE
fix: check handshake protocols array is not empty

### DIFF
--- a/.changeset/pink-icons-hope.md
+++ b/.changeset/pink-icons-hope.md
@@ -1,0 +1,5 @@
+---
+'@credo-ts/core': patch
+---
+
+Treat an empty received handshake_protocols array as undefined

--- a/packages/core/src/modules/oob/OutOfBandApi.ts
+++ b/packages/core/src/modules/oob/OutOfBandApi.ts
@@ -557,7 +557,7 @@ export class OutOfBandApi {
           `Connection already exists and reuse is enabled. Reusing an existing connection with ID ${existingConnection.id}.`
         )
 
-        if (!messages) {
+        if (!messages || messages?.length === 0) {
           this.logger.debug('Out of band message does not contain any request messages.')
           const isHandshakeReuseSuccessful = await this.handleHandshakeReuse(outOfBandRecord, existingConnection)
 
@@ -594,7 +594,7 @@ export class OutOfBandApi {
         })
       }
 
-      if (messages) {
+      if (messages && messages.length > 0) {
         this.logger.debug('Out of band message contains request messages.')
         if (connectionRecord.isReady) {
           await this.emitWithConnection(outOfBandRecord, connectionRecord, messages)

--- a/packages/core/src/modules/oob/OutOfBandApi.ts
+++ b/packages/core/src/modules/oob/OutOfBandApi.ts
@@ -548,7 +548,7 @@ export class OutOfBandApi {
 
     await this.outOfBandService.updateState(this.agentContext, outOfBandRecord, OutOfBandState.PrepareResponse)
 
-    if (handshakeProtocols) {
+    if (handshakeProtocols && handshakeProtocols.length > 0) {
       this.logger.debug('Out of band message contains handshake protocols.')
 
       let connectionRecord


### PR DESCRIPTION
This is related to https://github.com/bcgov/vc-authn-oidc/issues/583, where apparently ACA-Py is returning a present but empty handshake_protocols array in connection-less use case. I cannot think of a valid use case for an empty array so I think it is correct to consider it as undefined if it comes like that.