### PR TITLE
feat: emit rotation event on hangup

### DIFF
--- a/packages/core/src/modules/connections/services/DidRotateService.ts
+++ b/packages/core/src/modules/connections/services/DidRotateService.ts
@@ -128,9 +128,13 @@ export class DidRotateService {
       connection.previousTheirDids = [...connection.previousTheirDids, connection.theirDid]
     }
 
+    const previousTheirDid = connection.theirDid    
     connection.theirDid = undefined
 
     await agentContext.dependencyManager.resolve(ConnectionService).update(agentContext, connection)
+    this.emitDidRotatedEvent(agentContext, connection, {
+      previousTheirDid,
+    })
   }
 
   /**


### PR DESCRIPTION
At present, `processHangup` succeeds without emitting any event that can be captured by an external component

Added standard `emitDidRotatedEvent`