### PR TITLE
fix: presentation exchange handling when multiple mdocs

### DIFF
--- a/.changeset/big-countries-work.md
+++ b/.changeset/big-countries-work.md
@@ -1,0 +1,5 @@
+---
+'@credo-ts/core': patch
+---
+
+fix: presentation exchange handling when multiple mdocs in presentation definition

--- a/packages/core/src/modules/dif-presentation-exchange/__tests__/DifPresentationExchangeService.test.ts
+++ b/packages/core/src/modules/dif-presentation-exchange/__tests__/DifPresentationExchangeService.test.ts
@@ -1,5 +1,4 @@
-import type { DifPresentationExchangeDefinitionV2 } from '../models'
-
+import { MDoc } from '@animo-id/mdoc'
 import { Subject } from 'rxjs'
 
 import { InMemoryStorageService } from '../../../../../../tests/InMemoryStorageService'
@@ -7,12 +6,15 @@ import { InMemoryWallet } from '../../../../../../tests/InMemoryWallet'
 import { agentDependencies, getAgentContext } from '../../../../tests'
 import { AgentContext } from '../../../agent'
 import { InjectionSymbols } from '../../../constants'
+import { Buffer } from '../../../utils'
 import { Mdoc, MdocRecord, MdocRepository } from '../../mdoc'
 import { sprindFunkeTestVectorBase64Url } from '../../mdoc/__tests__/mdoc.fixtures'
 import { SdJwtVcRecord, SdJwtVcRepository } from '../../sd-jwt-vc'
 import { SignatureSuiteToken, W3cCredentialService, W3cCredentialsModuleConfig } from '../../vc'
 import { DifPresentationExchangeService } from '../DifPresentationExchangeService'
+import { DifPresentationExchangeSubmissionLocation, type DifPresentationExchangeDefinitionV2 } from '../models'
 
