### PR TITLE
docs(changeset): The mdoc device response now verifies each document separately

### DIFF
--- a/.changeset/three-needles-rescue.md
+++ b/.changeset/three-needles-rescue.md
@@ -1,0 +1,6 @@
+---
+"@credo-ts/openid4vc": minor
+"@credo-ts/core": minor
+---
+
+The mdoc device response now verifies each document separately based on the trusted certificates callback. This ensures only the trusted certificates for that specific document are used. In addition, only ONE document per device response is supported for openid4vp verifications from now on, this is expected behaviour according to ISO 18013-7

--- a/packages/core/src/modules/mdoc/Mdoc.ts
+++ b/packages/core/src/modules/mdoc/Mdoc.ts
@@ -25,6 +25,7 @@ import { isMdocSupportedSignatureAlgorithm, mdocSupporteSignatureAlgorithms } fr
  */
 export class Mdoc {
   public base64Url: string
+
   private constructor(private issuerSignedDocument: IssuerSignedDocument) {
     const issuerSigned = issuerSignedDocument.prepare().get('issuerSigned')
     this.base64Url = TypedArrayEncoder.toBase64URL(cborEncode(issuerSigned))
@@ -44,8 +45,6 @@ export class Mdoc {
     deviceSignedBase64Url: string,
     expectedDocType?: string
   ): Mdoc {
-    // biome-ignore lint/suspicious/noExplicitAny: <explanation>
-
     return new Mdoc(
       parseDeviceSigned(
         TypedArrayEncoder.fromBase64(deviceSignedBase64Url),


### PR DESCRIPTION
based on the trusted certificates callback. This ensures only the trusted certificates for that specific document are used. In addition, only ONE document per device response is supported for openid4vp verifications from now on, this is expected behaviour according to ISO 18013-7

