### PR TITLE
build: update target for tsc compiler to ES2020

### DIFF
--- a/.changeset/popular-walls-add.md
+++ b/.changeset/popular-walls-add.md
@@ -1,0 +1,18 @@
+---
+'@credo-ts/action-menu': minor
+'@credo-ts/anoncreds': minor
+'@credo-ts/askar': minor
+'@credo-ts/bbs-signatures': minor
+'@credo-ts/cheqd': minor
+'@credo-ts/core': minor
+'@credo-ts/drpc': minor
+'@credo-ts/indy-sdk-to-askar-migration': minor
+'@credo-ts/indy-vdr': minor
+'@credo-ts/node': minor
+'@credo-ts/openid4vc': minor
+'@credo-ts/question-answer': minor
+'@credo-ts/react-native': minor
+'@credo-ts/tenants': minor
+---
+
+update target for tsc compiler to ES2020. Generally this should not have an impact for the supported environments (Node.JS / React Native). However this will have to be tested in React Native

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "module": "commonjs",
-    "target": "ES2017",
+    "target": "ES2020",
     "declaration": true,
     "sourceMap": true,
     "strict": true,


### PR DESCRIPTION
Generally this should not have an impact for the supported environments (Node.JS / React Native). However this will have to be tested in React Native