### PR TITLE
feat: use dc+sd-jwt as SD-JWT VC typ header by default 

### DIFF
--- a/.changeset/ninety-tables-crash.md
+++ b/.changeset/ninety-tables-crash.md
@@ -1,0 +1,6 @@
+---
+"@credo-ts/openid4vc": minor
+"@credo-ts/core": minor
+---
+
+use dc+sd-jwt as SD-JWT VC typ header by default and verify that SD-JWT VCs have either dc+sd-jwt or vc+sd-jwt as typ header. You can still use vc+sd-jwt as typ header by providing the headerType value when signing an SD-JWT VC. For OID4VCI the typ header is based on the oid4vci credential format used.

--- a/packages/core/src/modules/sd-jwt-vc/SdJwtVcOptions.ts
+++ b/packages/core/src/modules/sd-jwt-vc/SdJwtVcOptions.ts
@@ -71,6 +71,15 @@ export interface SdJwtVcSignOptions<Payload extends SdJwtVcPayload = SdJwtVcPayl
    * Default of sha-256 will be used if not provided
    */
   hashingAlgorithm?: HashName
+
+  /**
+   * The header 'typ' to use for the SD-JWT VC. vc+sd-jwt is supported
+   * for backwards compatibility but implementations should update to
+   * dc+sd-jwt
+   *
+   * @default 'dc+sd-jwt'
+   */
+  headerType?: 'dc+sd-jwt' | 'vc+sd-jwt'
 }
 
 // TODO: use the payload type once types are fixed

--- a/packages/core/src/modules/sd-jwt-vc/SdJwtVcService.ts
+++ b/packages/core/src/modules/sd-jwt-vc/SdJwtVcService.ts
@@ -111,7 +111,7 @@ export class SdJwtVcService {
 
     const header = {
       alg: issuer.alg,
-      typ: 'vc+sd-jwt',
+      typ: options.headerType ?? 'dc+sd-jwt',
       kid: issuer.kid,
       x5c: issuer.x5c,
     } as const
@@ -315,8 +315,14 @@ export class SdJwtVcService {
         verificationResult.isStatusValid = false
       }
 
+      if (sdJwtVc.jwt.header?.typ !== 'vc+sd-jwt' && sdJwtVc.jwt.header?.typ !== 'dc+sd-jwt') {
+        verificationResult.areRequiredClaimsIncluded = false
+        _error = new SdJwtVcError(`SD-JWT VC header 'typ' must be 'dc+sd-jwt' or 'vc+sd-jwt'`)
+      }
+
       try {
         JwtPayload.fromJson(returnSdJwtVc.payload).validate()
+
         verificationResult.isValidJwtPayload = true
       } catch (error) {
         _error = error

--- a/packages/core/src/modules/sd-jwt-vc/__tests__/SdJwtVcService.test.ts
+++ b/packages/core/src/modules/sd-jwt-vc/__tests__/SdJwtVcService.test.ts
@@ -175,6 +175,7 @@ describe('SdJwtVcService', () => {
           x5c: [simpleX509.trustedCertficate],
           issuer: simpleX509.certificateIssuer,
         },
+        headerType: 'vc+sd-jwt',
       })
 
       expect(compact).toStrictEqual(simpleX509.sdJwtVc)
@@ -211,6 +212,7 @@ describe('SdJwtVcService', () => {
           method: 'did',
           didUrl: issuerDidUrl,
         },
+        headerType: 'vc+sd-jwt',
       })
 
       expect(compact).toStrictEqual(simpleJwtVc)
