### PR TITLE
fix: Changed condition to check if the revocationRegistryIndex is undefined instead of falsy

### DIFF
--- a/packages/anoncreds/src/formats/AnonCredsCredentialFormatService.ts
+++ b/packages/anoncreds/src/formats/AnonCredsCredentialFormatService.ts
@@ -318,7 +318,7 @@ export class AnonCredsCredentialFormatService implements CredentialFormatService
         revocationRegistryIndex = Number(credentialMetadata.credentialRevocationId)
       }
 
-      if (!revocationRegistryDefinitionId || !revocationRegistryIndex) {
+      if (!revocationRegistryDefinitionId || revocationRegistryIndex === undefined) {
         throw new CredoError(
           'Revocation registry definition id and revocation index are mandatory to issue AnonCreds revocable credentials'
         )


### PR DESCRIPTION
When the index is 0 it also fails which should not happen.