### PR TITLE
fix: add v13 param to createIssuer

### DIFF
--- a/packages/openid4vc/package.json
+++ b/packages/openid4vc/package.json
@@ -27,10 +27,10 @@
   },
   "dependencies": {
     "@credo-ts/core": "workspace:*",
-    "@sphereon/did-auth-siop": "^0.15.0",
-    "@sphereon/oid4vci-client": "^0.14.0",
-    "@sphereon/oid4vci-common": "^0.14.0",
-    "@sphereon/oid4vci-issuer": "^0.14.0",
+    "@sphereon/did-auth-siop": "0.15.1-next.4",
+    "@sphereon/oid4vci-client": "0.15.1-next.4",
+    "@sphereon/oid4vci-common": "0.15.1-next.4",
+    "@sphereon/oid4vci-issuer": "0.15.1-next.4",
     "@sphereon/ssi-types": "0.26.1-next.132",
     "class-transformer": "^0.5.1",
     "rxjs": "^7.8.0"

--- a/packages/openid4vc/src/openid4vc-issuer/OpenId4VcIssuerServiceOptions.ts
+++ b/packages/openid4vc/src/openid4vc-issuer/OpenId4VcIssuerServiceOptions.ts
@@ -1,4 +1,8 @@
-import type { OpenId4VcIssuanceSessionRecord } from './repository'
+import type {
+  OpenId4VcIssuanceSessionRecord,
+  OpenId4VcIssuerRecordCredentialConfigurationsSupportedProps,
+  OpenId4VcIssuerRecordCredentialSupportedProps,
+} from './repository'
 import type {
   OpenId4VcCredentialHolderBinding,
   OpenId4VciCredentialConfigurationsSupported,
@@ -34,6 +38,7 @@ export type OpenId4VcIssuerMetadata = {
 
   issuerDisplay?: OpenId4VciIssuerMetadataDisplay[]
   credentialsSupported: OpenId4VciCredentialSupportedWithId[]
+  credentialConfigurationsSupported: OpenId4VciCredentialConfigurationsSupported
 }
 
 export interface OpenId4VciCreateCredentialOfferOptions {
@@ -140,12 +145,11 @@ export interface OpenId4VciSignW3cCredential {
   credential: W3cCredential
 }
 
-export interface OpenId4VciCreateIssuerOptions {
+export type OpenId4VciCreateIssuerOptions = {
   /**
    * Id of the issuer, not the id of the issuer record. Will be exposed publicly
    */
   issuerId?: string
 
-  credentialsSupported: OpenId4VciCredentialSupportedWithId[] | OpenId4VciCredentialConfigurationsSupported
   display?: OpenId4VciIssuerMetadataDisplay[]
-}
+} & (OpenId4VcIssuerRecordCredentialSupportedProps | OpenId4VcIssuerRecordCredentialConfigurationsSupportedProps)

--- a/packages/openid4vc/src/openid4vc-issuer/router/metadataEndpoint.ts
+++ b/packages/openid4vc/src/openid4vc-issuer/router/metadataEndpoint.ts
@@ -2,7 +2,6 @@ import type { OpenId4VcIssuanceRequest } from './requestContext'
 import type { CredentialIssuerMetadata } from '@sphereon/oid4vci-common'
 import type { Router, Response } from 'express'
 
-import { credentialsSupportedV11ToV13 } from '../../shared/issuerMetadataUtils'
 import { getRequestContext, sendErrorResponse } from '../../shared/router'
 import { OpenId4VcIssuerService } from '../OpenId4VcIssuerService'
 
@@ -21,9 +20,7 @@ export function configureIssuerMetadataEndpoint(router: Router) {
           authorization_server: issuerMetadata.authorizationServer,
           authorization_servers: issuerMetadata.authorizationServer ? [issuerMetadata.authorizationServer] : undefined,
           credentials_supported: issuerMetadata.credentialsSupported,
-          credential_configurations_supported:
-            issuer.credentialConfigurationsSupported ??
-            credentialsSupportedV11ToV13(agentContext, issuerMetadata.credentialsSupported),
+          credential_configurations_supported: issuerMetadata.credentialConfigurationsSupported,
           display: issuerMetadata.issuerDisplay,
         } satisfies CredentialIssuerMetadata
 

--- a/packages/openid4vc/src/shared/issuerMetadataUtils.ts
+++ b/packages/openid4vc/src/shared/issuerMetadataUtils.ts
@@ -5,7 +5,7 @@ import type {
   OpenId4VciCredentialSupported,
 } from './models'
 import type { AgentContext, JwaSignatureAlgorithm } from '@credo-ts/core'
-import type { CredentialOfferFormat, KeyProofType, ProofType } from '@sphereon/oid4vci-common'
+import type { CredentialOfferFormat } from '@sphereon/oid4vci-common'
 
 import { CredoError } from '@credo-ts/core'
 
@@ -25,8 +25,19 @@ export function getTypesFromCredentialSupported(
     credentialSupported.format === 'jwt_vc_json' ||
     credentialSupported.format === 'jwt_vc'
   ) {
+    if (!credentialSupported.credential_definition || !Array.isArray(credentialSupported.type)) {
+      throw Error(
+        `Unable to extract types from credentials supported for format ${credentialSupported.format}. credential_definition.type is not defined`
+      )
+    }
+
     return credentialSupported.credential_definition.type
   } else if (credentialSupported.format === 'vc+sd-jwt') {
+    if (!credentialSupported.vct) {
+      throw Error(
+        `Unable to extract types from credentials supported for format ${credentialSupported.format}. vct is not defined`
+      )
+    }
     return credentialSupported.vct ? [credentialSupported.vct] : undefined
   }
 
@@ -50,23 +61,33 @@ export function credentialConfigurationSupportedToCredentialSupported(
     return {
       ...baseConfig,
       format: config.format,
-      credentialSubject: config.credential_definition.credentialSubject,
-      types: config.credential_definition.type ?? [],
+      credentialSubject: config.credential_definition?.credentialSubject,
+      types: config.credential_definition?.type ?? [],
     }
   } else if (config.format === 'ldp_vc' || config.format === 'jwt_vc_json-ld') {
+    if (!config.credential_definition?.['@context']) {
+      throw new Error(
+        `Unable to transform from draft 13 credential configuration to draft 11 credential supported for format ${config.format}. credential_definition.@context is not defined`
+      )
+    }
+
     return {
       ...baseConfig,
       format: config.format,
-      // @ts-expect-error this should exist
       '@context': config.credential_definition['@context'],
       credentialSubject: config.credential_definition.credentialSubject,
-      types: config.credential_definition.type ?? [],
+      types: config.credential_definition.type,
     }
   } else if (config.format === 'vc+sd-jwt') {
+    if (!config.vct) {
+      throw new Error(
+        `Unable to transform from draft 13 credential configuration to draft 11 credential supported for format ${config.format}. vct is not defined`
+      )
+    }
+
     return {
       ...baseConfig,
       format: config.format,
-      // @ts-expect-error keep this for now to allow back and forth conversion
       vct: config.vct,
       claims: config.claims,
     }
@@ -89,14 +110,7 @@ export function credentialSupportedToCredentialConfigurationSupported(
     jwt: {
       proof_signing_alg_values_supported: proofSigningAlgValuesSupported,
     },
-    // These should not be required
-    //cwt: {
-    //proof_signing_alg_values_supported: [],
-    //},
-    //ldp_vp: {
-    //proof_signing_alg_values_supported: [],
-    //},
-  } as Record<KeyProofType, ProofType>
+  } as const
 
   const baseCredentialConfigurationSupported = {
     id: credentialSupported.id,
@@ -126,8 +140,7 @@ export function credentialSupportedToCredentialConfigurationSupported(
       ...baseCredentialConfigurationSupported,
       format: credentialSupported.format,
       credential_definition: {
-        // @ts-expect-error this should exist
-        '@context': credentialSupported['@context'],
+        '@context': credentialSupported['@context'] as string[],
         credentialSubject: credentialSupported.credentialSubject,
         type: credentialSupported.types,
       },
@@ -139,7 +152,6 @@ export function credentialSupportedToCredentialConfigurationSupported(
       vct: credentialSupported.vct,
       id: credentialSupported.id,
       claims: credentialSupported.claims,
-      credential_definition: {},
     }
   }
 
@@ -247,19 +259,4 @@ export function getOfferedCredentialConfigurationsSupported(
   }
 
   return credentialConfigurationsOffered
-}
-
-export const getProofTypesSupported = (agentContext: AgentContext): Record<KeyProofType, ProofType> => {
-  return {
-    jwt: {
-      proof_signing_alg_values_supported: getSupportedJwaSignatureAlgorithms(agentContext) as string[],
-    },
-    // These properties should not be required
-    //cwt: {
-    //  proof_signing_alg_values_supported: [],
-    //},
-    //ldp_vp: {
-    //  proof_signing_alg_values_supported: [],
-    //},
-  } as Record<KeyProofType, ProofType>
 }

--- a/packages/openid4vc/src/shared/issuerMetadataUtils.ts
+++ b/packages/openid4vc/src/shared/issuerMetadataUtils.ts
@@ -25,7 +25,7 @@ export function getTypesFromCredentialSupported(
     credentialSupported.format === 'jwt_vc_json' ||
     credentialSupported.format === 'jwt_vc'
   ) {
-    if (!credentialSupported.credential_definition || !Array.isArray(credentialSupported.type)) {
+    if (!credentialSupported.credential_definition || !Array.isArray(credentialSupported.credential_definition.type)) {
       throw Error(
         `Unable to extract types from credentials supported for format ${credentialSupported.format}. credential_definition.type is not defined`
       )

--- a/packages/openid4vc/tests/openid4vc.e2e.test.ts
+++ b/packages/openid4vc/tests/openid4vc.e2e.test.ts
@@ -190,7 +190,7 @@ describe('OpenId4Vc', () => {
     const issuerTenant2 = await issuer.agent.modules.tenants.getTenantAgent({ tenantId: issuer2.tenantId })
 
     const openIdIssuerTenant1 = await issuerTenant1.modules.openId4VcIssuer.createIssuer({
-      credentialsSupported: {
+      credentialConfigurationsSupported: {
         universityDegree: universityDegreeCredentialConfigurationSupported,
       },
     })
@@ -204,7 +204,19 @@ describe('OpenId4Vc', () => {
         scope: universityDegreeCredentialConfigurationSupported.scope,
       },
     ])
-
+    expect(issuer1Record.credentialConfigurationsSupported).toEqual({
+      universityDegree: {
+        format: 'vc+sd-jwt',
+        cryptographic_binding_methods_supported: ['did:key'],
+        proof_types_supported: {
+          jwt: {
+            proof_signing_alg_values_supported: ['EdDSA'],
+          },
+        },
+        vct: universityDegreeCredentialConfigurationSupported.vct,
+        scope: universityDegreeCredentialConfigurationSupported.scope,
+      },
+    })
     const openIdIssuerTenant2 = await issuerTenant2.modules.openId4VcIssuer.createIssuer({
       credentialsSupported: [universityDegreeCredentialSdJwt2],
     })

--- a/packages/openid4vc/tests/utilsVci.ts
+++ b/packages/openid4vc/tests/utilsVci.ts
@@ -29,14 +29,11 @@ export const universityDegreeCredentialSdJwt = {
 } satisfies OpenId4VciCredentialSupportedWithId
 
 export const universityDegreeCredentialConfigurationSupported = {
-  credential_definition: {},
   format: OpenId4VciCredentialFormatProfile.SdJwtVc,
   scope: 'UniversityDegreeCredential',
   vct: 'UniversityDegreeCredential',
   proof_types_supported: {
     jwt: { proof_signing_alg_values_supported: ['EdDSA'] },
-    cwt: { proof_signing_alg_values_supported: [] },
-    ldp_vp: { proof_signing_alg_values_supported: [] },
   },
   cryptographic_binding_methods_supported: ['did:key'],
 } satisfies OpenId4VciCredentialConfigurationSupported

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -681,17 +681,17 @@ importers:
         specifier: workspace:*
         version: link:../core
       '@sphereon/did-auth-siop':
-        specifier: ^0.15.0
-        version: 0.15.0
+        specifier: 0.15.1-next.4
+        version: 0.15.1-next.4
       '@sphereon/oid4vci-client':
-        specifier: ^0.14.0
-        version: 0.14.0
+        specifier: 0.15.1-next.4
+        version: 0.15.1-next.4
       '@sphereon/oid4vci-common':
-        specifier: ^0.14.0
-        version: 0.14.0
+        specifier: 0.15.1-next.4
+        version: 0.15.1-next.4
       '@sphereon/oid4vci-issuer':
-        specifier: ^0.14.0
-        version: 0.14.0
+        specifier: 0.15.1-next.4
+        version: 0.15.1-next.4
       '@sphereon/ssi-types':
         specifier: 0.26.1-next.132
         version: 0.26.1-next.132
@@ -763,13 +763,13 @@ importers:
     devDependencies:
       react-native:
         specifier: ^0.71.4
-        version: 0.71.19(@babel/core@7.24.9)(@babel/preset-env@7.24.8(@babel/core@7.24.9))(react@18.2.0)
+        version: 0.71.19(@babel/core@7.24.9)(@babel/preset-env@7.24.8(@babel/core@7.24.9))(react@18.3.1)
       react-native-fs:
         specifier: ^2.20.0
-        version: 2.20.0(react-native@0.71.19(@babel/core@7.24.9)(@babel/preset-env@7.24.8(@babel/core@7.24.9))(react@18.2.0))
+        version: 2.20.0(react-native@0.71.19(@babel/core@7.24.9)(@babel/preset-env@7.24.8(@babel/core@7.24.9))(react@18.3.1))
       react-native-get-random-values:
         specifier: ^1.8.0
-        version: 1.11.0(react-native@0.71.19(@babel/core@7.24.9)(@babel/preset-env@7.24.8(@babel/core@7.24.9))(react@18.2.0))
+        version: 1.11.0(react-native@0.71.19(@babel/core@7.24.9)(@babel/preset-env@7.24.8(@babel/core@7.24.9))(react@18.3.1))
       rimraf:
         specifier: ^4.4.0
         version: 4.4.1
@@ -2370,23 +2370,23 @@ packages:
     resolution: {integrity: sha512-kQpk267uxB19X3X2T1mvNMjyvIEonpNSHrMlK5ZaBU6aZxw7wPbpgKJOjHN3+/GPVpXgAV9soVT2oyHpLkLtyw==}
     engines: {node: '>= 8'}
 
-  '@sphereon/did-auth-siop@0.15.0':
-    resolution: {integrity: sha512-3f/anBHOyZYsaRCW3iW8cu4xQ+DfcyyXRpe0cusdYCM03Wgc9tODOBBIQ98Mrq26EUhWZoOdYSX9nYTA9g6CbQ==}
+  '@sphereon/did-auth-siop@0.15.1-next.4':
+    resolution: {integrity: sha512-Rg5O6A0P6uqf/a5o5lrCxt2WGlpzemyHCrkiOjvYAWGxGCxGctpKRVCNgwxDdFpIFCuXICNi0l/lk4iuZ1ofmQ==}
     engines: {node: '>=18'}
 
   '@sphereon/did-uni-client@0.6.3':
     resolution: {integrity: sha512-g7LD7ofbE36slHN7Bhr5dwUrj6t0BuZeXBYJMaVY/pOeL1vJxW1cZHbZqu0NSfOmzyBg4nsYVlgTjyi/Aua2ew==}
 
-  '@sphereon/oid4vci-client@0.14.0':
-    resolution: {integrity: sha512-4QuXPnGI4TBH6YytTBEWSHCMLdTvUnTpTZEVrFM2H/wZxYd+EpCvULX3g6GQtEsDV2svuqH80cZaTv78RSnq2A==}
+  '@sphereon/oid4vci-client@0.15.1-next.4':
+    resolution: {integrity: sha512-HfSD5aa1dTMlx3D5QpEkYwHxbbSnvb8eEmv4xno7b9/WahNp4xmQeP9jxUz9K0VjIYNvAtCROEEbrgEo9F6iQA==}
     engines: {node: '>=18'}
 
-  '@sphereon/oid4vci-common@0.14.0':
-    resolution: {integrity: sha512-AubbtqNTnW5U+RFaiVWR28RsWdsvKnmmLKYsUW7T2Q+mmwHCAVNZhc8BP+JRdxN0cRYC4JVaXiUS797Odfiavg==}
+  '@sphereon/oid4vci-common@0.15.1-next.4':
+    resolution: {integrity: sha512-X5NKqfc59+D+sql3QU91WJrbWHYDL8nfZCUT0X8UCTIcc5ioUlw1rWxv8CG2HUIuNXA2Uf/Nvm/9UZkinELxQQ==}
     engines: {node: '>=18'}
 
-  '@sphereon/oid4vci-issuer@0.14.0':
-    resolution: {integrity: sha512-GImbDB/yesPK7iAD575J1ZNF8bjs4DinrMuLFfXqFPzLeJeyYZf8NgqG0W7KHtS37njNtchGsuGnammHFJl5ZA==}
+  '@sphereon/oid4vci-issuer@0.15.1-next.4':
+    resolution: {integrity: sha512-2C4KlhQY55PcmBHI4CVVHMdP3QntmEUgxoheHw4kRLc5ntsmeLrUkO8ZcwHZybXb981xjboN37v8k01j2jSLcg==}
     engines: {node: '>=18'}
     peerDependencies:
       awesome-qr: ^2.1.5-rc.0
@@ -5956,10 +5956,6 @@ packages:
     resolution: {integrity: sha512-oScf2FqQ9LFVQgA73vr86xl2NaOIX73rh+YFqcOp68CWj56tSfgtGKrEbyhCj0rSijyG9M1CYprTh39fBi5hzA==}
     peerDependencies:
       react: ^16.0.0 || ^17.0.0 || ^18.0.0
-
-  react@18.2.0:
-    resolution: {integrity: sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==}
-    engines: {node: '>=0.10.0'}
 
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
@@ -9793,7 +9789,7 @@ snapshots:
 
   '@sovpro/delimited-stream@1.1.0': {}
 
-  '@sphereon/did-auth-siop@0.15.0':
+  '@sphereon/did-auth-siop@0.15.1-next.4':
     dependencies:
       '@astronautlabs/jsonpath': 1.1.2
       '@sphereon/did-uni-client': 0.6.3
@@ -9820,9 +9816,9 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@sphereon/oid4vci-client@0.14.0':
+  '@sphereon/oid4vci-client@0.15.1-next.4':
     dependencies:
-      '@sphereon/oid4vci-common': 0.14.0
+      '@sphereon/oid4vci-common': 0.15.1-next.4
       '@sphereon/ssi-types': 0.26.1-next.132
       cross-fetch: 3.1.8
       debug: 4.3.5
@@ -9830,7 +9826,7 @@ snapshots:
       - encoding
       - supports-color
 
-  '@sphereon/oid4vci-common@0.14.0':
+  '@sphereon/oid4vci-common@0.15.1-next.4':
     dependencies:
       '@sphereon/ssi-types': 0.26.1-next.132
       cross-fetch: 3.1.8
@@ -9841,9 +9837,9 @@ snapshots:
       - encoding
       - supports-color
 
-  '@sphereon/oid4vci-issuer@0.14.0':
+  '@sphereon/oid4vci-issuer@0.15.1-next.4':
     dependencies:
-      '@sphereon/oid4vci-common': 0.14.0
+      '@sphereon/oid4vci-common': 0.15.1-next.4
       '@sphereon/ssi-types': 0.26.1-next.132
       uuid: 9.0.1
     transitivePeerDependencies:
@@ -14341,16 +14337,16 @@ snapshots:
       - '@babel/preset-env'
       - supports-color
 
-  react-native-fs@2.20.0(react-native@0.71.19(@babel/core@7.24.9)(@babel/preset-env@7.24.8(@babel/core@7.24.9))(react@18.2.0)):
+  react-native-fs@2.20.0(react-native@0.71.19(@babel/core@7.24.9)(@babel/preset-env@7.24.8(@babel/core@7.24.9))(react@18.3.1)):
     dependencies:
       base-64: 0.1.0
-      react-native: 0.71.19(@babel/core@7.24.9)(@babel/preset-env@7.24.8(@babel/core@7.24.9))(react@18.2.0)
+      react-native: 0.71.19(@babel/core@7.24.9)(@babel/preset-env@7.24.8(@babel/core@7.24.9))(react@18.3.1)
       utf8: 3.0.0
 
-  react-native-get-random-values@1.11.0(react-native@0.71.19(@babel/core@7.24.9)(@babel/preset-env@7.24.8(@babel/core@7.24.9))(react@18.2.0)):
+  react-native-get-random-values@1.11.0(react-native@0.71.19(@babel/core@7.24.9)(@babel/preset-env@7.24.8(@babel/core@7.24.9))(react@18.3.1)):
     dependencies:
       fast-base64-decode: 1.0.0
-      react-native: 0.71.19(@babel/core@7.24.9)(@babel/preset-env@7.24.8(@babel/core@7.24.9))(react@18.2.0)
+      react-native: 0.71.19(@babel/core@7.24.9)(@babel/preset-env@7.24.8(@babel/core@7.24.9))(react@18.3.1)
 
   react-native-gradle-plugin@0.71.19: {}
 
@@ -14359,52 +14355,6 @@ snapshots:
       base64-js: 1.5.1
       react-native: 0.71.19(@babel/core@7.24.9)(@babel/preset-env@7.24.8(@babel/core@7.24.9))(react@18.3.1)
     optional: true
-
-  react-native@0.71.19(@babel/core@7.24.9)(@babel/preset-env@7.24.8(@babel/core@7.24.9))(react@18.2.0):
-    dependencies:
-      '@jest/create-cache-key-function': 29.7.0
-      '@react-native-community/cli': 10.2.7(@babel/core@7.24.9)
-      '@react-native-community/cli-platform-android': 10.2.0
-      '@react-native-community/cli-platform-ios': 10.2.5
-      '@react-native/assets': 1.0.0
-      '@react-native/normalize-color': 2.1.0
-      '@react-native/polyfills': 2.0.0
-      abort-controller: 3.0.0
-      anser: 1.4.10
-      ansi-regex: 5.0.1
-      base64-js: 1.5.1
-      deprecated-react-native-prop-types: 3.0.2
-      event-target-shim: 5.0.1
-      invariant: 2.2.4
-      jest-environment-node: 29.7.0
-      jsc-android: 250231.0.0
-      memoize-one: 5.2.1
-      metro-react-native-babel-transformer: 0.73.10(@babel/core@7.24.9)
-      metro-runtime: 0.73.10
-      metro-source-map: 0.73.10
-      mkdirp: 0.5.6
-      nullthrows: 1.1.1
-      pretty-format: 26.6.2
-      promise: 8.3.0
-      react: 18.2.0
-      react-devtools-core: 4.28.5
-      react-native-codegen: 0.71.6(@babel/preset-env@7.24.8(@babel/core@7.24.9))
-      react-native-gradle-plugin: 0.71.19
-      react-refresh: 0.4.3
-      react-shallow-renderer: 16.15.0(react@18.2.0)
-      regenerator-runtime: 0.13.11
-      scheduler: 0.23.2
-      stacktrace-parser: 0.1.10
-      use-sync-external-store: 1.2.2(react@18.2.0)
-      whatwg-fetch: 3.6.20
-      ws: 6.2.3
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/preset-env'
-      - bufferutil
-      - encoding
-      - supports-color
-      - utf-8-validate
 
   react-native@0.71.19(@babel/core@7.24.9)(@babel/preset-env@7.24.8(@babel/core@7.24.9))(react@18.3.1):
     dependencies:
@@ -14457,21 +14407,11 @@ snapshots:
 
   react-refresh@0.4.3: {}
 
-  react-shallow-renderer@16.15.0(react@18.2.0):
-    dependencies:
-      object-assign: 4.1.1
-      react: 18.2.0
-      react-is: 18.3.1
-
   react-shallow-renderer@16.15.0(react@18.3.1):
     dependencies:
       object-assign: 4.1.1
       react: 18.3.1
       react-is: 18.3.1
-
-  react@18.2.0:
-    dependencies:
-      loose-envify: 1.4.0
 
   react@18.3.1:
     dependencies:
@@ -15391,10 +15331,6 @@ snapshots:
 
   url-join@4.0.0:
     optional: true
-
-  use-sync-external-store@1.2.2(react@18.2.0):
-    dependencies:
-      react: 18.2.0
 
   use-sync-external-store@1.2.2(react@18.3.1):
     dependencies:


### PR DESCRIPTION
Small update to the new v13 logic, so that we can also pass `credentialConfigurationsSupported` to the `createIssuer` method in addition to `updateIssuerMetadata`