### PR TITLE
fix: Anoncreds Offer Attachment Type

### DIFF
--- a/packages/anoncreds/src/formats/AnonCredsCredentialFormatService.ts
+++ b/packages/anoncreds/src/formats/AnonCredsCredentialFormatService.ts
@@ -567,7 +567,7 @@ export class AnonCredsCredentialFormatService implements CredentialFormatService
     // if the proposal has an attachment Id use that, otherwise the generated id of the formats object
     const format = new CredentialFormatSpec({
       attachmentId: attachmentId,
-      format: ANONCREDS_CREDENTIAL,
+      format: ANONCREDS_CREDENTIAL_OFFER,
     })
 
     const offer = await anonCredsIssuerService.createCredentialOffer(agentContext, {

--- a/packages/anoncreds/src/formats/AnonCredsCredentialFormatService.ts
+++ b/packages/anoncreds/src/formats/AnonCredsCredentialFormatService.ts
@@ -114,7 +114,7 @@ export class AnonCredsCredentialFormatService implements CredentialFormatService
       anoncredsFormat.attributes,
       anoncredsFormat.linkedAttachments
     )
-
+ 
     // Set the metadata
     credentialRecord.metadata.set<AnonCredsCredentialMetadata>(AnonCredsCredentialMetadataKey, {
       schemaId: proposal.schemaId,

--- a/packages/anoncreds/src/formats/AnonCredsCredentialFormatService.ts
+++ b/packages/anoncreds/src/formats/AnonCredsCredentialFormatService.ts
@@ -114,7 +114,7 @@ export class AnonCredsCredentialFormatService implements CredentialFormatService
       anoncredsFormat.attributes,
       anoncredsFormat.linkedAttachments
     )
- 
+
     // Set the metadata
     credentialRecord.metadata.set<AnonCredsCredentialMetadata>(AnonCredsCredentialMetadataKey, {
       schemaId: proposal.schemaId,


### PR DESCRIPTION
issue-credential-v2 anoncreds didcomm attachments are sending with `anoncreds/credential@v1.0` format type rather than `anoncreds/credential-offer@v1.0`

spec:
https://github.com/hyperledger/aries-rfcs/blob/main/features/0771-anoncreds-attachments/README.md#credential-offer-format