@@ -240,6 +242,7 @@ describe('SdJwtVcService', () => {
           claim: 'some-claim',
           vct: 'IdentityCredential',
         },
+        headerType: 'vc+sd-jwt',
         issuer: {
           method: 'did',
           didUrl: issuerDidUrl,
@@ -288,7 +291,7 @@ describe('SdJwtVcService', () => {
 
       expect(sdJwtVc.header).toEqual({
         alg: 'EdDSA',
-        typ: 'vc+sd-jwt',
+        typ: 'dc+sd-jwt',
         kid: '#z6MktqtXNG8CDUY9PrrtoStFzeCnhpMmgxYL1gikcW3BzvNW',
       })
 
@@ -317,6 +320,7 @@ describe('SdJwtVcService', () => {
           method: 'did',
           didUrl: issuerDidUrl,
         },
+        headerType: 'vc+sd-jwt',
       })
 
       expect(compact).toStrictEqual(sdJwtVcWithSingleDisclosure)
@@ -382,6 +386,7 @@ describe('SdJwtVcService', () => {
           method: 'did',
           didUrl: issuerDidUrl,
         },
+        headerType: 'vc+sd-jwt',
       })
 
       expect(compact).toStrictEqual(complexSdJwtVc)
@@ -478,7 +483,7 @@ describe('SdJwtVcService', () => {
 
       expect(header).toEqual({
         alg: 'EdDSA',
-        typ: 'vc+sd-jwt',
+        typ: 'dc+sd-jwt',
         kid: '#z6MktqtXNG8CDUY9PrrtoStFzeCnhpMmgxYL1gikcW3BzvNW',
       })
 

--- a/packages/core/src/modules/sd-jwt-vc/__tests__/sdJwtVc.test.ts
+++ b/packages/core/src/modules/sd-jwt-vc/__tests__/sdJwtVc.test.ts
@@ -100,7 +100,7 @@ describe('sd-jwt-vc end to end test', () => {
       header: {
         alg: 'EdDSA',
         kid: '#z6MktqtXNG8CDUY9PrrtoStFzeCnhpMmgxYL1gikcW3BzvNW',
-        typ: 'vc+sd-jwt',
+        typ: 'dc+sd-jwt',
       },
       payload: {
         _sd: [

--- a/packages/openid4vc/src/openid4vc-issuer/OpenId4VcIssuerService.ts
+++ b/packages/openid4vc/src/openid4vc-issuer/OpenId4VcIssuerService.ts
@@ -1240,7 +1240,15 @@ export class OpenId4VcIssuerService {
       return {
         format: credentialConfiguration.format,
         credentials: await Promise.all(
-          signOptions.credentials.map((credential) => sdJwtVcApi.sign(credential).then((signed) => signed.compact))
+          signOptions.credentials.map((credential) =>
+            sdJwtVcApi
+              .sign({
+                ...credential,
+                // Set header type based on the oid4vci format
+                headerType: credentialConfiguration.format,
+              })
+              .then((signed) => signed.compact)
+          )
         ),
       }
     }

--- a/packages/openid4vc/tests/openid4vc-draft21.e2e.test.ts
+++ b/packages/openid4vc/tests/openid4vc-draft21.e2e.test.ts
@@ -271,7 +271,7 @@ describe('OpenID4VP Draft 21', () => {
           header: {
             alg: 'EdDSA',
             kid: '#z6MktiQQEqm2yapXBDt1WEVB3dqgvyzi96FuFANYmrgTrKV9',
-            typ: 'vc+sd-jwt',
+            typ: 'dc+sd-jwt',
           },
           kbJwt: {
             header: {
@@ -623,7 +623,7 @@ describe('OpenID4VP Draft 21', () => {
           header: {
             alg: 'EdDSA',
             kid: '#z6MktiQQEqm2yapXBDt1WEVB3dqgvyzi96FuFANYmrgTrKV9',
-            typ: 'vc+sd-jwt',
+            typ: 'dc+sd-jwt',
           },
           kbJwt: {
             header: {

--- a/packages/openid4vc/tests/openid4vc.e2e.test.ts
+++ b/packages/openid4vc/tests/openid4vc.e2e.test.ts
@@ -1066,7 +1066,7 @@ describe('OpenId4Vc', () => {
           header: {
             alg: 'EdDSA',
             kid: '#z6MkrzQPBr4pyqC776KKtrz13SchM5ePPbssuPuQZb5t4uKQ',
-            typ: 'vc+sd-jwt',
+            typ: 'dc+sd-jwt',
           },
           payload: {
             _sd: [expect.any(String), expect.any(String)],
@@ -1125,6 +1125,7 @@ describe('OpenId4Vc', () => {
         degree: 'bachelor',
         name: 'John Doe',
       },
+      headerType: 'vc+sd-jwt',
       disclosureFrame: {
         _sd: ['university', 'name'],
       },
@@ -1726,7 +1727,7 @@ describe('OpenId4Vc', () => {
           header: {
             alg: 'EdDSA',
             kid: '#z6MkrzQPBr4pyqC776KKtrz13SchM5ePPbssuPuQZb5t4uKQ',
-            typ: 'vc+sd-jwt',
+            typ: 'dc+sd-jwt',
           },
           kbJwt: {
             header: {
@@ -1772,7 +1773,7 @@ describe('OpenId4Vc', () => {
           header: {
             alg: 'EdDSA',
             kid: '#z6MkrzQPBr4pyqC776KKtrz13SchM5ePPbssuPuQZb5t4uKQ',
-            typ: 'vc+sd-jwt',
+            typ: 'dc+sd-jwt',
           },
           payload: {
             _sd: [expect.any(String), expect.any(String)],
@@ -2374,7 +2375,7 @@ describe('OpenId4Vc', () => {
           header: {
             alg: 'EdDSA',
             kid: '#z6MkrzQPBr4pyqC776KKtrz13SchM5ePPbssuPuQZb5t4uKQ',
-            typ: 'vc+sd-jwt',
+            typ: 'dc+sd-jwt',
           },
           kbJwt: {
             header: {
@@ -2698,7 +2699,7 @@ describe('OpenId4Vc', () => {
           header: {
             alg: 'EdDSA',
             kid: '#z6MkrzQPBr4pyqC776KKtrz13SchM5ePPbssuPuQZb5t4uKQ',
-            typ: 'vc+sd-jwt',
+            typ: 'dc+sd-jwt',
           },
           kbJwt: {
             header: {
@@ -2742,7 +2743,7 @@ describe('OpenId4Vc', () => {
           header: {
             alg: 'EdDSA',
             kid: '#z6MkrzQPBr4pyqC776KKtrz13SchM5ePPbssuPuQZb5t4uKQ',
-            typ: 'vc+sd-jwt',
+            typ: 'dc+sd-jwt',
           },
           payload: {
             _sd: [expect.any(String), expect.any(String)],


### PR DESCRIPTION
and verify that SD-JWT VCs have either dc+sd-jwt or vc+sd-jwt as typ header. You can still use vc+sd-jwt as typ header by providing the headerType value when signing an SD-JWT VC. For OID4VCI the typ header is based on the oid4vci credential format used.