### PR TITLE
fix(openid4vc): v11 metadata type and transformation

### DIFF
--- a/.changeset/heavy-gorillas-draw.md
+++ b/.changeset/heavy-gorillas-draw.md
@@ -1,0 +1,5 @@
+---
+'@credo-ts/openid4vc': patch
+---
+
+fix v11 metadata typing and update v11<->v13 tranformation logic accordingly

--- a/packages/openid4vc/src/openid4vc-holder/OpenId4VcHolderApi.ts
+++ b/packages/openid4vc/src/openid4vc-holder/OpenId4VcHolderApi.ts
@@ -64,7 +64,7 @@ export class OpenId4VcHolderApi {
    * @returns The uniform credential offer payload, the issuer metadata, protocol version, and the offered credentials with metadata.
    */
   public async resolveCredentialOffer(credentialOffer: string) {
-    return await this.openId4VciHolderService.resolveCredentialOffer(credentialOffer)
+    return await this.openId4VciHolderService.resolveCredentialOffer(this.agentContext, credentialOffer)
   }
 
   /**

--- a/packages/openid4vc/src/openid4vc-holder/OpenId4VciHolderService.ts
+++ b/packages/openid4vc/src/openid4vc-holder/OpenId4VciHolderService.ts
@@ -12,7 +12,6 @@ import type {
   OpenId4VciTokenRequestOptions,
 } from './OpenId4VciHolderServiceOptions'
 import type {
-  OpenId4VciCredentialConfigurationsSupported,
   OpenId4VciCredentialConfigurationSupported,
   OpenId4VciCredentialSupported,
   OpenId4VciIssuerMetadata,
@@ -25,8 +24,6 @@ import type {
   OpenIDResponse,
   AuthorizationDetails,
   AuthorizationDetailsJwtVcJson,
-  CredentialIssuerMetadataV1_0_11,
-  CredentialIssuerMetadataV1_0_13,
   AuthorizationDetailsJwtVcJsonLdAndLdpVc,
   AuthorizationDetailsSdJwtVc,
 } from '@sphereon/oid4vci-common'
@@ -66,12 +63,7 @@ import {
 import { CodeChallengeMethod, OpenId4VCIVersion, PARMode, post } from '@sphereon/oid4vci-common'
 
 import { OpenId4VciCredentialFormatProfile } from '../shared'
-import {
-  getTypesFromCredentialSupported,
-  getOfferedCredentials,
-  credentialsSupportedV11ToV13,
-} from '../shared/issuerMetadataUtils'
-import { OpenId4VciCredentialSupportedWithId } from '../shared/models/index'
+import { getTypesFromCredentialSupported, getOfferedCredentials } from '../shared/issuerMetadataUtils'
 import { getSupportedJwaSignatureAlgorithms, isCredentialOfferV1Draft13 } from '../shared/utils'
 
 import { openId4VciSupportedCredentialFormats, OpenId4VciNotificationMetadata } from './OpenId4VciHolderServiceOptions'
@@ -92,7 +84,10 @@ export class OpenId4VciHolderService {
     this.logger = logger
   }
 
-  public async resolveCredentialOffer(credentialOffer: string): Promise<OpenId4VciResolvedCredentialOffer> {
+  public async resolveCredentialOffer(
+    agentContext: AgentContext,
+    credentialOffer: string
+  ): Promise<OpenId4VciResolvedCredentialOffer> {
     const client = await OpenID4VCIClient.fromURI({
       uri: credentialOffer,
       resolveOfferUri: true,
@@ -106,9 +101,7 @@ export class OpenId4VciHolderService {
     }
 
     const metadata = client.endpointMetadata
-    const credentialIssuerMetadata = metadata.credentialIssuerMetadata as
-      | CredentialIssuerMetadataV1_0_11
-      | CredentialIssuerMetadataV1_0_13
+    const credentialIssuerMetadata = metadata.credentialIssuerMetadata as OpenId4VciIssuerMetadata
 
     if (!credentialIssuerMetadata) {
       throw new CredoError(`Could not retrieve issuer metadata from '${metadata.issuer}'`)
@@ -128,10 +121,10 @@ export class OpenId4VciHolderService {
       ? credentialOfferPayload.credential_configuration_ids
       : credentialOfferPayload.credentials
 
-    const offeredCredentials = getOfferedCredentials(
+    const { credentialConfigurationsSupported, credentialsSupported } = getOfferedCredentials(
+      agentContext,
       offeredCredentialsData,
-      (credentialIssuerMetadata.credentials_supported as OpenId4VciCredentialSupportedWithId[] | undefined) ??
-        (credentialIssuerMetadata.credential_configurations_supported as OpenId4VciCredentialConfigurationsSupported)
+      credentialIssuerMetadata.credentials_supported ?? credentialIssuerMetadata.credential_configurations_supported
     )
 
     return {
@@ -139,7 +132,8 @@ export class OpenId4VciHolderService {
         ...metadata,
         credentialIssuerMetadata: credentialIssuerMetadata,
       },
-      offeredCredentials,
+      offeredCredentials: credentialsSupported,
+      offeredCredentialConfigurations: credentialConfigurationsSupported,
       credentialOfferPayload,
       credentialOfferRequestWithBaseUrl: client.credentialOffer,
       version: client.version(),
@@ -315,7 +309,7 @@ export class OpenId4VciHolderService {
     }
   ) {
     const { resolvedCredentialOffer, acceptCredentialOfferOptions } = options
-    const { metadata, version, offeredCredentials } = resolvedCredentialOffer
+    const { metadata, version, offeredCredentialConfigurations } = resolvedCredentialOffer
 
     const { credentialsToRequest, credentialBindingResolver, verifyCredentialStatus } = acceptCredentialOfferOptions
 
@@ -357,24 +351,18 @@ export class OpenId4VciHolderService {
     const receivedCredentials: Array<OpenId4VciCredentialResponse> = []
     let newCNonce: string | undefined
 
-    const credentialsSupportedToRequest =
-      credentialsToRequest
-        ?.map((id) => offeredCredentials.find((credential) => credential.id === id))
-        .filter((c, i): c is OpenId4VciCredentialSupportedWithId => {
-          if (!c) {
-            const offeredCredentialIds = offeredCredentials.map((c) => c.id).join(', ')
-            throw new CredoError(
-              `Credential to request '${credentialsToRequest[i]}' is not present in offered credentials. Offered credentials are ${offeredCredentialIds}`
-            )
-          }
+    const credentialConfigurationToRequest =
+      credentialsToRequest?.map((id, i) => {
+        if (!offeredCredentialConfigurations[id]) {
+          const offeredCredentialIds = Object.keys(offeredCredentialConfigurations).join(', ')
+          throw new CredoError(
+            `Credential to request '${credentialsToRequest[i]}' is not present in offered credentials. Offered credentials are ${offeredCredentialIds}`
+          )
+        }
+        return [id, offeredCredentialConfigurations[id]] as const
+      }) ?? Object.entries(offeredCredentialConfigurations)
 
-          return true
-        }) ?? offeredCredentials
-
-    const offeredCredentialConfigurations = credentialsSupportedV11ToV13(agentContext, credentialsSupportedToRequest)
-    for (const [offeredCredentialId, offeredCredentialConfiguration] of Object.entries(
-      offeredCredentialConfigurations
-    )) {
+    for (const [offeredCredentialId, offeredCredentialConfiguration] of credentialConfigurationToRequest) {
       // Get all options for the credential request (such as which kid to use, the signature algorithm, etc)
       const { credentialBinding, signatureAlgorithm } = await this.getCredentialRequestOptions(agentContext, {
         possibleProofOfPossessionSignatureAlgorithms: possibleProofOfPossessionSigAlgs,
@@ -570,10 +558,8 @@ export class OpenId4VciHolderService {
       }
     }
 
-    // FIXME credentialToRequest.credential_signing_alg_values_supported is only required for v11 compat
     const proofSigningAlgsSupported =
-      credentialToRequest.configuration.proof_types_supported?.jwt?.proof_signing_alg_values_supported ??
-      credentialToRequest.configuration.credential_signing_alg_values_supported
+      credentialToRequest.configuration.proof_types_supported?.jwt?.proof_signing_alg_values_supported
 
     // If undefined, it means the issuer didn't include the cryptographic suites in the metadata
     // We just guess that the first one is supported

--- a/packages/openid4vc/src/openid4vc-holder/OpenId4VciHolderService.ts
+++ b/packages/openid4vc/src/openid4vc-holder/OpenId4VciHolderService.ts
@@ -352,7 +352,7 @@ export class OpenId4VciHolderService {
     let newCNonce: string | undefined
 
     const credentialConfigurationToRequest =
-      credentialsToRequest?.map((id, i) => {
+      credentialsToRequest?.map((id) => {
         if (!offeredCredentialConfigurations[id]) {
           const offeredCredentialIds = Object.keys(offeredCredentialConfigurations).join(', ')
           throw new CredoError(

--- a/packages/openid4vc/src/openid4vc-holder/OpenId4VciHolderService.ts
+++ b/packages/openid4vc/src/openid4vc-holder/OpenId4VciHolderService.ts
@@ -356,7 +356,7 @@ export class OpenId4VciHolderService {
         if (!offeredCredentialConfigurations[id]) {
           const offeredCredentialIds = Object.keys(offeredCredentialConfigurations).join(', ')
           throw new CredoError(
-            `Credential to request '${credentialsToRequest[i]}' is not present in offered credentials. Offered credentials are ${offeredCredentialIds}`
+            `Credential to request '${id}' is not present in offered credentials. Offered credentials are ${offeredCredentialIds}`
           )
         }
         return [id, offeredCredentialConfigurations[id]] as const

--- a/packages/openid4vc/src/openid4vc-holder/OpenId4VciHolderServiceOptions.ts
+++ b/packages/openid4vc/src/openid4vc-holder/OpenId4VciHolderServiceOptions.ts
@@ -3,6 +3,7 @@ import type {
   OpenId4VciCredentialSupportedWithId,
   OpenId4VciIssuerMetadata,
   OpenId4VciCredentialOfferPayload,
+  OpenId4VciCredentialConfigurationsSupported,
 } from '../shared'
 import type { JwaSignatureAlgorithm, KeyType } from '@credo-ts/core'
 import type { VerifiableCredential } from '@credo-ts/core/src/modules/dif-presentation-exchange/models/index'
@@ -56,6 +57,7 @@ export interface OpenId4VciResolvedCredentialOffer {
   credentialOfferRequestWithBaseUrl: CredentialOfferRequestWithBaseUrl
   credentialOfferPayload: OpenId4VciCredentialOfferPayload
   offeredCredentials: OpenId4VciCredentialSupportedWithId[]
+  offeredCredentialConfigurations: OpenId4VciCredentialConfigurationsSupported
   version: OpenId4VCIVersion
 }
 

--- a/packages/openid4vc/src/openid4vc-issuer/__tests__/openid4vc-issuer.test.ts
+++ b/packages/openid4vc/src/openid4vc-issuer/__tests__/openid4vc-issuer.test.ts
@@ -534,7 +534,9 @@ describe('OpenId4VcIssuer', () => {
           userPinRequired: false,
         },
       })
-    ).rejects.toThrow("Offered credential 'invalid id' is not part of credentials_supported of the issuer metadata.")
+    ).rejects.toThrow(
+      "Offered credential 'invalid id' is not part of credentials_supported/credential_configurations_supported of the issuer metadata."
+    )
   })
 
   it('issuing non offered credential errors', async () => {

--- a/packages/openid4vc/src/shared/__tests__/issuerMetadataUtils.test.ts
+++ b/packages/openid4vc/src/shared/__tests__/issuerMetadataUtils.test.ts
@@ -1,0 +1,77 @@
+import type { Wallet } from '@credo-ts/core'
+
+import { KeyType } from '@credo-ts/core'
+
+import { getAgentContext } from '../../../../core/tests'
+import { credentialsSupportedV11ToV13, credentialsSupportedV13ToV11 } from '../issuerMetadataUtils'
+
+const agentContext = getAgentContext({
+  wallet: {
+    supportedKeyTypes: [KeyType.Ed25519, KeyType.P256],
+  } as Wallet,
+})
+
+describe('issuerMetadataUtils', () => {
+  describe('credentialsSupportedV13toV11', () => {
+    test('should correctly transform from v13 to v11 format', () => {
+      expect(
+        credentialsSupportedV13ToV11({
+          'pid-sd-jwt': {
+            scope: 'pid',
+            cryptographic_binding_methods_supported: ['jwk'],
+            credential_signing_alg_values_supported: ['ES256'],
+            proof_types_supported: {
+              jwt: {
+                proof_signing_alg_values_supported: ['ES256'],
+              },
+            },
+            vct: 'urn:eu.europa.ec.eudi:pid:1',
+            format: 'vc+sd-jwt',
+          },
+        })
+      ).toEqual([
+        {
+          id: 'pid-sd-jwt',
+          scope: 'pid',
+          cryptographic_binding_methods_supported: ['jwk'],
+          cryptographic_suites_supported: ['ES256'],
+          vct: 'urn:eu.europa.ec.eudi:pid:1',
+          format: 'vc+sd-jwt',
+        },
+      ])
+    })
+  })
+
+  describe('credentialsSupportedV11toV13', () => {
+    test('should correctly transform from v11 to v13 format', () => {
+      expect(
+        credentialsSupportedV11ToV13(agentContext, [
+          {
+            id: 'pid-sd-jwt',
+            scope: 'pid',
+            cryptographic_binding_methods_supported: ['jwk'],
+            cryptographic_suites_supported: ['ES256'],
+            vct: 'urn:eu.europa.ec.eudi:pid:1',
+            format: 'vc+sd-jwt',
+          },
+        ])
+      ).toEqual({
+        'pid-sd-jwt': {
+          scope: 'pid',
+          cryptographic_binding_methods_supported: ['jwk'],
+          credential_signing_alg_values_supported: ['ES256'],
+          proof_types_supported: {
+            jwt: {
+              proof_signing_alg_values_supported: ['ES256'],
+            },
+          },
+          vct: 'urn:eu.europa.ec.eudi:pid:1',
+          format: 'vc+sd-jwt',
+          order: undefined,
+          display: undefined,
+          claims: undefined,
+        },
+      })
+    })
+  })
+})

--- a/packages/openid4vc/src/shared/models/index.ts
+++ b/packages/openid4vc/src/shared/models/index.ts
@@ -19,12 +19,22 @@ import type {
   TxCode,
 } from '@sphereon/oid4vci-common'
 
-export type OpenId4VciCredentialSupportedWithId = CredentialsSupportedLegacy & { id: string }
-export type OpenId4VciCredentialSupported = CredentialsSupportedLegacy
+export type OpenId4VciCredentialSupportedWithId = OpenId4VciCredentialSupported & { id: string }
+
+// FIXME: https://github.com/Sphereon-Opensource/OID4VC/pull/136
+export type OpenId4VciCredentialSupported = CredentialsSupportedLegacy & { cryptographic_suites_supported?: string[] }
+
 export type OpenId4VciCredentialConfigurationSupported = CredentialConfigurationSupportedV1_0_13
 export type OpenId4VciCredentialConfigurationsSupported = Record<string, OpenId4VciCredentialConfigurationSupported>
 export type OpenId4VciTxCode = TxCode
-export type OpenId4VciIssuerMetadata = CredentialIssuerMetadataV1_0_11 | CredentialIssuerMetadataV1_0_13
+
+// FIXME: https://github.com/Sphereon-Opensource/OID4VC/pull/136
+export type OpenId4VciIssuerMetadataV1Draft11 = Omit<CredentialIssuerMetadataV1_0_11, 'credentials_supported'> & {
+  credentials_supported: OpenId4VciCredentialSupported[]
+}
+export type OpenId4VciIssuerMetadataV1Draft13 = CredentialIssuerMetadataV1_0_13
+
+export type OpenId4VciIssuerMetadata = OpenId4VciIssuerMetadataV1Draft11 | OpenId4VciIssuerMetadataV1Draft13
 export type OpenId4VciIssuerMetadataDisplay = MetadataDisplay
 
 export type OpenId4VciCredentialRequest =


### PR DESCRIPTION
There were some issues in the transformation logic between v11 and v13 metadata. I fixedthe issue and also updated the code to use v13 by default as the v13 format is richer and thus we make sure we won't lose any metadata when transforming from v11 -> 13

Signed-off-by: Timo Glastra <timo@animo.id>