### PR TITLE
fix: correct provider source file in npm run script

### DIFF
--- a/demo-openid/package.json
+++ b/demo-openid/package.json
@@ -10,7 +10,7 @@
   "license": "Apache-2.0",
   "scripts": {
     "issuer": "ts-node src/IssuerInquirer.ts",
-    "provider": "tsx src/provider.js",
+    "provider": "tsx src/Provider.js",
     "holder": "ts-node src/HolderInquirer.ts",
     "verifier": "ts-node src/VerifierInquirer.ts",
     "proxies": "ngrok --config ngrok.yml,ngrok.auth.yml start provider issuer verifier"


### PR DESCRIPTION
In order to run the crede-ts demo properly it is required to fix the `npm run provider` script accordingly to the `Provider.js` in `src`.