### PR TITLE
fix: correct indyVdrCreateLatestRevocationDelta to allow individual credential revocation/unrevocation

### DIFF
--- a/packages/indy-vdr/src/anoncreds/utils/__tests__/transform.test.ts
+++ b/packages/indy-vdr/src/anoncreds/utils/__tests__/transform.test.ts
@@ -102,7 +102,7 @@ describe('transform', () => {
           delta,
           true
         )
-      ).toThrowError()
+      ).toThrow()
     })
   })
 
@@ -170,7 +170,7 @@ describe('transform', () => {
 
       const { revoked, issued } = indyVdrCreateLatestRevocationDelta(accum, revocationStatusList, delta)
 
-      expect(issued).toStrictEqual([1, 2, 3, 4])
+      expect(issued).toStrictEqual([])
       expect(revoked).toStrictEqual([6, 7, 8, 9])
     })
 
@@ -184,7 +184,67 @@ describe('transform', () => {
 
       const revocationStatusList = [0, 0, 0, 0, 0, 1, 1, 1, 1, 1]
 
-      expect(() => indyVdrCreateLatestRevocationDelta(accum, revocationStatusList, delta)).toThrowError()
+      expect(() => indyVdrCreateLatestRevocationDelta(accum, revocationStatusList, delta)).toThrow()
+    })
+
+    test('unrevoking a credential adds its index to issued', () => {
+      // Previous delta: index 2 was revoked
+      const delta = {
+        accum,
+        issued: [],
+        revoked: [2],
+        txnTime: 1,
+      }
+
+      // Current status: index 2 is now active (unrevoked), no new revokes
+      const revocationStatusList = [0, 0, 0, 0, 0]
+      const { issued, revoked } = indyVdrCreateLatestRevocationDelta(accum, revocationStatusList, delta)
+      console.log(issued, revoked)
+      expect(issued).toStrictEqual([2])
+      expect(revoked).toStrictEqual([])
+    })
+
+    test('only newly unrevoked indexes are included in issued', () => {
+      // Previous: index 1 and 3 were revoked
+      const delta: RevocationRegistryDelta = {
+        accum,
+        issued: [],
+        revoked: [1, 3],
+        txnTime: 1,
+      }
+      // Now: index 1 is unrevoked (active), 3 is still revoked
+      const revocationStatusList = [0, 0, 0, 1, 0]
+      const { issued, revoked } = indyVdrCreateLatestRevocationDelta(accum, revocationStatusList, delta)
+      expect(issued).toStrictEqual([1])
+      expect(revoked).toStrictEqual([])
+    })
+
+    test('only newly revoked indexes are included in revoked', () => {
+      // Previous: index 1 and 3 were revoked
+      const delta: RevocationRegistryDelta = {
+        accum,
+        issued: [],
+        revoked: [1, 3],
+        txnTime: 1,
+      }
+      // Now: index 2 is newly revoked
+      const revocationStatusList = [0, 1, 1, 1, 0]
+      const { issued, revoked } = indyVdrCreateLatestRevocationDelta(accum, revocationStatusList, delta)
+      expect(issued).toStrictEqual([])
+      expect(revoked).toStrictEqual([2])
+    })
+
+    test('no change results in empty issued and revoked', () => {
+      const delta: RevocationRegistryDelta = {
+        accum,
+        issued: [],
+        revoked: [1, 3],
+        txnTime: 1,
+      }
+      const revocationStatusList = [0, 1, 0, 1, 0]
+      const { issued, revoked } = indyVdrCreateLatestRevocationDelta(accum, revocationStatusList, delta)
+      expect(issued).toStrictEqual([])
+      expect(revoked).toStrictEqual([])
     })
   })
 })

--- a/packages/indy-vdr/src/anoncreds/utils/transform.ts
+++ b/packages/indy-vdr/src/anoncreds/utils/transform.ts
@@ -94,9 +94,9 @@ export function indyVdrCreateLatestRevocationDelta(
 
   if (previousDelta) {
     revocationStatusList.forEach((revocationStatus, idx) => {
-      // Check whether the revocationStatusList entry is not included in the previous delta issued indices
-      if (revocationStatus === RevocationState.Active && !previousDelta.issued.includes(idx)) {
-        issued.push(idx)
+      // If the current status is Active and this index was previously revoked, it means the credential was just unrevoked, so add it to the issued list
+      if (revocationStatus === RevocationState.Active && previousDelta.revoked.includes(idx)) {
+        issued.push(idx);
       }
 
       // Check whether the revocationStatusList entry is not included in the previous delta revoked indices


### PR DESCRIPTION
## Summary

Fixes a bug in `indyVdrCreateLatestRevocationDelta` where the delta calculation incorrectly included all active indexes in `issued` if `previousDelta.issued` was empty, preventing correct individual credential revocation/unrevocation.

Closes #2318, #1960, #1807 

## Details

- The previous logic added all active indexes to `issued` if they were not in `previousDelta.issued`, even if they were never revoked.
- The new logic only adds indexes to `issued` if they were previously revoked and are now active (i.e., actually unrevoked).
- Updated/added tests to cover individual revoke and unrevoke scenarios.

## Testing

- All existing and new tests pass.
- See `transformers.test.ts` for new/updated test cases.

## Additional Context

See linked issues for detailed reproduction steps and discussion.