### PR TITLE
fix: resolve undefined credential_definition.type in credentialRequest

### DIFF
--- a/packages/openid4vc/src/openid4vc-issuer/OpenId4VcIssuerService.ts
+++ b/packages/openid4vc/src/openid4vc-issuer/OpenId4VcIssuerService.ts
@@ -468,6 +468,17 @@ export class OpenId4VcIssuerService {
           credentialRequest.format === OpenId4VciCredentialFormatProfile.JwtVcJson &&
           offeredCredential.format === credentialRequest.format
         ) {
+          /*
+            Issue: https://github.com/openwallet-foundation/credo-ts/issues/1963
+            Handling `credentialRequest.types` by checking if `credentialRequest.credential_definition` is not `undefined`.
+            `credentialRequest.credential_definition` requires a `type` attribute which does not currently exist.
+            Therefore, adding the `type` attribute at line 41 in `packages/openid4vc/src/shared/models/index.ts`.
+           */
+
+          credentialRequest.types = credentialRequest.credential_definition
+            ? credentialRequest.credential_definition.type
+            : credentialRequest.types
+
           return equalsIgnoreOrder(offeredCredential.credential_definition.type ?? [], credentialRequest.types)
         } else if (
           credentialRequest.format === OpenId4VciCredentialFormatProfile.JwtVcJsonLd &&

--- a/packages/openid4vc/src/shared/models/index.ts
+++ b/packages/openid4vc/src/shared/models/index.ts
@@ -32,7 +32,7 @@ export type OpenId4VciIssuerMetadata = OpenId4VciIssuerMetadataV1Draft11 | OpenI
 export type OpenId4VciIssuerMetadataDisplay = MetadataDisplay
 
 export type OpenId4VciCredentialRequest =
-  | CredentialRequestJwtVcJson
+  | (CredentialRequestJwtVcJson & { credential_definition: { type: string[] } })
   | CredentialRequestJwtVcJsonLdAndLdpVc
   | CredentialRequestSdJwtVc
 


### PR DESCRIPTION
This fixes the issue reported in (https://github.com/openwallet-foundation/credo-ts/issues/1963).

- Added logic to set `credentialRequest.types` based on `credentialRequest.credential_definition.type` if `credential_definition` is defined.
- This ensures that the `types` attribute is correctly populated from `credential_definition` when available, preventing potential issues with undefined `credential_definition.type`.
- The change is applied at line 41 in `packages/openid4vc/src/shared/models/index.ts`.