### PR TITLE
fix: 1993 assign satisfiedSubmissions to submissionEntry in `getSubmissionRequirementRulePick`

### DIFF
--- a/packages/core/src/modules/dif-presentation-exchange/utils/credentialSelection.ts
+++ b/packages/core/src/modules/dif-presentation-exchange/utils/credentialSelection.ts
@@ -273,7 +273,7 @@ function getSubmissionRequirementRulePick(
     // if the requirement is satisfied, we only need to return the satisfied submissions
     // however if the requirement is not satisfied, we include all entries so the wallet could
     // render which credentials are missing.
-    submission:
+    submissionEntry:
       satisfiedSubmissions.length >= selectedSubmission.needsCount
         ? satisfiedSubmissions
         : [...satisfiedSubmissions, ...unsatisfiedSubmissions],


### PR DESCRIPTION
Fixes #1993 

The PR adjusts `getSubmissionRequirementRulePick` to assign all `satisfiedSubmissions` to `submissionEntry`, rather than `submission`.

This is a bug fix, but if anyone relies on the `submission` property, this could be seen as a breaking change.