### PR TITLE
chore: remove abort controller

### DIFF
--- a/.changeset/hip-planes-hunt.md
+++ b/.changeset/hip-planes-hunt.md
@@ -1,0 +1,5 @@
+---
+"@credo-ts/core": minor
+---
+
+Remove dependency on `abort-controller` library. Abort Controller has been supported on all platforms for quite some time already.

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -81,11 +81,6 @@ module.exports = {
             name: 'Buffer',
             message: 'Global buffer is not supported on all platforms. Import buffer from `src/utils/buffer`',
           },
-          {
-            name: 'AbortController',
-            message:
-              "Global AbortController is not supported on all platforms. Use `import { AbortController } from 'abort-controller'`",
-          },
         ],
       },
     },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -47,7 +47,6 @@
     "@sphereon/ssi-types": "0.30.2-next.135",
     "@stablelib/ed25519": "^1.0.2",
     "@types/ws": "^8.5.4",
-    "abort-controller": "^3.0.0",
     "big-integer": "^1.6.51",
     "borc": "^3.0.0",
     "buffer": "^6.0.3",

--- a/packages/core/src/transport/HttpOutboundTransport.ts
+++ b/packages/core/src/transport/HttpOutboundTransport.ts
@@ -4,7 +4,6 @@ import type { AgentMessageReceivedEvent } from '../agent/Events'
 import type { Logger } from '../logger'
 import type { OutboundPackage } from '../types'
 
-import { AbortController } from 'abort-controller'
 import { Subject } from 'rxjs'
 
 import { AgentEventTypes } from '../agent/Events'

--- a/packages/core/src/utils/fetch.ts
+++ b/packages/core/src/utils/fetch.ts
@@ -1,7 +1,5 @@
 import type { AgentDependencies } from '../agent/AgentDependencies'
 
-import { AbortController } from 'abort-controller'
-
 export async function fetchWithTimeout(
   fetch: AgentDependencies['fetch'],
   url: string,

--- a/packages/core/src/utils/parseInvitation.ts
+++ b/packages/core/src/utils/parseInvitation.ts
@@ -1,6 +1,5 @@
 import type { AgentDependencies } from '../agent/AgentDependencies'
 
-import { AbortController } from 'abort-controller'
 import { parseUrl } from 'query-string'
 
 import { AgentMessage } from '../agent/AgentMessage'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -505,9 +505,6 @@ importers:
       '@types/ws':
         specifier: ^8.5.4
         version: 8.5.12
-      abort-controller:
-        specifier: ^3.0.0
-        version: 3.0.0
       big-integer:
         specifier: ^1.6.51
         version: 1.6.52
@@ -7406,9 +7403,11 @@ packages:
 
   sudo-prompt@8.2.5:
     resolution: {integrity: sha512-rlBo3HU/1zAJUrkY6jNxDOC9eVYliG6nS4JA8u8KAshITd07tafMc/Br7xQwCSseXwJ2iCcHCE8SNWX3q8Z+kw==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   sudo-prompt@9.1.1:
     resolution: {integrity: sha512-es33J1g2HjMpyAhz8lOR+ICmXXAqTuKbuXuUWLhOLew20oN9oUCgCJx615U/v7aioZg7IX5lIh9x34vwneu4pA==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   sudo-prompt@9.2.1:
     resolution: {integrity: sha512-Mu7R0g4ig9TUuGSxJavny5Rv0egCEtpZRNMrZaYS1vxkiIxGiGUwoezU3LazIQ+KE04hTrTfNPgxU5gzi7F5Pw==}
@@ -14736,7 +14735,7 @@ snapshots:
       debug: 4.3.6
       enhanced-resolve: 5.17.1
       eslint: 8.57.0
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.5.4))(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0)
       eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.6
@@ -14748,7 +14747,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.8.1(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0):
+  eslint-module-utils@2.8.1(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.5.4))(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -14769,7 +14768,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.5.4))(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0)
       hasown: 2.0.2
       is-core-module: 2.15.0
       is-glob: 4.0.3


### PR DESCRIPTION
It has been supported for a long time now in all platforms and it's currently causing issues in our wallets. Using the native abort controller 