### PR TITLE
fix: correct indyVdrCreateLatestRevocationDelta to allow individual credential revocation/unrevocation

### DIFF
--- a/.changeset/clean-zoos-swim.md
+++ b/.changeset/clean-zoos-swim.md
@@ -1,0 +1,5 @@
+---
+"@credo-ts/indy-vdr": patch
+---
+
+fix: correct indyVdrCreateLatestRevocationDelta to allow individual credential revocation/unrevocation

--- a/packages/indy-vdr/src/anoncreds/utils/transform.ts
+++ b/packages/indy-vdr/src/anoncreds/utils/transform.ts
@@ -94,8 +94,8 @@ export function indyVdrCreateLatestRevocationDelta(
 
   if (previousDelta) {
     revocationStatusList.forEach((revocationStatus, idx) => {
-      // Check whether the revocationStatusList entry is not included in the previous delta issued indices
-      if (revocationStatus === RevocationState.Active && !previousDelta.issued.includes(idx)) {
+      // If the current status is Active and this index was previously revoked, it means the credential was just unrevoked, so add it to the issued list
+      if (revocationStatus === RevocationState.Active && previousDelta.revoked.includes(idx)) {
         issued.push(idx)
       }
 


### PR DESCRIPTION
Backport of #2319 to v0.5.x

This PR cherry-picks the fix for `indyVdrCreateLatestRevocationDelta` to allow individual credential revocation/unrevocation.

See original PR #2319 for full context and discussion.