### PR TITLE
fix: remove Wallet injection symbol

### DIFF
--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -6,6 +6,5 @@ export const InjectionSymbols = {
   AgentDependencies: Symbol('AgentDependencies'),
   Stop$: Symbol('Stop$'),
   FileSystem: Symbol('FileSystem'),
-  Wallet: Symbol('Wallet'),
   WebCrypto: Symbol('WebCrypto'),
 }


### PR DESCRIPTION
I think after #2203 Wallet injection symbol is not used anymore. So I guess we can drop it?