### PR TITLE
fix: add missing parameter in findAllByQuery method in credential api

### DIFF
--- a/packages/core/src/modules/credentials/CredentialsApi.ts
+++ b/packages/core/src/modules/credentials/CredentialsApi.ts
@@ -635,8 +635,8 @@ export class CredentialsApi<CPs extends CredentialProtocol[]> implements Credent
    *
    * @returns List containing all credential records matching specified query paramaters
    */
-  public findAllByQuery(query: Query<CredentialExchangeRecord>) {
-    return this.credentialRepository.findByQuery(this.agentContext, query)
+  public findAllByQuery(query: Query<CredentialExchangeRecord>, queryOptions?: QueryOptions) {
+    return this.credentialRepository.findByQuery(this.agentContext, query, queryOptions)
   }
 
   /**


### PR DESCRIPTION
 ### Summary

- Added missing parameter in `findAllByQuery` method in credential api