### PR TITLE
fix: exclude test types from core

### DIFF
--- a/packages/core/tsconfig.build.json
+++ b/packages/core/tsconfig.build.json
@@ -5,5 +5,5 @@
     "outDir": "./build"
   },
 
-  "include": ["src/**/*", "types"]
+  "include": ["src/**/*"]
 }


### PR DESCRIPTION
In Core we are including test types in the source code, and since now we have dependency on DIDComm module it was messing up the core package build process (it creates 2 directories, one with core and another with didcomm).

Thanks @sairanjit for noticing and showing the solution for this!