+const wallet = new InMemoryWallet()
 const agentContext = getAgentContext({
   registerInstances: [
     [InjectionSymbols.StorageService, new InMemoryStorageService()],
@@ -21,7 +23,7 @@ const agentContext = getAgentContext({
     [SignatureSuiteToken, 'default'],
     [W3cCredentialsModuleConfig, new W3cCredentialsModuleConfig()],
   ],
-  wallet: new InMemoryWallet(),
+  wallet,
 })
 agentContext.dependencyManager.registerInstance(AgentContext, agentContext)
 const sdJwtVcRecord = new SdJwtVcRecord({
@@ -31,6 +33,13 @@ const sdJwtVcRecord = new SdJwtVcRecord({
 const mdocRecord = new MdocRecord({
   mdoc: Mdoc.fromBase64Url(sprindFunkeTestVectorBase64Url),
 })
+
+const randomMdoc = new MdocRecord({
+  mdoc: Mdoc.fromBase64Url(
+    'uQACam5hbWVTcGFjZXOhZWhlbGxvg9gYWGOkaGRpZ2VzdElEAHFlbGVtZW50SWRlbnRpZmllcmV3b3JsZGxlbGVtZW50VmFsdWVpZnJvbS1tZG9jZnJhbmRvbVggykhTxfNlSKof8C76L0PbEicRNyvvtkLK2tk5_B9szZfYGFhgpGhkaWdlc3RJRAFxZWxlbWVudElkZW50aWZpZXJmc2VjcmV0bGVsZW1lbnRWYWx1ZWV2YWx1ZWZyYW5kb21YIEnaTGtx_X06jnK1gwhM_F5mWx9smnHlOpwEAoO_yhfS2BhYX6RoZGlnZXN0SUQCcWVsZW1lbnRJZGVudGlmaWVyZW5pY2VybGVsZW1lbnRWYWx1ZWVkaWNlcmZyYW5kb21YIFMhbyABKjRO5hwvhuOw7t--_Y-DsTrbQmSrO3lKlc2Uamlzc3VlckF1dGiEQ6EBJqIEWDF6RG5hZVVVRDg5Rkh4Sk1QWXdkOTZVM0RMV3g4UGczVUxETHNGRGlxcURpV1lweWhBGCGBWQFKMIIBRjCB7aADAgECAhAMuKdk7KygttyPJUktOlcsMAoGCCqGSM49BAMCMAAwHhcNMjUwMTE5MTIyNzM3WhcNMjUwMTIxMTIyNzM3WjAAMDkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDIgACPAHTvdNcCar4tHhZfOWvgxlbAKOkyw_KO1VI0pFrEKGjaTBnMCoGA1UdDgQjBCECPAHTvdNcCar4tHhZfOWvgxlbAKOkyw_KO1VI0pFrEKEwCwYDVR0PBAQDAgKEMCwGA1UdIwQlMCOAIQI8AdO901wJqvi0eFl85a-DGVsAo6TLD8o7VUjSkWsQoTAKBggqhkjOPQQDAgNIADBFAiAY7g2u0qO3UKz7yyV3hh9IzDfvht_jz-1wTpy3LsyyswIhALslr_rb11V5J1kmr7D0MOcY7DuQUZP-wlXvzY_YtOteWQGs2BhZAae5AAZndmVyc2lvbmMxLjBvZGlnZXN0QWxnb3JpdGhtZ1NIQS0yNTZsdmFsdWVEaWdlc3RzoWVoZWxsb6MAWCDWNYt9om-Teg88Vz14AQvCrijzlZa9MXXI9GjcStZbGwFYIBIGkp2cYU3jRG4RhqOpzcn28XbZcqmEOZaJ18akqXcFAlggdO0W0KteWaNQKdPYlaRX8nzDoHsPWcpo1g9k76mLnARtZGV2aWNlS2V5SW5mb7kAAWlkZXZpY2VLZXmkAQIgASFYIDUO6wyneiIQ90Fg03iwcOXLEkDeimIMiV2R4K0X-QsxIlggvEfFpe3_rayQf8N_bFTH33gU7h9MJBYtU2lGVoLRGcVnZG9jVHlwZXVvcmcuaXNvLjE4MDEzLjUuMS5tRExsdmFsaWRpdHlJbmZvuQAEZnNpZ25lZMB0MjAyNS0wMS0yMFQxMjoyNzozN1ppdmFsaWRGcm9twHQyMDI1LTAxLTIwVDEyOjI3OjM3Wmp2YWxpZFVudGlswHQyMDI2LTAxLTIwVDEyOjI3OjM3Wm5leHBlY3RlZFVwZGF0ZfdYQG2HNQU7OSOWi2x4L8qjePNcJGi4RR0L9IVTEiD3EvkfDmsdSfiyAHJniMU8bAgYSwxTpMh1-N-LI_5Xi743Zl0'
+  ),
+})
+
 const sdJwtVcRepository = agentContext.dependencyManager.resolve(SdJwtVcRepository)
 const mdocRepository = agentContext.dependencyManager.resolve(MdocRepository)
 const pexService = new DifPresentationExchangeService(agentContext.dependencyManager.resolve(W3cCredentialService))
@@ -370,5 +379,280 @@ describe('DifPresentationExchangeService', () => {
       name: 'PID and MDL - Rent a Car (vc+sd-jwt)',
       purpose: 'To secure your car reservations and finalize the transaction, we require the following attributes',
     })
+  })
+
+  test('handles request with request for one of two mdocs with submission requirements', async () => {
+    await mdocRepository.save(agentContext, randomMdoc)
+    const presentationDefinition = {
+      id: `OverAgeCheck`,
+      purpose: 'Age check',
+      submission_requirements: [
+        {
+          name: 'Proof of age and photo',
+          rule: 'pick',
+          count: 1,
+          from: 'validAgeCheckInputDescriptor',
+        },
+      ],
+      input_descriptors: [
+        {
+          name: 'Mdoc proof of age and photo',
+          id: 'eu.europa.ec.eudi.pid.1',
+          group: ['validAgeCheckInputDescriptor'],
+          format: { mso_mdoc: { alg: ['EdDSA', 'ES256'] } },
+          constraints: {
+            limit_disclosure: 'required',
+            fields: [
+              {
+                path: [`$['eu.europa.ec.eudi.pid.1']['age_in_years']`],
+                filter: {
+                  type: 'number',
+                  minimum: 18,
+                },
+                intent_to_retain: false,
+              },
+            ],
+          },
+        },
+        {
+          name: 'Driving licence Mdoc date of birth and photo',
+          id: 'org.iso.18013.5.1.mDL',
+          group: ['validAgeCheckInputDescriptor'],
+          format: { mso_mdoc: { alg: ['EdDSA', 'ES256'] } },
+          constraints: {
+            limit_disclosure: 'required',
+            fields: [
+              {
+                path: [`$['hello']['world']`],
+                intent_to_retain: false,
+              },
+            ],
+          },
+        },
+      ],
+    } satisfies DifPresentationExchangeDefinitionV2
+
+    const credentialsForRequest = await pexService.getCredentialsForRequest(agentContext, presentationDefinition)
+    expect(credentialsForRequest).toEqual({
+      requirements: [
+        {
+          rule: 'pick',
+          needsCount: 1,
+          purpose: undefined,
+          name: 'Proof of age and photo',
+          submissionEntry: [
+            {
+              inputDescriptorId: 'eu.europa.ec.eudi.pid.1',
+              name: 'Mdoc proof of age and photo',
+              purpose: undefined,
+              verifiableCredentials: [
+                {
+                  credentialRecord: await mdocRepository.getById(agentContext, mdocRecord.id),
+                  type: 'mso_mdoc',
+                  disclosedPayload: {
+                    'eu.europa.ec.eudi.pid.1': {
+                      age_in_years: 40,
+                    },
+                  },
+                },
+              ],
+            },
+            {
+              inputDescriptorId: 'org.iso.18013.5.1.mDL',
+              name: 'Driving licence Mdoc date of birth and photo',
+              purpose: undefined,
+              verifiableCredentials: [
+                {
+                  credentialRecord: await mdocRepository.getById(agentContext, randomMdoc.id),
+                  type: 'mso_mdoc',
+                  disclosedPayload: {
+                    hello: {
+                      world: 'from-mdoc',
+                    },
+                  },
+                },
+              ],
+            },
+          ],
+          isRequirementSatisfied: true,
+        },
+      ],
+      areRequirementsSatisfied: true,
+      name: undefined,
+      purpose: 'Age check',
+    })
+
+    const selectedCredentials = pexService.selectCredentialsForRequest(credentialsForRequest)
+
+    jest.spyOn(wallet, 'sign').mockImplementation(async () => Buffer.from('signed'))
+
+    const presentation = await pexService.createPresentation(agentContext, {
+      credentialsForInputDescriptor: selectedCredentials,
+      challenge: 'something',
+      presentationDefinition,
+      domain: 'hello',
+      presentationSubmissionLocation: DifPresentationExchangeSubmissionLocation.EXTERNAL,
+      openid4vp: { mdocGeneratedNonce: 'something', responseUri: 'https://response.com' },
+    })
+
+    expect(presentation).toMatchObject({
+      presentationSubmission: {
+        id: expect.stringContaining('MdocPresentationSubmission'),
+        definition_id: 'OverAgeCheck',
+        descriptor_map: [{ id: 'eu.europa.ec.eudi.pid.1', format: 'mso_mdoc', path: '$' }],
+      },
+    })
+    await mdocRepository.deleteById(agentContext, randomMdoc.id)
+  })
+
+  test('handles request with request for two mdocs with submission requirements', async () => {
+    await mdocRepository.save(agentContext, randomMdoc)
+
+    const presentationDefinition = {
+      id: `OverAgeCheck`,
+      purpose: 'Age check',
+      submission_requirements: [
+        {
+          name: 'Proof of age and photo',
+          rule: 'pick',
+          count: 1,
+          from: 'validAgeCheckInputDescriptor',
+        },
+        {
+          name: 'Proof of age and photo 2',
+          rule: 'pick',
+          count: 1,
+          from: 'validAgeCheckInputDescriptor2',
+        },
+      ],
+      input_descriptors: [
+        {
+          name: 'Mdoc proof of age and photo',
+          id: 'eu.europa.ec.eudi.pid.1',
+          group: ['validAgeCheckInputDescriptor'],
+          format: { mso_mdoc: { alg: ['EdDSA', 'ES256'] } },
+          constraints: {
+            limit_disclosure: 'required',
+            fields: [
+              {
+                path: [`$['eu.europa.ec.eudi.pid.1']['age_in_years']`],
+                filter: {
+                  type: 'number',
+                  minimum: 18,
+                },
+                intent_to_retain: false,
+              },
+            ],
+          },
+        },
+        {
+          name: 'Driving licence Mdoc date of birth and photo',
+          id: 'org.iso.18013.5.1.mDL',
+          group: ['validAgeCheckInputDescriptor2'],
+          format: { mso_mdoc: { alg: ['EdDSA', 'ES256'] } },
+          constraints: {
+            limit_disclosure: 'required',
+            fields: [
+              {
+                path: [`$['hello']['world']`],
+                intent_to_retain: false,
+              },
+            ],
+          },
+        },
+      ],
+    } satisfies DifPresentationExchangeDefinitionV2
+
+    const credentialsForRequest = await pexService.getCredentialsForRequest(agentContext, presentationDefinition)
+    expect(credentialsForRequest).toEqual({
+      requirements: [
+        {
+          rule: 'pick',
+          needsCount: 1,
+          purpose: undefined,
+          name: 'Proof of age and photo',
+          submissionEntry: [
+            {
+              inputDescriptorId: 'eu.europa.ec.eudi.pid.1',
+              name: 'Mdoc proof of age and photo',
+              purpose: undefined,
+              verifiableCredentials: [
+                {
+                  credentialRecord: await mdocRepository.getById(agentContext, mdocRecord.id),
+                  type: 'mso_mdoc',
+                  disclosedPayload: {
+                    'eu.europa.ec.eudi.pid.1': {
+                      age_in_years: 40,
+                    },
+                  },
+                },
+              ],
+            },
+          ],
+          isRequirementSatisfied: true,
+        },
+        {
+          rule: 'pick',
+          needsCount: 1,
+          purpose: undefined,
+          name: 'Proof of age and photo 2',
+          submissionEntry: [
+            {
+              inputDescriptorId: 'org.iso.18013.5.1.mDL',
+              name: 'Driving licence Mdoc date of birth and photo',
+              purpose: undefined,
+              verifiableCredentials: [
+                {
+                  credentialRecord: await mdocRepository.getById(agentContext, randomMdoc.id),
+                  type: 'mso_mdoc',
+                  disclosedPayload: {
+                    hello: {
+                      world: 'from-mdoc',
+                    },
+                  },
+                },
+              ],
+            },
+          ],
+          isRequirementSatisfied: true,
+        },
+      ],
+      areRequirementsSatisfied: true,
+      name: undefined,
+      purpose: 'Age check',
+    })
+
+    const selectedCredentials = pexService.selectCredentialsForRequest(credentialsForRequest)
+
+    jest.spyOn(wallet, 'sign').mockImplementation(async () => Buffer.from('signed'))
+
+    const presentation = await pexService.createPresentation(agentContext, {
+      credentialsForInputDescriptor: selectedCredentials,
+      challenge: 'something',
+      presentationDefinition,
+      domain: 'hello',
+      presentationSubmissionLocation: DifPresentationExchangeSubmissionLocation.EXTERNAL,
+      openid4vp: { mdocGeneratedNonce: 'something', responseUri: 'https://response.com' },
+    })
+
+    expect(presentation).toMatchObject({
+      presentationSubmission: {
+        id: expect.stringContaining('MdocPresentationSubmission'),
+        definition_id: 'OverAgeCheck',
+        descriptor_map: [
+          {
+            id: 'eu.europa.ec.eudi.pid.1',
+            format: 'mso_mdoc',
+            path: '$[0]',
+          },
+          {
+            format: 'mso_mdoc',
+            id: 'org.iso.18013.5.1.mDL',
+            path: '$[1]',
+          },
+        ],
+      },
+    })
+    await mdocRepository.deleteById(agentContext, randomMdoc.id)
   })
 })

--- a/packages/core/src/modules/dif-presentation-exchange/models/DifPexCredentialsForRequest.ts
+++ b/packages/core/src/modules/dif-presentation-exchange/models/DifPexCredentialsForRequest.ts
@@ -61,20 +61,16 @@ export interface DifPexCredentialsForRequestRequirement {
    * Array of objects, where each entry contains one or more credentials that will be part
    * of the submission.
    *
-   * NOTE: if the `isRequirementSatisfied` is `false` the submission list will
-   * contain entries where the verifiable credential list is empty. In this case it could also
+   * NOTE: Make sure to check the `needsCount` value
+   * to see how many of those submissions needed. if the `isRequirementSatisfied` is `false` the submission list will
+   * contain entries where the verifiable credential list is empty. It could also
    * contain more entries than are actually needed (as you sometimes can choose from
-   * e.g. 4 types of credentials and need to submit at least two). If
-   * `isRequirementSatisfied` is `false`, make sure to check the `needsCount` value
-   * to see how many of those submissions needed.
+   * e.g. 4 types of credentials and need to submit at least two).
    */
   submissionEntry: DifPexCredentialsForRequestSubmissionEntry[]
 
   /**
    * The number of submission entries that are needed to fulfill the requirement.
-   * If `isRequirementSatisfied` is `true`, the submission list will always be equal
-   * to the number of `needsCount`. If `isRequirementSatisfied` is `false` the list of
-   * submissions could be longer.
    */
   needsCount: number
 

--- a/packages/core/src/modules/mdoc/MdocDeviceResponse.ts
+++ b/packages/core/src/modules/mdoc/MdocDeviceResponse.ts
@@ -174,9 +174,18 @@ export class MdocDeviceResponse {
     }
 
     const publicDeviceJwk = COSEKey.import(deviceKeyInfo.deviceKey).toJWK()
+    const docTypes = mdoc.documents.map((d) => d.docType)
+
+    // We do PEX filtering on a different layer, so we only include the needed input descriptors here
+    const presentationDefinitionForDocuments = {
+      ...presentationDefinition,
+      input_descriptors: presentationDefinition.input_descriptors.filter((inputDescriptor) =>
+        docTypes.includes(inputDescriptor.id)
+      ),
+    }
 
     const deviceResponseBuilder = DeviceResponse.from(mdoc)
-      .usingPresentationDefinition(presentationDefinition)
+      .usingPresentationDefinition(presentationDefinitionForDocuments)
       .usingSessionTranscriptForOID4VP(sessionTranscriptOptions)
       .authenticateWithSignature(publicDeviceJwk, 'ES256')
 
@@ -190,7 +199,7 @@ export class MdocDeviceResponse {
       deviceResponseBase64Url: TypedArrayEncoder.toBase64URL(deviceResponseMdoc.encode()),
       presentationSubmission: MdocDeviceResponse.createPresentationSubmission({
         id: 'MdocPresentationSubmission ' + uuid(),
-        presentationDefinition,
+        presentationDefinition: presentationDefinitionForDocuments,
       }),
     }
   }


### PR DESCRIPTION
Fixes some issues when presentation definition included multiple input descriptors for mdocs. 

Added two tests:
- mulitple mdoc input descriptors, but only one mdoc in presentation
- multiple mdoc input descriptors, but multiple mdoc in presentation