### PR TITLE
fix: correct revocation registry check edge case

### DIFF
--- a/.changeset/violet-meals-worry.md
+++ b/.changeset/violet-meals-worry.md
@@ -1,0 +1,5 @@
+---
+"@credo-ts/indy-vdr": patch
+---
+
+fix: correct revocation registry check edge case

--- a/packages/indy-vdr/src/anoncreds/utils/transform.ts
+++ b/packages/indy-vdr/src/anoncreds/utils/transform.ts
@@ -23,7 +23,7 @@ export function anonCredsRevocationStatusListFromIndyVdr(
   // Check whether the highest delta index is supported in the `maxCredNum` field of the
   // revocation registry definition. This will likely also be checked on other levels as well
   // by the ledger or the indy-vdr library itself
-  if (Math.max(...delta.issued, ...delta.revoked) >= revocationRegistryDefinition.value.maxCredNum) {
+  if (Math.max(...delta.issued, ...delta.revoked) > revocationRegistryDefinition.value.maxCredNum) {
     throw new CredoError(
       `Highest delta index '${Math.max(
         ...delta.issued,


### PR DESCRIPTION
We discovered this bug when we ran into an issue where if you created a credential with revocation registry size 4, issued 4 credentials, then revoked the last one, all proof requests with that credential would fail. Off by one errors strike again 😁