### PR TITLE
fix: handling of diddoc content as string

### DIFF
--- a/packages/indy-vdr/src/dids/__tests__/IndyVdrIndyDidResolver.test.ts
+++ b/packages/indy-vdr/src/dids/__tests__/IndyVdrIndyDidResolver.test.ts
@@ -34,7 +34,7 @@ describe('IndyVdrIndyDidResolver', () => {
             did: 'LjgpST2rjsoxYegQDRm7EL',
             verkey: 'E6D1m3eERqCueX4ZgMCY14B4NceAr6XP2HyVqt55gDhu',
             role: 'ENDORSER',
-            diddocContent: didIndyLjgpST2rjsoxYegQDRm7ELdiddocContent,
+            diddocContent: JSON.stringify(didIndyLjgpST2rjsoxYegQDRm7ELdiddocContent),
           }),
         },
       }

--- a/packages/indy-vdr/src/dids/didIndyUtil.ts
+++ b/packages/indy-vdr/src/dids/didIndyUtil.ts
@@ -271,7 +271,16 @@ export async function buildDidDocument(agentContext: AgentContext, pool: IndyVdr
     }
     return builder.build()
   } else {
-    // Combine it with didDoc (TODO: Check if diddocContent is returned as a JSON object or a string)
-    return combineDidDocumentWithJson(builder.build(), nym.diddocContent)
+    // Combine it with didDoc
+    let diddocContent
+    try {
+      diddocContent = JSON.parse(nym.diddocContent) as Record<string, unknown>
+    } catch (error) {
+      agentContext.config.logger.error(
+        `Nym diddocContent is not a valid json string: ${diddocContent}`
+      )
+      throw new IndyVdrError(`Nym diddocContent failed to parse as JSON: ${error}`)
+    }
+    return combineDidDocumentWithJson(builder.build(), diddocContent)
   }
 }

--- a/packages/indy-vdr/src/dids/didIndyUtil.ts
+++ b/packages/indy-vdr/src/dids/didIndyUtil.ts
@@ -276,9 +276,7 @@ export async function buildDidDocument(agentContext: AgentContext, pool: IndyVdr
     try {
       diddocContent = JSON.parse(nym.diddocContent) as Record<string, unknown>
     } catch (error) {
-      agentContext.config.logger.error(
-        `Nym diddocContent is not a valid json string: ${diddocContent}`
-      )
+      agentContext.config.logger.error(`Nym diddocContent is not a valid json string: ${diddocContent}`)
       throw new IndyVdrError(`Nym diddocContent failed to parse as JSON: ${error}`)
     }
     return combineDidDocumentWithJson(builder.build(), diddocContent)

--- a/packages/indy-vdr/src/dids/didSovUtil.ts
+++ b/packages/indy-vdr/src/dids/didSovUtil.ts
@@ -25,7 +25,7 @@ export interface GetNymResponseData {
   verkey: string
   role: string
   alias?: string
-  diddocContent?: Record<string, unknown>
+  diddocContent?: string
 }
 
 export const FULL_VERKEY_REGEX = /^[1-9A-HJ-NP-Za-km-z]{43,44}$/


### PR DESCRIPTION
This PR fixes a TODO item left in the Indy DID Resolution code. nym.diddocContent is in fact a string and not a json object when retrieved from the ledger.