### PR TITLE
Update README.md with DeepWiki link

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Credo is a framework written in TypeScript for building **decentralized identity
 ## Quickstart
 
 Documentation on how to get started with Credo can be found at https://credo.js.org/
+DeepWiki AI-generated documentation on Credo can be found at https://deepwiki.com/openwallet-foundation/credo-ts
 
 ## Features
 


### PR DESCRIPTION
This PR adds a [DeepWiki](https://deepwiki.com/) link to the readme as an addition to our current documentation website. 

I think it would be helpful to add the deepwiki link here for users of the framework as a recommended documentation site. It is AI-based and generates a full documentation site. It's not perfect but it is quite extensive.

https://credo.js.org/ is not really updated and maintained to be the helpful resource that it could be, in addition to adding the deepwiki resource, we should align on what we would like to have as a documentation base, what provides value to users of the framework, and whether we can reliably outsource it to AI.
