### PR TITLE
fix: Remove unnecessary conditional

### DIFF
--- a/packages/openid4vc/src/openid4vc-verifier/OpenId4VcSiopVerifierService.ts
+++ b/packages/openid4vc/src/openid4vc-verifier/OpenId4VcSiopVerifierService.ts
@@ -643,14 +643,6 @@ export class OpenId4VcSiopVerifierService {
           isValid = verificationResult.isValid
         }
 
-        // FIXME: we throw an error here as there's a bug in sphereon library where they
-        // don't check the returned 'verified' property and only catch errors thrown.
-        // Once https://github.com/Sphereon-Opensource/SIOP-OID4VP/pull/70 is merged we
-        // can remove this.
-        if (!isValid) {
-          throw new CredoError('Presentation verification failed.')
-        }
-
         return {
           verified: isValid,
         }

--- a/packages/openid4vc/src/openid4vc-verifier/OpenId4VcSiopVerifierService.ts
+++ b/packages/openid4vc/src/openid4vc-verifier/OpenId4VcSiopVerifierService.ts
@@ -607,6 +607,7 @@ export class OpenId4VcSiopVerifierService {
         if (!encodedPresentation) throw new CredoError('Did not receive a presentation for verification.')
 
         let isValid: boolean
+        let reason: string | undefined
 
         // TODO: it might be better here to look at the presentation submission to know
         // If presentation includes a ~, we assume it's an SD-JWT-VC
@@ -622,6 +623,7 @@ export class OpenId4VcSiopVerifierService {
           })
 
           isValid = verificationResult.verification.isValid
+          reason = verificationResult.isValid ? undefined : verificationResult.error.message
         } else if (typeof encodedPresentation === 'string') {
           const verificationResult = await this.w3cCredentialService.verifyPresentation(agentContext, {
             presentation: encodedPresentation,
@@ -633,6 +635,7 @@ export class OpenId4VcSiopVerifierService {
           })
 
           isValid = verificationResult.isValid
+          reason = verificationResult.error?.message
         } else {
           const verificationResult = await this.w3cCredentialService.verifyPresentation(agentContext, {
             presentation: JsonTransformer.fromJSON(encodedPresentation, W3cJsonLdVerifiablePresentation),
@@ -641,10 +644,12 @@ export class OpenId4VcSiopVerifierService {
           })
 
           isValid = verificationResult.isValid
+          reason = verificationResult.error?.message
         }
 
         return {
           verified: isValid,
+          reason,
         }
       } catch (error) {
         agentContext.config.logger.warn('Error occurred during verification of presentation', {


### PR DESCRIPTION
Fixes #2075 by removing the obsolete if block, and using the errors thrown by the various verifier functions to establish a `reason` when a presentation isn't valid.