### PR TITLE
fix: incorrect DCQL query in OpenID4VC demo

### DIFF
--- a/demo-openid/src/Verifier.ts
+++ b/demo-openid/src/Verifier.ts
@@ -15,15 +15,15 @@ const universityDegreeDcql = {
   credential_sets: [
     {
       required: true,
-      options: [['UniversityDegreeCredential-vc+sd-jwt'], ['UniversityDegreeCredential-jwt_vc_json']],
+      options: [['UniversityDegreeCredential-vc-sd-jwt'], ['UniversityDegreeCredential-jwt_vc_json']],
     },
   ],
   credentials: [
     {
-      id: 'UniversityDegreeCredential-vc+sd-jwt',
+      id: 'UniversityDegreeCredential-vc-sd-jwt',
       format: 'vc+sd-jwt',
       meta: {
-        vct_values: ['UniversityDegree'],
+        vct_values: ['UniversityDegreeCredential'],
       },
     },
     {
@@ -36,7 +36,7 @@ const universityDegreeDcql = {
         },
       ],
       meta: {
-        type_values: [['UniversityDegree']],
+        type_values: [['UniversityDegreeCredential']],
       },
     },
   ],
@@ -46,12 +46,12 @@ const openBadgeCredentialDcql = {
   credential_sets: [
     {
       required: true,
-      options: [['OpenBadgeCredential-vc+sd-jwt'], ['OpenBadgeCredential-jwt_vc_json']],
+      options: [['OpenBadgeCredential-vc-sd-jwt'], ['OpenBadgeCredential-jwt_vc_json']],
     },
   ],
   credentials: [
     {
-      id: 'OpenBadgeCredential-vc+sd-jwt',
+      id: 'OpenBadgeCredential-vc-sd-jwt',
       format: 'vc+sd-jwt',
       meta: {
         vct_values: ['OpenBadgeCredential'],


### PR DESCRIPTION
In the OpenID4VC demo, presentation with DCQL failed with the holder unable to handle the request.

Two corrections to the DCQL query in the demo are made:
* The `id` is changed to not use the forbidden character `+`
* The credential type query is changed to match the credential type issued in the demo