### PR TITLE
fix: remove key id

### DIFF
--- a/packages/core/src/crypto/Key.ts
+++ b/packages/core/src/crypto/Key.ts
@@ -9,17 +9,9 @@ export class Key {
   public readonly publicKey: Buffer
   public readonly keyType: KeyType
 
-  /**
-   *
-   * the identifier of the key. If not provided in the constructor the base58 encoded public key will be used as the key identifier by default
-   *
-   */
-  public keyId: string
-
-  public constructor(publicKey: Uint8Array, keyType: KeyType, keyId?: string) {
+  public constructor(publicKey: Uint8Array, keyType: KeyType) {
     this.publicKey = Buffer.from(publicKey)
     this.keyType = keyType
-    this.keyId = keyId ?? TypedArrayEncoder.toBase58(this.publicKey)
   }
 
   public static fromPublicKey(publicKey: Uint8Array, keyType: KeyType) {


### PR DESCRIPTION
- Had to remove the `keyId` property on the `Key` class as it was not ready yet. It caused some issues as some places we just infer the key id as the `publicKeyBase58` and because of that, some keys with a custom would not work.
- It is not required for the hardware key as the key id for the record is the `publicKeyBase58`, but for the underlying hardware key in the secure element it will just be a UUID.

When we do a bigger crypto move I would like to bring the custom key id back.