### PR TITLE
feat: remove MessagePickupRepository injection symbol

### DIFF
--- a/packages/core/src/agent/__tests__/Agent.test.ts
+++ b/packages/core/src/agent/__tests__/Agent.test.ts
@@ -19,7 +19,7 @@ import { BasicMessagesApi } from '../../../../didcomm/src/modules/basic-messages
 import { ConnectionsApi, ConnectionRepository } from '../../../../didcomm/src/modules/connections'
 import { CredentialRepository } from '../../../../didcomm/src/modules/credentials'
 import { CredentialsApi } from '../../../../didcomm/src/modules/credentials/CredentialsApi'
-import { MessagePickupApi, InMemoryMessagePickupRepository } from '../../../../didcomm/src/modules/message-pickup'
+import { MessagePickupApi } from '../../../../didcomm/src/modules/message-pickup'
 import { ProofsApi, ProofRepository } from '../../../../didcomm/src/modules/proofs'
 import {
   MediationRecipientService,
@@ -185,9 +185,6 @@ describe('Agent', () => {
 
       // Symbols, interface based
       expect(container.resolve(InjectionSymbols.Logger)).toBe(agentOptions.config.logger)
-      expect(container.resolve(InjectionSymbols.MessagePickupRepository)).toBeInstanceOf(
-        InMemoryMessagePickupRepository
-      )
 
       // Agent
       expect(container.resolve(MessageSender)).toBeInstanceOf(MessageSender)
@@ -226,9 +223,6 @@ describe('Agent', () => {
 
       // Symbols, interface based
       expect(container.resolve(InjectionSymbols.Logger)).toBe(container.resolve(InjectionSymbols.Logger))
-      expect(container.resolve(InjectionSymbols.MessagePickupRepository)).toBe(
-        container.resolve(InjectionSymbols.MessagePickupRepository)
-      )
       expect(container.resolve(InjectionSymbols.StorageService)).toBe(
         container.resolve(InjectionSymbols.StorageService)
       )

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -1,5 +1,4 @@
 export const InjectionSymbols = {
-  MessagePickupRepository: Symbol('MessagePickupRepository'), // TODO: Move to DIDComm
   StorageService: Symbol('StorageService'),
   Logger: Symbol('Logger'),
   AgentContextProvider: Symbol('AgentContextProvider'),

--- a/packages/didcomm/README.md
+++ b/packages/didcomm/README.md
@@ -34,7 +34,7 @@ Base DIDComm package for [Credo](https://github.com/openwallet-foundation/credo-
 
 In order for this module to work, we have to inject it into the agent to access agent functionality. See the example for more information.
 
-> **Note**: At the moment, for a basic DIDComm agent to work, it is required to instantiate at least 3 modules besides the basic `DidCommModule`: `OutOfBandModule`, `ConnectionsModule` and `MessagePickupModule`
+> **Note**: At the moment, for a basic DIDComm agent to work, it is required to instantiate at least 2 modules besides the basic `DidCommModule`: `OutOfBandModule` and `ConnectionsModule`
 
 ### Example of usage
 

--- a/packages/didcomm/src/Events.ts
+++ b/packages/didcomm/src/Events.ts
@@ -9,6 +9,7 @@ export enum AgentEventTypes {
   AgentMessageReceived = 'AgentMessageReceived',
   AgentMessageProcessed = 'AgentMessageProcessed',
   AgentMessageSent = 'AgentMessageSent',
+  QueuePackedMessageForPickup = 'QueuePackedMessageForPickup',
 }
 
 export interface AgentMessageReceivedEvent extends BaseEvent {
@@ -37,5 +38,14 @@ export interface AgentMessageSentEvent extends BaseEvent {
   payload: {
     message: OutboundMessageContext
     status: OutboundMessageSendStatus
+  }
+}
+
+export interface QueuePackedMessageForPickupEvent extends BaseEvent {
+  type: typeof AgentEventTypes.QueuePackedMessageForPickup
+  payload: {
+    connectionId: string
+    recipientDids: string[]
+    payload: EncryptedMessage
   }
 }

--- a/packages/didcomm/src/__tests__/MessageSender.test.ts
+++ b/packages/didcomm/src/__tests__/MessageSender.test.ts
@@ -4,7 +4,6 @@ import type { DidDocumentService, IndyAgentService } from '../../../core/src/mod
 import type { ResolvedDidCommService } from '../../../core/src/types'
 import type { AgentMessageSentEvent } from '../Events'
 import type { ConnectionRecord } from '../modules'
-import type { MessagePickupRepository } from '../modules/message-pickup/storage'
 import type { OutboundTransport } from '../transport'
 import type { EncryptedMessage } from '../types'
 
@@ -17,13 +16,7 @@ import { DidCommV1Service } from '../../../core/src/modules/dids/domain/service/
 import { verkeyToInstanceOfKey } from '../../../core/src/modules/dids/helpers'
 import { DidResolverService } from '../../../core/src/modules/dids/services/DidResolverService'
 import { TestMessage } from '../../../core/tests/TestMessage'
-import {
-  agentDependencies,
-  getAgentConfig,
-  getAgentContext,
-  getMockConnection,
-  mockFunction,
-} from '../../../core/tests/helpers'
+import { agentDependencies, getAgentContext, getMockConnection, mockFunction } from '../../../core/tests/helpers'
 import testLogger from '../../../core/tests/logger'
 import { EnvelopeService as EnvelopeServiceImpl } from '../EnvelopeService'
 import { AgentEventTypes } from '../Events'
@@ -31,7 +24,6 @@ import { MessageSender } from '../MessageSender'
 import { TransportService } from '../TransportService'
 import { ReturnRouteTypes } from '../decorators/transport/TransportDecorator'
 import { OutboundMessageContext, OutboundMessageSendStatus } from '../models'
-import { InMemoryMessagePickupRepository } from '../modules/message-pickup/storage'
 import { DidCommDocumentService } from '../services/DidCommDocumentService'
 
 import { DummyTransportSession } from './stubs'
@@ -134,10 +126,8 @@ describe('MessageSender', () => {
 
   let messageSender: MessageSender
   let outboundTransport: OutboundTransport
-  let messagePickupRepository: MessagePickupRepository
   let connection: ConnectionRecord
   let outboundMessageContext: OutboundMessageContext
-  const agentConfig = getAgentConfig('MessageSender')
   const agentContext = getAgentContext()
   const eventListenerMock = jest.fn()
 
@@ -149,11 +139,9 @@ describe('MessageSender', () => {
       eventEmitter.on<AgentMessageSentEvent>(AgentEventTypes.AgentMessageSent, eventListenerMock)
 
       outboundTransport = new DummyHttpOutboundTransport()
-      messagePickupRepository = new InMemoryMessagePickupRepository(agentConfig.logger)
       messageSender = new MessageSender(
         enveloperService,
         transportService,
-        messagePickupRepository,
         logger,
         didResolverService,
         didCommDocumentService,
@@ -499,7 +487,6 @@ describe('MessageSender', () => {
       messageSender = new MessageSender(
         enveloperService,
         transportService,
-        new InMemoryMessagePickupRepository(agentConfig.logger),
         logger,
         didResolverService,
         didCommDocumentService,
@@ -638,11 +625,9 @@ describe('MessageSender', () => {
   describe('packMessage', () => {
     beforeEach(() => {
       outboundTransport = new DummyHttpOutboundTransport()
-      messagePickupRepository = new InMemoryMessagePickupRepository(agentConfig.logger)
       messageSender = new MessageSender(
         enveloperService,
         transportService,
-        messagePickupRepository,
         logger,
         didResolverService,
         didCommDocumentService,

--- a/packages/didcomm/src/modules/message-pickup/MessagePickupApi.ts
+++ b/packages/didcomm/src/modules/message-pickup/MessagePickupApi.ts
@@ -14,7 +14,6 @@ import type { MessagePickupCompletedEvent } from './MessagePickupEvents'
 import type { MessagePickupSession, MessagePickupSessionRole } from './MessagePickupSession'
 import type { V1MessagePickupProtocol, V2MessagePickupProtocol } from './protocol'
 import type { MessagePickupProtocol } from './protocol/MessagePickupProtocol'
-import type { MessagePickupRepository } from './storage/MessagePickupRepository'
 
 import { AgentContext, EventEmitter, InjectionSymbols, CredoError, Logger, inject, injectable } from '@credo-ts/core'
 import { ReplaySubject, Subject, filter, first, firstValueFrom, takeUntil, timeout } from 'rxjs'
@@ -93,11 +92,11 @@ export class MessagePickupApi<MPPs extends MessagePickupProtocol[] = [V1MessageP
     const { connectionId, message, recipientDids } = options
     const connectionRecord = await this.connectionService.getById(this.agentContext, connectionId)
 
-    const messagePickupRepository = this.agentContext.dependencyManager.resolve<MessagePickupRepository>(
-      InjectionSymbols.MessagePickupRepository
-    )
-
-    await messagePickupRepository.addMessage({ connectionId: connectionRecord.id, recipientDids, payload: message })
+    await this.config.messagePickupRepository.addMessage({
+      connectionId: connectionRecord.id,
+      recipientDids,
+      payload: message,
+    })
   }
 
   /**

--- a/packages/didcomm/src/modules/message-pickup/MessagePickupModuleConfig.ts
+++ b/packages/didcomm/src/modules/message-pickup/MessagePickupModuleConfig.ts
@@ -1,6 +1,8 @@
 import type { MessagePickupProtocol } from './protocol/MessagePickupProtocol'
 import type { MessagePickupRepository } from './storage/MessagePickupRepository'
 
+import { InMemoryMessagePickupRepository } from './storage'
+
 /**
  * MessagePickupModuleConfigOptions defines the interface for the options of the MessagePickupModuleConfig class.
  * This can contain optional parameters that have default values in the config class itself.
@@ -36,8 +38,12 @@ export interface MessagePickupModuleConfigOptions<MessagePickupProtocols extends
 export class MessagePickupModuleConfig<MessagePickupProtocols extends MessagePickupProtocol[]> {
   private options: MessagePickupModuleConfigOptions<MessagePickupProtocols>
 
+  #messagePickupRepository: MessagePickupRepository
+
   public constructor(options: MessagePickupModuleConfigOptions<MessagePickupProtocols>) {
     this.options = options
+    // Message Pickup queue: use provided one or in-memory one if no injection symbol is yet defined
+    this.#messagePickupRepository = options.messagePickupRepository ?? new InMemoryMessagePickupRepository()
   }
 
   /** See {@link MessagePickupModuleConfig.maximumBatchSize} */
@@ -52,6 +58,6 @@ export class MessagePickupModuleConfig<MessagePickupProtocols extends MessagePic
 
   /** See {@link MessagePickupModuleConfig.messagePickupRepository} */
   public get messagePickupRepository() {
-    return this.options.messagePickupRepository
+    return this.#messagePickupRepository
   }
 }

--- a/packages/didcomm/src/modules/message-pickup/__tests__/MessagePickupModule.test.ts
+++ b/packages/didcomm/src/modules/message-pickup/__tests__/MessagePickupModule.test.ts
@@ -1,14 +1,15 @@
 import type { DependencyManager } from '../../../../../core/src/plugins'
 import type { MessagePickupProtocol } from '../protocol/MessagePickupProtocol'
 
+import { Subject } from 'rxjs'
+
 import { MessageHandlerRegistry } from '../../..//MessageHandlerRegistry'
-import { InjectionSymbols } from '../../../../../core'
-import { getAgentContext } from '../../../../../core/tests'
+import { EventEmitter, InjectionSymbols } from '../../../../../core'
+import { agentDependencies, getAgentContext } from '../../../../../core/tests'
 import { FeatureRegistry } from '../../../FeatureRegistry'
 import { MessagePickupModule } from '../MessagePickupModule'
 import { MessagePickupModuleConfig } from '../MessagePickupModuleConfig'
 import { MessagePickupSessionService } from '../services'
-import { InMemoryMessagePickupRepository } from '../storage'
 
 describe('MessagePickupModule', () => {
   test('registers dependencies on the dependency manager', () => {
@@ -26,15 +27,11 @@ describe('MessagePickupModule', () => {
     expect(dependencyManager.registerInstance).toHaveBeenCalledTimes(1)
     expect(dependencyManager.registerInstance).toHaveBeenCalledWith(MessagePickupModuleConfig, module.config)
 
-    expect(dependencyManager.registerSingleton).toHaveBeenCalledTimes(2)
-    expect(dependencyManager.registerSingleton).toHaveBeenCalledWith(
-      InjectionSymbols.MessagePickupRepository,
-      InMemoryMessagePickupRepository
-    )
+    expect(dependencyManager.registerSingleton).toHaveBeenCalledTimes(1)
     expect(dependencyManager.registerSingleton).toHaveBeenCalledWith(MessagePickupSessionService)
   })
 
-  test('calls register on the provided ProofProtocols', async () => {
+  test('calls register on the provided MessagePickup protocols', async () => {
     const messagePickupProtocol = {
       register: jest.fn(),
     } as unknown as MessagePickupProtocol
@@ -57,6 +54,8 @@ describe('MessagePickupModule', () => {
         [MessagePickupSessionService, messagePickupSessionSessionService],
         [MessageHandlerRegistry, messageHandlerRegistry],
         [FeatureRegistry, featureRegistry],
+        [InjectionSymbols.Stop$, new Subject<boolean>()],
+        [EventEmitter, new EventEmitter(agentDependencies, new Subject<boolean>())],
       ],
     })
     await messagePickupModule.initialize(agentContext)

--- a/packages/didcomm/src/modules/message-pickup/protocol/v2/__tests__/V2MessagePickupProtocol.test.ts
+++ b/packages/didcomm/src/modules/message-pickup/protocol/v2/__tests__/V2MessagePickupProtocol.test.ts
@@ -1,7 +1,6 @@
 import type { EncryptedMessage } from '../../../../../types'
 
 import { EventEmitter } from '../../../../../../../core/src/agent/EventEmitter'
-import { InjectionSymbols } from '../../../../../../../core/src/constants'
 import { CredoError } from '../../../../../../../core/src/error'
 import { verkeyToDidKey } from '../../../../../../../core/src/modules/dids/helpers'
 import { uuid } from '../../../../../../../core/src/utils/uuid'
@@ -39,18 +38,18 @@ const EventEmitterMock = EventEmitter as jest.Mock<EventEmitter>
 const MessageSenderMock = MessageSender as jest.Mock<MessageSender>
 const ConnectionServiceMock = ConnectionService as jest.Mock<ConnectionService>
 
-const messagePickupModuleConfig = new MessagePickupModuleConfig({
-  maximumBatchSize: 10,
-  protocols: [new V1MessagePickupProtocol(), new V2MessagePickupProtocol()],
-})
 const messageSender = new MessageSenderMock()
 const eventEmitter = new EventEmitterMock()
 const connectionService = new ConnectionServiceMock()
 const messagePickupRepository = new InMessageRepositoryMock()
+const messagePickupModuleConfig = new MessagePickupModuleConfig({
+  maximumBatchSize: 10,
+  protocols: [new V1MessagePickupProtocol(), new V2MessagePickupProtocol()],
+  messagePickupRepository,
+})
 
 const agentContext = getAgentContext({
   registerInstances: [
-    [InjectionSymbols.MessagePickupRepository, messagePickupRepository],
     [EventEmitter, eventEmitter],
     [MessageSender, messageSender],
     [ConnectionService, connectionService],

--- a/packages/didcomm/src/modules/message-pickup/storage/InMemoryMessagePickupRepository.ts
+++ b/packages/didcomm/src/modules/message-pickup/storage/InMemoryMessagePickupRepository.ts
@@ -17,10 +17,10 @@ interface InMemoryQueuedMessage extends QueuedMessage {
 
 @injectable()
 export class InMemoryMessagePickupRepository implements MessagePickupRepository {
-  private logger: Logger
+  private logger?: Logger
   private messages: InMemoryQueuedMessage[]
 
-  public constructor(@inject(InjectionSymbols.Logger) logger: Logger) {
+  public constructor(@inject(InjectionSymbols.Logger) logger?: Logger) {
     this.logger = logger
     this.messages = []
   }
@@ -51,7 +51,7 @@ export class InMemoryMessagePickupRepository implements MessagePickupRepository 
 
     messages = messages.slice(0, messagesToTake)
 
-    this.logger.debug(`Taking ${messagesToTake} messages from queue for connection ${connectionId}`)
+    this.logger?.debug(`Taking ${messagesToTake} messages from queue for connection ${connectionId}`)
 
     // Mark taken messages in order to prevent them of being retrieved again
     messages.forEach((msg) => {

--- a/samples/extension-module/requester.ts
+++ b/samples/extension-module/requester.ts
@@ -8,7 +8,6 @@ import {
   ConnectionsModule,
   DidCommModule,
   OutOfBandModule,
-  MessagePickupModule,
 } from '@credo-ts/didcomm'
 import { agentDependencies } from '@credo-ts/node'
 import { ariesAskar } from '@hyperledger/aries-askar-nodejs'
@@ -36,7 +35,6 @@ const run = async () => {
       askar: new AskarModule({ ariesAskar }),
       didcomm: new DidCommModule(),
       oob: new OutOfBandModule(),
-      messagePickup: new MessagePickupModule(),
       dummy: new DummyModule(),
       connections: new ConnectionsModule({
         autoAcceptConnections: true,

--- a/samples/extension-module/responder.ts
+++ b/samples/extension-module/responder.ts
@@ -3,7 +3,7 @@ import type { Socket } from 'net'
 
 import { AskarModule } from '@credo-ts/askar'
 import { Agent, ConsoleLogger, LogLevel } from '@credo-ts/core'
-import { ConnectionsModule, DidCommModule, MessagePickupModule, OutOfBandModule } from '@credo-ts/didcomm'
+import { ConnectionsModule, DidCommModule, OutOfBandModule } from '@credo-ts/didcomm'
 import { agentDependencies, HttpInboundTransport, WsInboundTransport } from '@credo-ts/node'
 import { ariesAskar } from '@hyperledger/aries-askar-nodejs'
 import express from 'express'
@@ -35,7 +35,6 @@ const run = async () => {
       askar: new AskarModule({ ariesAskar }),
       didcomm: new DidCommModule({ endpoints: [`http://localhost:${port}`] }),
       oob: new OutOfBandModule(),
-      messagePickup: new MessagePickupModule(),
       dummy: new DummyModule({ autoAcceptRequests }),
       connections: new ConnectionsModule({
         autoAcceptConnections: true,


### PR DESCRIPTION
This PR removes MessagePickupRepository injection symbol, which makes DIDComm base module to not depend on Message Pickup. Instead, `MessageSender` emits an internal event when a message is meant to be queued for pickup (e.g. when the recipient does have a transport queue endpoint). Such event is catched by `MessagePickupModule` and effectively added to the queue there.

The main advantage for now (apart from removing an InjectionSymbol) is that we can define a very basic DIDComm Agent that only includes the very basic DIDComm modules (didcomm, oob and connections).

I want to take this as an initial step to refactor the relationship between modules within DIDComm. For instance, I think it would be nice to put in MessagePickupModule the logic for pickup clients that currently resides on `MediationRecipientApi`, and maybe we can even reduce the amount of modules by having a single mediation module that will be used for the Mediation Coordination protocol, leaving the base mediation features (records, Forward message handling) to the base DIDComm module, along with connections/oob.