### PR TITLE
fix: return error response to avoid hanging

### DIFF
--- a/packages/openid4vc/src/openid4vc-issuer/router/accessTokenEndpoint.ts
+++ b/packages/openid4vc/src/openid4vc-issuer/router/accessTokenEndpoint.ts
@@ -206,7 +206,7 @@ export function verifyTokenRequest(options: { preAuthorizedCodeExpirationInSecon
       }
     } catch (error) {
       if (error instanceof TokenError) {
-        sendErrorResponse(
+        return sendErrorResponse(
           response,
           agentContext.config.logger,
           error.statusCode,
@@ -214,7 +214,7 @@ export function verifyTokenRequest(options: { preAuthorizedCodeExpirationInSecon
           error.getDescription()
         )
       } else {
-        sendErrorResponse(response, agentContext.config.logger, 400, TokenErrorResponse.invalid_request, error)
+        return sendErrorResponse(response, agentContext.config.logger, 400, TokenErrorResponse.invalid_request, error)
       }
     }
 


### PR DESCRIPTION
This PR updates the access token endpoint so it returns when an error happens, closing the connection. 

This fixes a crash when the end user takes a good while to fetch the credential after creating an offer, triggering a `ERR_HTTP_HEADERS_SENT: Cannot set headers after they are sent to the client` error.

We talked about this before and it was unclear if this change would break anything else but we've been running this successfully for months so I think it's okay.