### PR TITLE
docs(changeset): changed the console logger to call `toString()`

### DIFF
--- a/.changeset/fluffy-countries-hide.md
+++ b/.changeset/fluffy-countries-hide.md
@@ -1,0 +1,5 @@
+---
+"@credo-ts/core": minor
+---
+
+changed the console logger to call `toString()` on an error, due to the error serialization not working great in all environments

--- a/packages/core/src/logger/replaceError.ts
+++ b/packages/core/src/logger/replaceError.ts
@@ -3,14 +3,7 @@
  */
 export function replaceError(_: unknown, value: unknown) {
   if (value instanceof Error) {
-    const newValue = Object.getOwnPropertyNames(value).reduce(
-      (obj, propName) => {
-        obj[propName] = (value as unknown as Record<string, unknown>)[propName]
-        return obj
-      },
-      { name: value.name } as Record<string, unknown>
-    )
-    return newValue
+    return value.toString()
   }
 
   return value


### PR DESCRIPTION
 on an error, due to the error serialization not working great in all environments

Fixes #2274
