### PR TITLE
fix: unhandled rejection in the oid4vp verifier service

### DIFF
--- a/.changeset/empty-days-tickle.md
+++ b/.changeset/empty-days-tickle.md
@@ -1,0 +1,5 @@
+---
+"@credo-ts/openid4vc": patch
+---
+
+fix: unhandled rejection in the oid4vp verifier service

--- a/packages/core/src/modules/vc/data-integrity/libraries/nativeDocumentLoader.ts
+++ b/packages/core/src/modules/vc/data-integrity/libraries/nativeDocumentLoader.ts
@@ -6,3 +6,4 @@ export function getNativeDocumentLoader(): () => DocumentLoader {
 
   return loader as () => DocumentLoader
 }
+ 

--- a/packages/core/src/modules/vc/data-integrity/libraries/nativeDocumentLoader.ts
+++ b/packages/core/src/modules/vc/data-integrity/libraries/nativeDocumentLoader.ts
@@ -6,4 +6,3 @@ export function getNativeDocumentLoader(): () => DocumentLoader {
 
   return loader as () => DocumentLoader
 }
- 


### PR DESCRIPTION
currently if `await relyingParty.createAuthorizationRequest` or `await relyingParty.verifyAuthorizationResponse` take longer than 10 seconds (the rxjs timeout), then the timeout throws an unhandled promise rejection that can bubble up in nasty ways.

This fix catches the error and wraps the promise as a result where the error is rethrown in the correct context