### PR TITLE
fix: resolve undefined credential_definition.type in credentialRequest

### DIFF
--- a/packages/openid4vc/src/openid4vc-issuer/OpenId4VcIssuerService.ts
+++ b/packages/openid4vc/src/openid4vc-issuer/OpenId4VcIssuerService.ts
@@ -468,6 +468,17 @@ export class OpenId4VcIssuerService {
           credentialRequest.format === OpenId4VciCredentialFormatProfile.JwtVcJson &&
           offeredCredential.format === credentialRequest.format
         ) {
+          /*
+            Issue: https://github.com/openwallet-foundation/credo-ts/issues/1963
+            Handling `credentialRequest.types` by checking if `credentialRequest.credential_definition` is not `undefined`.
+            `credentialRequest.credential_definition` requires a `type` attribute which does not currently exist.
+            Therefore, adding the `type` attribute at line 41 in `packages/openid4vc/src/shared/models/index.ts`.
+           */
+
+          credentialRequest.types = credentialRequest.credential_definition
+            ? credentialRequest.credential_definition.type
+            : credentialRequest.types
+
           return equalsIgnoreOrder(offeredCredential.credential_definition.type ?? [], credentialRequest.types)
         } else if (
           credentialRequest.format === OpenId4VciCredentialFormatProfile.JwtVcJsonLd &&

--- a/packages/openid4vc/src/openid4vc-issuer/OpenId4VcIssuerService.ts
+++ b/packages/openid4vc/src/openid4vc-issuer/OpenId4VcIssuerService.ts
@@ -468,34 +468,32 @@ export class OpenId4VcIssuerService {
           credentialRequest.format === OpenId4VciCredentialFormatProfile.JwtVcJson &&
           offeredCredential.format === credentialRequest.format
         ) {
-          /*
-            Issue: https://github.com/openwallet-foundation/credo-ts/issues/1963
-            Handling `credentialRequest.types` by checking if `credentialRequest.credential_definition` is not `undefined`.
-            `credentialRequest.credential_definition` requires a `type` attribute which does not currently exist.
-            Therefore, adding the `type` attribute at line 41 in `packages/openid4vc/src/shared/models/index.ts`.
-           */
+          const types =
+            'credential_definition' in credentialRequest
+              ? credentialRequest.credential_definition.type
+              : credentialRequest.types
 
-          credentialRequest.types = credentialRequest.credential_definition
-            ? credentialRequest.credential_definition.type
-            : credentialRequest.types
-
-          return equalsIgnoreOrder(offeredCredential.credential_definition.type ?? [], credentialRequest.types)
+          return equalsIgnoreOrder(offeredCredential.credential_definition.type ?? [], types)
         } else if (
           credentialRequest.format === OpenId4VciCredentialFormatProfile.JwtVcJsonLd &&
           offeredCredential.format === credentialRequest.format
         ) {
-          return equalsIgnoreOrder(
-            offeredCredential.credential_definition.type ?? [],
-            credentialRequest.credential_definition.types
-          )
+          const types =
+            'type' in credentialRequest.credential_definition
+              ? credentialRequest.credential_definition.type
+              : credentialRequest.credential_definition.types
+
+          return equalsIgnoreOrder(offeredCredential.credential_definition.type ?? [], types)
         } else if (
           credentialRequest.format === OpenId4VciCredentialFormatProfile.LdpVc &&
           offeredCredential.format === credentialRequest.format
         ) {
-          return equalsIgnoreOrder(
-            offeredCredential.credential_definition.type ?? [],
-            credentialRequest.credential_definition.types
-          )
+          const types =
+            'type' in credentialRequest.credential_definition
+              ? credentialRequest.credential_definition.type
+              : credentialRequest.credential_definition.types
+
+          return equalsIgnoreOrder(offeredCredential.credential_definition.type ?? [], types)
         } else if (
           credentialRequest.format === OpenId4VciCredentialFormatProfile.SdJwtVc &&
           offeredCredential.format === credentialRequest.format

--- a/packages/openid4vc/src/shared/models/index.ts
+++ b/packages/openid4vc/src/shared/models/index.ts
@@ -32,7 +32,7 @@ export type OpenId4VciIssuerMetadata = OpenId4VciIssuerMetadataV1Draft11 | OpenI
 export type OpenId4VciIssuerMetadataDisplay = MetadataDisplay
 
 export type OpenId4VciCredentialRequest =
-  | CredentialRequestJwtVcJson
+  | (CredentialRequestJwtVcJson & { credential_definition: { type: string[] } })
   | CredentialRequestJwtVcJsonLdAndLdpVc
   | CredentialRequestSdJwtVc
 

--- a/packages/openid4vc/src/shared/models/index.ts
+++ b/packages/openid4vc/src/shared/models/index.ts
@@ -13,10 +13,13 @@ import type {
   CredentialOfferPayloadV1_0_13,
   CredentialRequestJwtVcJson,
   CredentialRequestJwtVcJsonLdAndLdpVc,
+  CredentialRequestJwtVcJsonLdAndLdpVcV1_0_13,
+  CredentialRequestJwtVcJsonV1_0_13,
   CredentialRequestSdJwtVc,
   CredentialsSupportedLegacy,
   MetadataDisplay,
   TxCode,
+  UniformCredentialRequest,
 } from '@sphereon/oid4vci-common'
 
 export type OpenId4VciCredentialSupportedWithId = OpenId4VciCredentialSupported & { id: string }
@@ -31,13 +34,14 @@ export type OpenId4VciIssuerMetadata = OpenId4VciIssuerMetadataV1Draft11 | OpenI
 
 export type OpenId4VciIssuerMetadataDisplay = MetadataDisplay
 
-export type OpenId4VciCredentialRequest =
-  | (CredentialRequestJwtVcJson & { credential_definition: { type: string[] } })
-  | CredentialRequestJwtVcJsonLdAndLdpVc
-  | CredentialRequestSdJwtVc
+export type OpenId4VciCredentialRequest = UniformCredentialRequest
 
-export type OpenId4VciCredentialRequestJwtVcJson = CredentialRequestJwtVcJson
-export type OpenId4VciCredentialRequestJwtVcJsonLdAndLdpVc = CredentialRequestJwtVcJsonLdAndLdpVc
+export type OpenId4VciCredentialRequestJwtVcJson = CredentialRequestJwtVcJson | CredentialRequestJwtVcJsonV1_0_13
+
+export type OpenId4VciCredentialRequestJwtVcJsonLdAndLdpVc =
+  | CredentialRequestJwtVcJsonLdAndLdpVc
+  | CredentialRequestJwtVcJsonLdAndLdpVcV1_0_13
+
 export type OpenId4VciCredentialRequestSdJwtVc = CredentialRequestSdJwtVc
 export type OpenId4VciCredentialOffer = AssertedUniformCredentialOffer
 export type OpenId4VciCredentialOfferPayload = CredentialOfferPayloadV1_0_11 | CredentialOfferPayloadV1_0_13


### PR DESCRIPTION
This fixes the issue reported in ([#1963](https://github.com/openwallet-foundation/credo-ts/issues/1963)).
* Added logic to set credentialRequest.types based on credentialRequest.credential_definition.type if credential_definition is defined.
* This ensures that the types attribute is correctly populated from credential_definition when available, preventing potential issues with undefined credential_definition.type.
* The change is applied at line 41 in packages/openid4vc/src/shared/models/index.ts.