### PR TITLE
fix(x509): use the SHA-1 hash of the public key for the SubjectKeyIdentifier and the AuthorityKeyIdentifier

### DIFF
--- a/.changeset/famous-meals-rhyme.md
+++ b/.changeset/famous-meals-rhyme.md
@@ -1,0 +1,5 @@
+---
+"@credo-ts/core": minor
+---
+
+Changed the SubjectKeyIdentifier and the AuthorityKeyIdentifier to a SHA-1 hash of the public key

--- a/packages/core/src/modules/x509/__tests__/X509Service.test.ts
+++ b/packages/core/src/modules/x509/__tests__/X509Service.test.ts
@@ -10,7 +10,7 @@ import { P256Jwk, getJwkFromKey } from '../../../crypto/jose/jwk'
 import { X509Error } from '../X509Error'
 import { X509Service } from '../X509Service'
 
-import { Hasher, Key, TypedArrayEncoder, X509ExtendedKeyUsage, X509KeyUsage } from '@credo-ts/core'
+import { CredoWebCrypto, Hasher, Key, TypedArrayEncoder, X509ExtendedKeyUsage, X509KeyUsage } from '@credo-ts/core'
 
 /**
  *
@@ -57,6 +57,8 @@ describe('X509Service', () => {
     const rootKey = await wallet.createKey({ keyType: KeyType.P256 })
     const intermediateKey = await wallet.createKey({ keyType: KeyType.P256 })
     const leafKey = await wallet.createKey({ keyType: KeyType.P256 })
+
+    x509.cryptoProvider.set(new CredoWebCrypto(agentContext))
 
     const rootCert = await X509Service.createCertificate(agentContext, {
       serialNumber: '01',

--- a/packages/core/src/modules/x509/__tests__/X509Service.test.ts
+++ b/packages/core/src/modules/x509/__tests__/X509Service.test.ts
@@ -7,11 +7,10 @@ import { InMemoryWallet } from '../../../../../../tests/InMemoryWallet'
 import { getAgentConfig, getAgentContext } from '../../../../tests'
 import { KeyType } from '../../../crypto/KeyType'
 import { P256Jwk, getJwkFromKey } from '../../../crypto/jose/jwk'
-import { CredoWebCrypto } from '../../../crypto/webcrypto'
 import { X509Error } from '../X509Error'
 import { X509Service } from '../X509Service'
 
-import { Key, TypedArrayEncoder, X509ExtendedKeyUsage, X509KeyUsage } from '@credo-ts/core'
+import { Hasher, Key, TypedArrayEncoder, X509ExtendedKeyUsage, X509KeyUsage } from '@credo-ts/core'
 
 /**
  *
@@ -58,8 +57,6 @@ describe('X509Service', () => {
     const rootKey = await wallet.createKey({ keyType: KeyType.P256 })
     const intermediateKey = await wallet.createKey({ keyType: KeyType.P256 })
     const leafKey = await wallet.createKey({ keyType: KeyType.P256 })
-
-    x509.cryptoProvider.set(new CredoWebCrypto(agentContext))
 
     const rootCert = await X509Service.createCertificate(agentContext, {
       serialNumber: '01',
@@ -169,13 +166,13 @@ describe('X509Service', () => {
       },
     })
 
-    expect(certificate).toMatchObject({
-      sanDnsNames: expect.arrayContaining(['paradym.id']),
-      sanUriNames: expect.arrayContaining(['animo.id']),
-      keyUsage: expect.arrayContaining([X509KeyUsage.DigitalSignature]),
-      extendedKeyUsage: expect.arrayContaining([X509ExtendedKeyUsage.MdlDs]),
-      subjectKeyIdentifier: TypedArrayEncoder.toHex(authorityKey.publicKey),
-    })
+    expect(certificate.sanDnsNames).toStrictEqual(expect.arrayContaining(['paradym.id']))
+    expect(certificate.sanUriNames).toStrictEqual(expect.arrayContaining(['animo.id']))
+    expect(certificate.keyUsage).toStrictEqual(expect.arrayContaining([X509KeyUsage.DigitalSignature]))
+    expect(certificate.extendedKeyUsage).toStrictEqual(expect.arrayContaining([X509ExtendedKeyUsage.MdlDs]))
+    expect(certificate.subjectKeyIdentifier).toStrictEqual(
+      TypedArrayEncoder.toHex(Hasher.hash(authorityKey.publicKey, 'SHA-1'))
+    )
   })
 
   it('should create a valid self-signed certifcate as IACA Root + DCS for mDoc', async () => {
@@ -217,7 +214,7 @@ describe('X509Service', () => {
     expect(mdocRootCertificate).toMatchObject({
       ianUriNames: expect.arrayContaining(['animo.id']),
       keyUsage: expect.arrayContaining([X509KeyUsage.KeyCertSign, X509KeyUsage.CrlSign]),
-      subjectKeyIdentifier: TypedArrayEncoder.toHex(authorityKey.publicKey),
+      subjectKeyIdentifier: TypedArrayEncoder.toHex(Hasher.hash(authorityKey.publicKey, 'SHA-1')),
     })
 
     const mdocDocumentSignerCertificate = await X509Service.createCertificate(agentContext, {
@@ -265,8 +262,8 @@ describe('X509Service', () => {
       sanUriNames: expect.arrayContaining(['paradym.id']),
       keyUsage: expect.arrayContaining([X509KeyUsage.DigitalSignature]),
       extendedKeyUsage: expect.arrayContaining([X509ExtendedKeyUsage.MdlDs]),
-      subjectKeyIdentifier: TypedArrayEncoder.toHex(documentSignerKey.publicKey),
-      authorityKeyIdentifier: TypedArrayEncoder.toHex(authorityKey.publicKey),
+      subjectKeyIdentifier: TypedArrayEncoder.toHex(Hasher.hash(documentSignerKey.publicKey, 'SHA-1')),
+      authorityKeyIdentifier: TypedArrayEncoder.toHex(Hasher.hash(authorityKey.publicKey, 'SHA-1')),
     })
   })
 
@@ -285,15 +282,15 @@ describe('X509Service', () => {
       },
     })
 
-    expect(certificate.subjectKeyIdentifier).toStrictEqual(TypedArrayEncoder.toHex(subjectKey.publicKey))
-    expect(certificate.authorityKeyIdentifier).toStrictEqual(TypedArrayEncoder.toHex(authorityKey.publicKey))
+    expect(certificate.subjectKeyIdentifier).toStrictEqual(
+      TypedArrayEncoder.toHex(Hasher.hash(subjectKey.publicKey, 'SHA-1'))
+    )
+    expect(certificate.authorityKeyIdentifier).toStrictEqual(
+      TypedArrayEncoder.toHex(Hasher.hash(authorityKey.publicKey, 'SHA-1'))
+    )
     expect(certificate.publicKey.keyType).toStrictEqual(KeyType.P256)
     expect(certificate.publicKey.publicKey.length).toStrictEqual(65)
     expect(certificate.subject).toStrictEqual('CN=DCS credo')
-    expect(certificate).toMatchObject({
-      subjectKeyIdentifier: TypedArrayEncoder.toHex(subjectKey.publicKey),
-      authorityKeyIdentifier: TypedArrayEncoder.toHex(authorityKey.publicKey),
-    })
   })
 
   it('should correctly parse an X.509 certificate with an uncompressed key to a JWK', async () => {

--- a/packages/core/src/modules/x509/utils/extensions.ts
+++ b/packages/core/src/modules/x509/utils/extensions.ts
@@ -1,4 +1,4 @@
-import type { Key } from '../../../crypto'
+import { Hasher, type Key } from '../../../crypto'
 import type { X509CertificateExtensionsOptions } from '../X509ServiceOptions'
 
 import {
@@ -20,7 +20,9 @@ export const createSubjectKeyIdentifierExtension = (
 ) => {
   if (!options || !options.include) return
 
-  return new SubjectKeyIdentifierExtension(TypedArrayEncoder.toHex(additionalOptions.key.publicKey))
+  const hash = Hasher.hash(additionalOptions.key.publicKey, 'SHA-1')
+
+  return new SubjectKeyIdentifierExtension(TypedArrayEncoder.toHex(hash))
 }
 
 export const createKeyUsagesExtension = (options: X509CertificateExtensionsOptions['keyUsage']) => {
@@ -43,10 +45,9 @@ export const createAuthorityKeyIdentifierExtension = (
 ) => {
   if (!options) return
 
-  return new AuthorityKeyIdentifierExtension(
-    TypedArrayEncoder.toHex(additionalOptions.key.publicKey),
-    options.markAsCritical
-  )
+  const hash = Hasher.hash(additionalOptions.key.publicKey, 'SHA-1')
+
+  return new AuthorityKeyIdentifierExtension(TypedArrayEncoder.toHex(hash), options.markAsCritical)
 }
 
 export const createIssuerAlternativeNameExtension = (


### PR DESCRIPTION
Use SHA-1 hash of the key to generate the AuthorityKeyIdentifier and the SubjectKeyIdentifier

