### PR TITLE
fix(didcomm): support receivedAt in message receiver

### DIFF
--- a/packages/didcomm/src/DidCommModule.ts
+++ b/packages/didcomm/src/DidCommModule.ts
@@ -73,6 +73,7 @@ export class DidCommModule implements Module {
                 connection: e.payload.connection,
                 contextCorrelationId: e.payload.contextCorrelationId,
                 session: e.payload.session,
+                receivedAt: e.payload.receivedAt,
               })
               .catch((error) => {
                 agentContext.config.logger.error('Failed to process message', { error })


### PR DESCRIPTION
In https://github.com/openwallet-foundation/credo-ts/pull/1824 we've added reception time support for mediated messages. However, after the change in message processing we introduced at https://github.com/openwallet-foundation/credo-ts/pull/2026 it looks like we lost this functionality on client side, since we are not providing the `receivedAt` to the message receiver. So here's back!