### PR TITLE
chore: add raw filepath for logo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
   <br />
   <img
     alt="Credo Logo"
-    src="https://github.com/openwallet-foundation/credo-ts/blob/c7886cb8377ceb8ee4efe8d264211e561a75072d/images/credo-logo.png"
+    src="
+https://raw.githubusercontent.com/openwallet-foundation/credo-ts/c7886cb8377ceb8ee4efe8d264211e561a75072d/images/credo-logo.png"
     height="250px"
   />
 </p>


### PR DESCRIPTION
Add the raw file path for the logo

The current path will point to the file in the repository, but not the the path that will return the image to display it. Github itself has some auto correct for this, but when you are referencing the readme from another source, it will fail to load it.