### PR TITLE
refactor: split async `getData` method on x509 certificate

### DIFF
--- a/.changeset/eleven-deers-rush.md
+++ b/.changeset/eleven-deers-rush.md
@@ -1,0 +1,5 @@
+---
+'@credo-ts/core': minor
+---
+
+refactor: split async `getData` method on x509 certificate to sync `.data` getter and async `getThumbprint` method

--- a/packages/core/src/modules/mdoc/MdocContext.ts
+++ b/packages/core/src/modules/mdoc/MdocContext.ts
@@ -105,7 +105,10 @@ export const getMdocContext = (agentContext: AgentContext): MdocContext => {
       getCertificateData: async (input) => {
         const { certificate } = input
         const x509Certificate = X509Certificate.fromRawCertificate(certificate)
-        return x509Certificate.getData(crypto)
+        return {
+          ...x509Certificate.data,
+          thumbprint: await x509Certificate.getThumprint(agentContext),
+        }
       },
     } satisfies X509Context,
   }

--- a/packages/core/src/modules/x509/X509Certificate.ts
+++ b/packages/core/src/modules/x509/X509Certificate.ts
@@ -1,5 +1,5 @@
 import type { X509CreateSelfSignedCertificateOptions } from './X509ServiceOptions'
-import type { CredoWebCrypto } from '../../crypto/webcrypto'
+import type { AgentContext } from '../../agent'
 
 import { AsnParser } from '@peculiar/asn1-schema'
 import {
@@ -14,7 +14,7 @@ import * as x509 from '@peculiar/x509'
 import { Key } from '../../crypto/Key'
 import { KeyType } from '../../crypto/KeyType'
 import { compress } from '../../crypto/jose/jwk/ecCompression'
-import { CredoWebCryptoKey } from '../../crypto/webcrypto'
+import { CredoWebCrypto, CredoWebCryptoKey } from '../../crypto/webcrypto'
 import { credoKeyTypeIntoCryptoKeyAlgorithm, spkiAlgorithmIntoCredoKeyType } from '../../crypto/webcrypto/utils'
 import { TypedArrayEncoder } from '../../utils'
 
@@ -271,16 +271,30 @@ export class X509Certificate {
     }
   }
 
-  public async getData(crypto?: CredoWebCrypto) {
+  /**
+   * Get the thumprint of the X509 certificate in hex format.
+   */
+  public async getThumprint(agentContext: AgentContext) {
     const certificate = new x509.X509Certificate(this.rawCertificate)
 
-    const thumbprint = await certificate.getThumbprint(crypto)
+    const thumbprint = await certificate.getThumbprint(new CredoWebCrypto(agentContext))
     const thumbprintHex = TypedArrayEncoder.toHex(new Uint8Array(thumbprint))
+
+    return thumbprintHex
+  }
+
+  /**
+   * Get the data elements of the x509 certificate
+   */
+  public get data() {
+    const certificate = new x509.X509Certificate(this.rawCertificate)
+
     return {
       issuerName: certificate.issuerName.toString(),
+      issuer: certificate.issuer,
       subjectName: certificate.subjectName.toString(),
+      subject: certificate.subject,
       serialNumber: certificate.serialNumber,
-      thumbprint: thumbprintHex,
       pem: certificate.toString(),
       notBefore: certificate.notBefore,
       notAfter: certificate.notAfter,


### PR DESCRIPTION
I've noticed i often need some elements but not the thumbprint and the method requiring crypto and being async was a bit annoying.

