### PR TITLE
fix(cheqd): Populate contexts for JsonLD issuance

### DIFF
--- a/.changeset/kind-pots-yell.md
+++ b/.changeset/kind-pots-yell.md
@@ -1,0 +1,5 @@
+---
+'@credo-ts/cheqd': patch
+---
+
+Populate contexts for Cheqd DID Document Records in wallet

--- a/packages/cheqd/src/anoncreds/utils/identifiers.ts
+++ b/packages/cheqd/src/anoncreds/utils/identifiers.ts
@@ -12,6 +12,9 @@ const QUERY = `([?][^#]*)?`
 const VERSION_ID = `(.*?)`
 const FRAGMENT = `([#].*)?`
 
+export const ED25519_SUITE_CONTEXT_URL_2018 = 'https://w3id.org/security/suites/ed25519-2018/v1'
+export const ED25519_SUITE_CONTEXT_URL_2020 = 'https://w3id.org/security/suites/ed25519-2020/v1'
+
 export const cheqdSdkAnonCredsRegistryIdentifierRegex = new RegExp(
   `^did:cheqd:${NETWORK}:${IDENTIFIER}${PATH}${QUERY}${FRAGMENT}$`
 )

--- a/packages/cheqd/src/dids/CheqdDidRegistrar.ts
+++ b/packages/cheqd/src/dids/CheqdDidRegistrar.ts
@@ -44,6 +44,11 @@ import {
 
 export class CheqdDidRegistrar implements DidRegistrar {
   public readonly supportedMethods = ['cheqd']
+  private contextMapping = {
+    Ed25519VerificationKey2018: ED25519_SUITE_CONTEXT_URL_2018,
+    Ed25519VerificationKey2020: ED25519_SUITE_CONTEXT_URL_2020,
+    JsonWebKey2020: SECURITY_JWS_CONTEXT_URL,
+  }
 
   public async create(agentContext: AgentContext, options: CheqdDidCreateOptions): Promise<DidCreateResult> {
     const didRepository = agentContext.dependencyManager.resolve(DidRepository)
@@ -106,12 +111,6 @@ export class CheqdDidRegistrar implements DidRegistrar {
         }
       }
 
-      const contextMapping = {
-        Ed25519VerificationKey2018: ED25519_SUITE_CONTEXT_URL_2018,
-        Ed25519VerificationKey2020: ED25519_SUITE_CONTEXT_URL_2020,
-        JsonWebKey2020: SECURITY_JWS_CONTEXT_URL,
-      }
-
       // Normalize context to an array
       const contextSet = new Set<string>(
         typeof didDocument.context === 'string'
@@ -122,7 +121,7 @@ export class CheqdDidRegistrar implements DidRegistrar {
       )
 
       for (const verificationMethod of didDocument.verificationMethod || []) {
-        const contextUrl = contextMapping[verificationMethod.type as keyof typeof contextMapping]
+        const contextUrl = this.contextMapping[verificationMethod.type as keyof typeof this.contextMapping]
         if (contextUrl) {
           contextSet.add(contextUrl)
         }
@@ -131,7 +130,7 @@ export class CheqdDidRegistrar implements DidRegistrar {
       // Add the context to the did document
       // NOTE: cheqd sdk uses https://www.w3.org/ns/did/v1 while Credo did doc uses https://w3id.org/did/v1
       // We should align these at some point. For now we just return a consistent value.
-      didDocument.context = Array.from(contextSet.add('https://www.w3.org/ns/did/v1'))
+      didDocument.context = Array.from(contextSet.add('https://w3id.org/did/v1'))
 
       const didDocumentJson = didDocument.toJSON() as DIDDocument
 
@@ -198,6 +197,14 @@ export class CheqdDidRegistrar implements DidRegistrar {
             },
           }
         }
+        // Normalize existing context to an array
+        const contextSet = new Set<string>(
+          typeof didDocument.context === 'string'
+            ? [didDocument.context]
+            : Array.isArray(didDocument.context)
+            ? didDocument.context
+            : []
+        )
 
         if (verificationMethod) {
           const privateKey = verificationMethod.privateKey
@@ -216,6 +223,14 @@ export class CheqdDidRegistrar implements DidRegistrar {
             keyType: KeyType.Ed25519,
             privateKey: privateKey,
           })
+          const contextUrl = this.contextMapping[verificationMethod.type as keyof typeof this.contextMapping]
+          if (contextUrl) {
+            contextSet.add(contextUrl)
+          }
+          // Add the context to the did document
+          // NOTE: cheqd sdk uses https://www.w3.org/ns/did/v1 while Credo did doc uses https://w3id.org/did/v1
+          // We should align these at some point. For now we just return a consistent value.
+          didDocument.context = Array.from(contextSet.add('https://w3id.org/did/v1'))
 
           didDocument.verificationMethod?.concat(
             JsonTransformer.fromJSON(

--- a/packages/cheqd/src/dids/CheqdDidRegistrar.ts
+++ b/packages/cheqd/src/dids/CheqdDidRegistrar.ts
@@ -26,6 +26,7 @@ import {
   JsonTransformer,
   VerificationMethod,
   SECURITY_JWS_CONTEXT_URL,
+  DID_V1_CONTEXT_URL,
 } from '@credo-ts/core'
 
 import {
@@ -127,10 +128,8 @@ export class CheqdDidRegistrar implements DidRegistrar {
         }
       }
 
-      // Add the context to the did document
-      // NOTE: cheqd sdk uses https://www.w3.org/ns/did/v1 while Credo did doc uses https://w3id.org/did/v1
-      // We should align these at some point. For now we just return a consistent value.
-      didDocument.context = Array.from(contextSet.add('https://w3id.org/did/v1'))
+      // Add Cheqd default context to the did document
+      didDocument.context = Array.from(contextSet.add(DID_V1_CONTEXT_URL))
 
       const didDocumentJson = didDocument.toJSON() as DIDDocument
 
@@ -227,10 +226,8 @@ export class CheqdDidRegistrar implements DidRegistrar {
           if (contextUrl) {
             contextSet.add(contextUrl)
           }
-          // Add the context to the did document
-          // NOTE: cheqd sdk uses https://www.w3.org/ns/did/v1 while Credo did doc uses https://w3id.org/did/v1
-          // We should align these at some point. For now we just return a consistent value.
-          didDocument.context = Array.from(contextSet.add('https://w3id.org/did/v1'))
+          // Add Cheqd default context to the did document
+          didDocument.context = Array.from(contextSet.add(DID_V1_CONTEXT_URL))
 
           didDocument.verificationMethod?.concat(
             JsonTransformer.fromJSON(
@@ -335,7 +332,7 @@ export class CheqdDidRegistrar implements DidRegistrar {
         didState: {
           state: 'finished',
           did: didDocument.id,
-          didDocument: JsonTransformer.fromJSON(didDocument, DidDocument),
+          didDocument: JsonTransformer.fromJSON(didRecord.didDocument, DidDocument),
           secret: options.secret,
         },
       }

--- a/packages/cheqd/src/dids/CheqdDidRegistrar.ts
+++ b/packages/cheqd/src/dids/CheqdDidRegistrar.ts
@@ -31,9 +31,8 @@ import {
 import {
   ED25519_SUITE_CONTEXT_URL_2018,
   ED25519_SUITE_CONTEXT_URL_2020,
-} from '../../../core/src/modules/vc/data-integrity/signature-suites/ed25519/constants'
-
-import { parseCheqdDid } from '../anoncreds/utils/identifiers'
+  parseCheqdDid,
+} from '../anoncreds/utils/identifiers'
 import { CheqdLedgerService } from '../ledger'
 
 import {

--- a/packages/cheqd/src/dids/CheqdDidRegistrar.ts
+++ b/packages/cheqd/src/dids/CheqdDidRegistrar.ts
@@ -28,6 +28,11 @@ import {
   SECURITY_JWS_CONTEXT_URL,
 } from '@credo-ts/core'
 
+import {
+  ED25519_SUITE_CONTEXT_URL_2018,
+  ED25519_SUITE_CONTEXT_URL_2020,
+} from '../../../core/src/modules/vc/data-integrity/signature-suites/ed25519/constants'
+
 import { parseCheqdDid } from '../anoncreds/utils/identifiers'
 import { CheqdLedgerService } from '../ledger'
 
@@ -37,10 +42,6 @@ import {
   validateSpecCompliantPayload,
   createMsgDeactivateDidDocPayloadToSign,
 } from './didCheqdUtil'
-import {
-  ED25519_SUITE_CONTEXT_URL_2018,
-  ED25519_SUITE_CONTEXT_URL_2020,
-} from 'packages/core/src/modules/vc/data-integrity/signature-suites/ed25519/constants'
 
 export class CheqdDidRegistrar implements DidRegistrar {
   public readonly supportedMethods = ['cheqd']
@@ -113,7 +114,7 @@ export class CheqdDidRegistrar implements DidRegistrar {
       }
 
       // Normalize context to an array
-      let contextSet = new Set<string>(
+      const contextSet = new Set<string>(
         typeof didDocument.context === 'string'
           ? [didDocument.context]
           : Array.isArray(didDocument.context)

--- a/packages/cheqd/tests/cheqd-did-registrar.e2e.test.ts
+++ b/packages/cheqd/tests/cheqd-did-registrar.e2e.test.ts
@@ -2,7 +2,6 @@ import type { CheqdDidCreateOptions } from '../src'
 import type { DidDocument } from '@credo-ts/core'
 
 import {
-  SECURITY_JWS_CONTEXT_URL,
   DidDocumentBuilder,
   getEd25519VerificationKey2018,
   getJsonWebKey2020,
@@ -127,9 +126,11 @@ describe('Cheqd DID registrar', () => {
         didDocument,
       },
     })
-
+    expect(updateResult.didState.didDocument?.toJSON()).toMatchObject(didDocument.toJSON())
     const deactivateResult = await agent.dids.deactivate({ did })
-    expect(deactivateResult.didState.didDocument?.toJSON()).toMatchObject(didDocument.toJSON())
+    // NOTE: cheqd sdk uses https://www.w3.org/ns/did/v1 while Credo did doc uses https://w3id.org/did/v1
+    // We should align these at some point and then uncomment the below check.
+    //expect(deactivateResult.didState.didDocument?.toJSON()).toMatchObject(didDocument.toJSON())
     expect(deactivateResult.didState.state).toEqual('finished')
 
     const resolvedDocument = await agent.dids.resolve(did, {
@@ -148,7 +149,6 @@ describe('Cheqd DID registrar', () => {
     const createResult = await agent.dids.create<CheqdDidCreateOptions>({
       method: 'cheqd',
       didDocument: new DidDocumentBuilder(did)
-        .addContext(SECURITY_JWS_CONTEXT_URL)
         .addVerificationMethod(
           getEd25519VerificationKey2018({
             key: ed25519Key,
@@ -166,7 +166,7 @@ describe('Cheqd DID registrar', () => {
     })
 
     expect(createResult.didState.didDocument?.toJSON()).toMatchObject({
-      '@context': ['https://w3id.org/did/v1', 'https://w3id.org/security/suites/jws-2020/v1'],
+      '@context': ['https://w3id.org/did/v1', 'https://w3id.org/security/suites/ed25519-2018/v1'],
       verificationMethod: [
         {
           controller: did,
@@ -187,7 +187,6 @@ describe('Cheqd DID registrar', () => {
     const createResult = await agent.dids.create<CheqdDidCreateOptions>({
       method: 'cheqd',
       didDocument: new DidDocumentBuilder(did)
-        .addContext(SECURITY_JWS_CONTEXT_URL)
         .addVerificationMethod(
           getJsonWebKey2020({
             did,

--- a/packages/cheqd/tests/cheqd-did-registrar.e2e.test.ts
+++ b/packages/cheqd/tests/cheqd-did-registrar.e2e.test.ts
@@ -128,9 +128,7 @@ describe('Cheqd DID registrar', () => {
     })
     expect(updateResult.didState.didDocument?.toJSON()).toMatchObject(didDocument.toJSON())
     const deactivateResult = await agent.dids.deactivate({ did })
-    // NOTE: cheqd sdk uses https://www.w3.org/ns/did/v1 while Credo did doc uses https://w3id.org/did/v1
-    // We should align these at some point and then uncomment the below check.
-    //expect(deactivateResult.didState.didDocument?.toJSON()).toMatchObject(didDocument.toJSON())
+    expect(deactivateResult.didState.didDocument?.toJSON()).toMatchObject(didDocument.toJSON())
     expect(deactivateResult.didState.state).toEqual('finished')
 
     const resolvedDocument = await agent.dids.resolve(did, {
@@ -166,7 +164,11 @@ describe('Cheqd DID registrar', () => {
     })
 
     expect(createResult.didState.didDocument?.toJSON()).toMatchObject({
-      '@context': ['https://w3id.org/did/v1', 'https://w3id.org/security/suites/ed25519-2018/v1'],
+      '@context': [
+        'https://w3id.org/did/v1',
+        'https://w3id.org/security/suites/ed25519-2018/v1',
+        'https://www.w3.org/ns/did/v1',
+      ],
       verificationMethod: [
         {
           controller: did,

--- a/packages/cheqd/tests/cheqd-did-resolver.e2e.test.ts
+++ b/packages/cheqd/tests/cheqd-did-resolver.e2e.test.ts
@@ -82,7 +82,11 @@ describe('Cheqd DID resolver', () => {
     })
     expect(JsonTransformer.toJSON(resolveResult)).toMatchObject({
       didDocument: {
-        '@context': ['https://www.w3.org/ns/did/v1', 'https://w3id.org/security/suites/ed25519-2020/v1'],
+        '@context': [
+          'https://www.w3.org/ns/did/v1',
+          'https://w3id.org/did/v1',
+          'https://w3id.org/security/suites/ed25519-2020/v1',
+        ],
         id: did,
         controller: [did],
         verificationMethod: [

--- a/packages/cheqd/tests/cheqd-did-resolver.e2e.test.ts
+++ b/packages/cheqd/tests/cheqd-did-resolver.e2e.test.ts
@@ -83,9 +83,9 @@ describe('Cheqd DID resolver', () => {
     expect(JsonTransformer.toJSON(resolveResult)).toMatchObject({
       didDocument: {
         '@context': [
-          'https://www.w3.org/ns/did/v1',
           'https://w3id.org/did/v1',
           'https://w3id.org/security/suites/ed25519-2020/v1',
+          'https://www.w3.org/ns/did/v1',
         ],
         id: did,
         controller: [did],

--- a/packages/cheqd/tests/cheqd-ld-proof.e2e.test.ts
+++ b/packages/cheqd/tests/cheqd-ld-proof.e2e.test.ts
@@ -1,0 +1,340 @@
+import type { CheqdDidCreateOptions } from '../src'
+
+import {
+  SECURITY_JWS_CONTEXT_URL,
+  DidDocumentBuilder,
+  getEd25519VerificationKey2018,
+  KeyType,
+  utils,
+  Agent,
+  TypedArrayEncoder,
+  DifPresentationExchangeProofFormatService,
+  JsonLdCredentialFormatService,
+  CredentialsModule,
+  V2CredentialProtocol,
+  ProofsModule,
+  V2ProofProtocol,
+  CacheModule,
+  InMemoryLruCache,
+  W3cCredentialsModule,
+  CredentialState,
+  CredentialExchangeRecord,
+  JsonTransformer,
+  ProofEventTypes,
+  CredentialEventTypes,
+} from '@credo-ts/core'
+
+import { getInMemoryAgentOptions, makeConnection, waitForCredentialRecordSubject } from '../../core/tests/helpers'
+
+import { cheqdPayerSeeds, getCheqdModules } from './setupCheqdModule'
+import { EventReplaySubject, setupEventReplaySubjects, setupSubjectTransports, testLogger } from '../../core/tests'
+
+let did = `did:cheqd:testnet:${utils.uuid()}`
+
+const signCredentialOptions = {
+  credential: {
+    '@context': [
+      'https://www.w3.org/2018/credentials/v1',
+      'https://w3id.org/citizenship/v1',
+      'https://w3id.org/security/bbs/v1',
+    ],
+    id: 'https://issuer.oidp.uscis.gov/credentials/83627465',
+    type: ['VerifiableCredential', 'PermanentResidentCard'],
+    issuer: did,
+    issuanceDate: '2019-12-03T12:19:52Z',
+    expirationDate: '2029-12-03T12:19:52Z',
+    identifier: '83627465',
+    name: 'Permanent Resident Card',
+    credentialSubject: {
+      id: 'did:example:b34ca6cd37bbf23',
+      type: ['PermanentResident', 'Person'],
+      givenName: 'JOHN',
+      familyName: 'SMITH',
+      gender: 'Male',
+      image: 'data:image/png;base64,iVBORw0KGgokJggg==',
+      residentSince: '2015-01-01',
+      description: 'Government of Example Permanent Resident Card.',
+      lprCategory: 'C09',
+      lprNumber: '999-999-999',
+      commuterClassification: 'C1',
+      birthCountry: 'Bahamas',
+      birthDate: '1958-07-17',
+    },
+  },
+  options: {
+    proofType: 'Ed25519Signature2018',
+    proofPurpose: 'assertionMethod',
+  },
+}
+
+const jsonLdCredentialFormat = new JsonLdCredentialFormatService()
+const jsonLdProofFormat = new DifPresentationExchangeProofFormatService()
+
+const getCheqdJsonLdModules = () =>
+  ({
+    ...getCheqdModules(cheqdPayerSeeds[0], 'https://rpc.cheqd.network'),
+    credentials: new CredentialsModule({
+      credentialProtocols: [
+        new V2CredentialProtocol({
+          credentialFormats: [jsonLdCredentialFormat],
+        }),
+      ],
+    }),
+    proofs: new ProofsModule({
+      proofProtocols: [
+        new V2ProofProtocol({
+          proofFormats: [jsonLdProofFormat],
+        }),
+      ],
+    }),
+    cache: new CacheModule({
+      cache: new InMemoryLruCache({ limit: 100 }),
+    }),
+    w3cCredentials: new W3cCredentialsModule({}),
+  } as const)
+
+// TODO: extract these very specific tests to the jsonld format
+describe('Cheqd V2 Credentials - JSON-LD - Ed25519', () => {
+  let faberAgent: Agent<ReturnType<typeof getCheqdJsonLdModules>>
+  let faberReplay: EventReplaySubject
+  let aliceAgent: Agent<ReturnType<typeof getCheqdJsonLdModules>>
+  let aliceReplay: EventReplaySubject
+  let aliceConnectionId: string
+
+  beforeAll(async () => {
+    faberAgent = new Agent(
+      getInMemoryAgentOptions(
+        'Faber Agent Indy/JsonLD',
+        {
+          endpoints: ['rxjs:faber'],
+        },
+        getCheqdJsonLdModules()
+      )
+    )
+    aliceAgent = new Agent(
+      getInMemoryAgentOptions(
+        'Alice Agent Indy/JsonLD',
+        {
+          endpoints: ['rxjs:alice'],
+        },
+        getCheqdJsonLdModules()
+      )
+    )
+
+    setupSubjectTransports([faberAgent, aliceAgent])
+    ;[faberReplay, aliceReplay] = setupEventReplaySubjects(
+      [faberAgent, aliceAgent],
+      [CredentialEventTypes.CredentialStateChanged, ProofEventTypes.ProofStateChanged]
+    )
+    await faberAgent.initialize()
+    await aliceAgent.initialize()
+    ;[, { id: aliceConnectionId }] = await makeConnection(faberAgent, aliceAgent)
+
+    await faberAgent.context.wallet.createKey({
+      privateKey: TypedArrayEncoder.fromString('testseed000000000000000000000001'),
+      keyType: KeyType.Ed25519,
+    })
+  })
+
+  afterAll(async () => {
+    await faberAgent.shutdown()
+    await faberAgent.wallet.delete()
+    await aliceAgent.shutdown()
+    await aliceAgent.wallet.delete()
+  })
+
+  it('should create a did:cheqd did using custom did document containing Ed25519 key', async () => {
+    const ed25519Key = await faberAgent.wallet.createKey({
+      keyType: KeyType.Ed25519,
+    })
+
+    const createResult = await faberAgent.dids.create<CheqdDidCreateOptions>({
+      method: 'cheqd',
+      didDocument: new DidDocumentBuilder(did)
+        .addContext(SECURITY_JWS_CONTEXT_URL)
+        .addVerificationMethod(
+          getEd25519VerificationKey2018({
+            key: ed25519Key,
+            controller: did,
+            id: `${did}#${ed25519Key.fingerprint}`,
+          })
+        )
+        .addAssertionMethod(`${did}#${ed25519Key.fingerprint}`)
+        .addAuthentication(`${did}#${ed25519Key.fingerprint}`)
+        .build(),
+    })
+
+    expect(createResult).toMatchObject({
+      didState: {
+        state: 'finished',
+      },
+    })
+
+    expect(createResult.didState.didDocument?.toJSON()).toMatchObject({
+      '@context': ['https://w3id.org/did/v1', 'https://w3id.org/security/suites/jws-2020/v1'],
+      verificationMethod: [
+        {
+          controller: did,
+          type: 'Ed25519VerificationKey2018',
+          publicKeyBase58: ed25519Key.publicKeyBase58,
+        },
+      ],
+    })
+  })
+
+  test('Alice starts with V2 (ld format, Ed25519 signature) credential proposal to Faber', async () => {
+    testLogger.test('Alice sends (v2 jsonld) credential proposal to Faber')
+
+    const credentialExchangeRecord = await aliceAgent.credentials.proposeCredential({
+      connectionId: aliceConnectionId,
+      protocolVersion: 'v2',
+      credentialFormats: {
+        jsonld: signCredentialOptions,
+      },
+      comment: 'v2 propose credential test for W3C Credentials',
+    })
+
+    expect(credentialExchangeRecord.connectionId).toEqual(aliceConnectionId)
+    expect(credentialExchangeRecord.protocolVersion).toEqual('v2')
+    expect(credentialExchangeRecord.state).toEqual(CredentialState.ProposalSent)
+    expect(credentialExchangeRecord.threadId).not.toBeNull()
+
+    testLogger.test('Faber waits for credential proposal from Alice')
+    let faberCredentialRecord = await waitForCredentialRecordSubject(faberReplay, {
+      threadId: credentialExchangeRecord.threadId,
+      state: CredentialState.ProposalReceived,
+    })
+
+    testLogger.test('Faber sends credential offer to Alice')
+    await faberAgent.credentials.acceptProposal({
+      credentialRecordId: faberCredentialRecord.id,
+      comment: 'V2 W3C Offer',
+    })
+
+    testLogger.test('Alice waits for credential offer from Faber')
+    let aliceCredentialRecord = await waitForCredentialRecordSubject(aliceReplay, {
+      threadId: faberCredentialRecord.threadId,
+      state: CredentialState.OfferReceived,
+    })
+
+    const offerMessage = await aliceAgent.credentials.findOfferMessage(aliceCredentialRecord.id)
+    expect(JsonTransformer.toJSON(offerMessage)).toMatchObject({
+      '@type': 'https://didcomm.org/issue-credential/2.0/offer-credential',
+      '@id': expect.any(String),
+      comment: 'V2 W3C Offer',
+      formats: [
+        {
+          attach_id: expect.any(String),
+          format: 'aries/ld-proof-vc-detail@v1.0',
+        },
+      ],
+      'offers~attach': [
+        {
+          '@id': expect.any(String),
+          'mime-type': 'application/json',
+          data: expect.any(Object),
+          lastmod_time: undefined,
+          byte_count: undefined,
+        },
+      ],
+      '~thread': {
+        thid: expect.any(String),
+        pthid: undefined,
+        sender_order: undefined,
+        received_orders: undefined,
+      },
+      '~service': undefined,
+      '~attach': undefined,
+      '~please_ack': undefined,
+      '~timing': undefined,
+      '~transport': undefined,
+      '~l10n': undefined,
+      credential_preview: expect.any(Object),
+      replacement_id: undefined,
+    })
+    expect(aliceCredentialRecord.id).not.toBeNull()
+    expect(aliceCredentialRecord.type).toBe(CredentialExchangeRecord.type)
+
+    const offerCredentialExchangeRecord = await aliceAgent.credentials.acceptOffer({
+      credentialRecordId: aliceCredentialRecord.id,
+      credentialFormats: {
+        jsonld: {},
+      },
+    })
+
+    expect(offerCredentialExchangeRecord.connectionId).toEqual(aliceConnectionId)
+    expect(offerCredentialExchangeRecord.protocolVersion).toEqual('v2')
+    expect(offerCredentialExchangeRecord.state).toEqual(CredentialState.RequestSent)
+    expect(offerCredentialExchangeRecord.threadId).not.toBeNull()
+
+    testLogger.test('Faber waits for credential request from Alice')
+    await waitForCredentialRecordSubject(faberReplay, {
+      threadId: aliceCredentialRecord.threadId,
+      state: CredentialState.RequestReceived,
+    })
+
+    testLogger.test('Faber sends credential to Alice')
+
+    await faberAgent.credentials.acceptRequest({
+      credentialRecordId: faberCredentialRecord.id,
+      comment: 'V2 Indy Credential',
+    })
+
+    testLogger.test('Alice waits for credential from Faber')
+    aliceCredentialRecord = await waitForCredentialRecordSubject(aliceReplay, {
+      threadId: faberCredentialRecord.threadId,
+      state: CredentialState.CredentialReceived,
+    })
+
+    testLogger.test('Alice sends credential ack to Faber')
+    await aliceAgent.credentials.acceptCredential({ credentialRecordId: aliceCredentialRecord.id })
+
+    testLogger.test('Faber waits for credential ack from Alice')
+    faberCredentialRecord = await waitForCredentialRecordSubject(faberReplay, {
+      threadId: faberCredentialRecord.threadId,
+      state: CredentialState.Done,
+    })
+    expect(aliceCredentialRecord).toMatchObject({
+      type: CredentialExchangeRecord.type,
+      id: expect.any(String),
+      createdAt: expect.any(Date),
+      threadId: expect.any(String),
+      connectionId: expect.any(String),
+      state: CredentialState.CredentialReceived,
+    })
+
+    const credentialMessage = await faberAgent.credentials.findCredentialMessage(faberCredentialRecord.id)
+    expect(JsonTransformer.toJSON(credentialMessage)).toMatchObject({
+      '@type': 'https://didcomm.org/issue-credential/2.0/issue-credential',
+      '@id': expect.any(String),
+      comment: 'V2 Indy Credential',
+      formats: [
+        {
+          attach_id: expect.any(String),
+          format: 'aries/ld-proof-vc@v1.0',
+        },
+      ],
+      'credentials~attach': [
+        {
+          '@id': expect.any(String),
+          'mime-type': 'application/json',
+          data: expect.any(Object),
+          lastmod_time: undefined,
+          byte_count: undefined,
+        },
+      ],
+      '~thread': {
+        thid: expect.any(String),
+        pthid: undefined,
+        sender_order: undefined,
+        received_orders: undefined,
+      },
+      '~please_ack': { on: ['RECEIPT'] },
+      '~service': undefined,
+      '~attach': undefined,
+      '~timing': undefined,
+      '~transport': undefined,
+      '~l10n': undefined,
+    })
+  })
+})

--- a/packages/cheqd/tests/cheqd-ld-proof.e2e.test.ts
+++ b/packages/cheqd/tests/cheqd-ld-proof.e2e.test.ts
@@ -153,6 +153,7 @@ describe('Cheqd V2 Credentials - JSON-LD - Ed25519', () => {
     const createResult = await faberAgent.dids.create<CheqdDidCreateOptions>({
       method: 'cheqd',
       didDocument: new DidDocumentBuilder(did)
+        .addController(did)
         .addVerificationMethod(
           getEd25519VerificationKey2018({
             key: ed25519Key,

--- a/packages/cheqd/tests/cheqd-ld-proof.e2e.test.ts
+++ b/packages/cheqd/tests/cheqd-ld-proof.e2e.test.ts
@@ -174,8 +174,8 @@ describe('Cheqd V2 Credentials - JSON-LD - Ed25519', () => {
     expect(createResult.didState.didDocument?.toJSON()).toMatchObject({
       '@context': [
         'https://w3id.org/did/v1',
-        'https://w3id.org/security/suites/jws-2020/v1',
         'https://w3id.org/security/suites/ed25519-2018/v1',
+        'https://www.w3.org/ns/did/v1',
       ],
       verificationMethod: [
         {

--- a/packages/cheqd/tests/cheqd-ld-proof.e2e.test.ts
+++ b/packages/cheqd/tests/cheqd-ld-proof.e2e.test.ts
@@ -3,7 +3,6 @@ import type { CheqdDidCreateOptions } from '../src'
 import type { Key } from '@credo-ts/core'
 
 import {
-  SECURITY_JWS_CONTEXT_URL,
   DidDocumentBuilder,
   getEd25519VerificationKey2018,
   KeyType,
@@ -154,8 +153,6 @@ describe('Cheqd V2 Credentials - JSON-LD - Ed25519', () => {
     const createResult = await faberAgent.dids.create<CheqdDidCreateOptions>({
       method: 'cheqd',
       didDocument: new DidDocumentBuilder(did)
-        .addContext(SECURITY_JWS_CONTEXT_URL)
-        .addContext('https://w3id.org/security/suites/ed25519-2018/v1')
         .addVerificationMethod(
           getEd25519VerificationKey2018({
             key: ed25519Key,


### PR DESCRIPTION
we are facing an issue in JSONLD issuance with credo, and issue is with the default document loader
```
DidDocument {
	context: ['https://www.w3.org/ns/did/v1', 'https://w3id.org/did/v1', 'https://w3id.org/security/suites/jws-2020/v1', 'https://w3id.org/security/suites/ed25519-2018/v1'],
	id: 'did:cheqd:testnet:151734ba-d9c8-4bf6-a83c-bc4098b10ac6',
	controller: [],
	verificationMethod: [ VerificationMethod {
		id: 'did:cheqd:testnet:151734ba-d9c8-4bf6-a83c-bc4098b10ac6#z6MktzU5kM5XdEKmGrZwXfQEa3jZAyexhmP7iNDMotin4GcR',
		type: 'Ed25519VerificationKey2018',
		controller: 'did:cheqd:testnet:151734ba-d9c8-4bf6-a83c-bc4098b10ac6',
		publicKeyBase58: 'FYD3A6q6HgqJAMjEr6SPixBZMQP7Ht8m2MJRyckm93q3'
	}],
	authentication: ['did:cheqd:testnet:151734ba-d9c8-4bf6-a83c-bc4098b10ac6#z6MktzU5kM5XdEKmGrZwXfQEa3jZAyexhmP7iNDMotin4GcR'],
	assertionMethod: ['did:cheqd:testnet:151734ba-d9c8-4bf6-a83c-bc4098b10ac6#z6MktzU5kM5XdEKmGrZwXfQEa3jZAyexhmP7iNDMotin4GcR']
}
```

This is the input for jsond.frame in [default document loader](https://github.com/openwallet-foundation/credo-ts/blob/e7b59000502bb893a26e12200ea0f701237b972e/packages/core/src/modules/vc/data-integrity/libraries/documentLoader.ts#L43)

The result is missing the publicKeyBase58, same is the case for other signature suites.
```
{
	'@context': ['https://w3id.org/did/v1', 'https://w3id.org/security/suites/jws-2020/v1'],
	id: 'did:cheqd:testnet:efa002a1-ea59-4a87-9fe9-1be2919886d7#z6MkqzAn7GL2srNkmFN8iPXfPKCHfHvY5eTeRUFTeN1xYLsa',
	type: 'Ed25519VerificationKey2018',
	controller: 'did:cheqd:testnet:efa002a1-ea59-4a87-9fe9-1be2919886d7'
}
```