### PR TITLE
fix: duplicate offer being created on issuers side while negotiating offer as a holder

### DIFF
--- a/packages/core/src/modules/credentials/protocol/v2/V2CredentialProtocol.ts
+++ b/packages/core/src/modules/credentials/protocol/v2/V2CredentialProtocol.ts
@@ -186,15 +186,6 @@ export class V2CredentialProtocol<CFs extends CredentialFormatService[] = Creden
 
     // credential record already exists
     if (credentialRecord) {
-      //  This makes sure to associate the connectionId
-      if (!credentialRecord?.connectionId) {
-        await connectionService.matchIncomingMessageToRequestMessageInOutOfBandExchange(messageContext, {
-          expectedConnectionId: credentialRecord?.connectionId,
-        })
-
-        credentialRecord.connectionId = connection?.id
-      }
-
       const proposalCredentialMessage = await didCommMessageRepository.findAgentMessage(messageContext.agentContext, {
         associatedRecordId: credentialRecord.id,
         messageClass: V2ProposeCredentialMessage,
@@ -214,6 +205,15 @@ export class V2CredentialProtocol<CFs extends CredentialFormatService[] = Creden
         lastSentMessage: offerCredentialMessage ?? undefined,
         expectedConnectionId: credentialRecord.connectionId,
       })
+
+      // This makes sure that the sender of the incoming message is authorized to do so.
+      if (!credentialRecord?.connectionId) {
+        await connectionService.matchIncomingMessageToRequestMessageInOutOfBandExchange(messageContext, {
+          expectedConnectionId: credentialRecord?.connectionId,
+        })
+
+        credentialRecord.connectionId = connection?.id
+      }
 
       await this.credentialFormatCoordinator.processProposal(messageContext.agentContext, {
         credentialRecord,

--- a/packages/core/src/modules/credentials/protocol/v2/V2CredentialProtocol.ts
+++ b/packages/core/src/modules/credentials/protocol/v2/V2CredentialProtocol.ts
@@ -177,7 +177,6 @@ export class V2CredentialProtocol<CFs extends CredentialFormatService[] = Creden
     let credentialRecord = await this.findByProperties(messageContext.agentContext, {
       threadId: proposalMessage.threadId,
       role: CredentialRole.Issuer,
-      connectionId: connection?.id,
     })
 
     const formatServices = this.getFormatServicesFromMessage(proposalMessage.formats)

--- a/packages/core/src/modules/credentials/protocol/v2/V2CredentialProtocol.ts
+++ b/packages/core/src/modules/credentials/protocol/v2/V2CredentialProtocol.ts
@@ -186,6 +186,20 @@ export class V2CredentialProtocol<CFs extends CredentialFormatService[] = Creden
 
     // credential record already exists
     if (credentialRecord) {
+      // Assert
+      await connectionService.assertConnectionOrOutOfBandExchange(messageContext, {
+        expectedConnectionId: credentialRecord.connectionId,
+      })
+
+      //  This makes sure to associate the connectionId
+      if (!credentialRecord?.connectionId) {
+        await connectionService.matchIncomingMessageToRequestMessageInOutOfBandExchange(messageContext, {
+          expectedConnectionId: credentialRecord?.connectionId,
+        })
+
+        credentialRecord.connectionId = connection?.id
+      }
+
       const proposalCredentialMessage = await didCommMessageRepository.findAgentMessage(messageContext.agentContext, {
         associatedRecordId: credentialRecord.id,
         messageClass: V2ProposeCredentialMessage,

--- a/packages/core/src/modules/credentials/protocol/v2/V2CredentialProtocol.ts
+++ b/packages/core/src/modules/credentials/protocol/v2/V2CredentialProtocol.ts
@@ -186,11 +186,6 @@ export class V2CredentialProtocol<CFs extends CredentialFormatService[] = Creden
 
     // credential record already exists
     if (credentialRecord) {
-      // Assert
-      await connectionService.assertConnectionOrOutOfBandExchange(messageContext, {
-        expectedConnectionId: credentialRecord.connectionId,
-      })
-
       //  This makes sure to associate the connectionId
       if (!credentialRecord?.connectionId) {
         await connectionService.matchIncomingMessageToRequestMessageInOutOfBandExchange(messageContext, {


### PR DESCRIPTION
## What
- Fixes #2022 

## How
- Initially during processing proposal in cases where an OOB credential is being offered.
- If holder, accepts OOB invitation and negotiates the offer, the connection details are appended on the holders side.
- But for issuer we are unable to update the credential record with the connection details.
- Hence, the issuer considers this credential proposal as a new flow and creates a new credential record with connection details. This causes the flow to break further in the processing when two records against a single threadId are found