### PR TITLE
feat(didcomm): emit event on hangup

### DIFF
--- a/.changeset/cyan-tomatoes-end.md
+++ b/.changeset/cyan-tomatoes-end.md
@@ -1,0 +1,5 @@
+---
+"@credo-ts/didcomm": patch
+---
+
+feat(didcomm): emit event on hangup

--- a/packages/didcomm/src/modules/connections/__tests__/did-rotate.test.ts
+++ b/packages/didcomm/src/modules/connections/__tests__/did-rotate.test.ts
@@ -434,7 +434,6 @@ describe('Rotation E2E tests', () => {
       expect(aliceBasicMessages.find((message) => message.content === 'Message before hangup')).toBeUndefined()
     })
 
-
     test('Event emitted after processing hangup', async () => {
       // Send message to initial did
       await bobAgent.modules.basicMessages.sendMessage(bobAliceConnection!.id, 'Hello initial did')

--- a/packages/didcomm/src/modules/connections/__tests__/did-rotate.test.ts
+++ b/packages/didcomm/src/modules/connections/__tests__/did-rotate.test.ts
@@ -433,5 +433,20 @@ describe('Rotation E2E tests', () => {
       const aliceBasicMessages = await aliceAgent.modules.basicMessages.findAllByQuery({})
       expect(aliceBasicMessages.find((message) => message.content === 'Message before hangup')).toBeUndefined()
     })
+
+
+    test('Event emitted after processing hangup', async () => {
+      // Send message to initial did
+      await bobAgent.modules.basicMessages.sendMessage(bobAliceConnection!.id, 'Hello initial did')
+
+      await waitForBasicMessage(aliceAgent, { content: 'Hello initial did' })
+
+      // Call hangup
+      await aliceAgent.modules.connections.hangup({ connectionId: aliceBobConnection!.id })
+
+      // Catch did rotation event message from processHangup()
+      const rotationEvent = await waitForDidRotate(bobAgent, {})
+      expect(rotationEvent.theirDid?.to).toBeUndefined()
+    })
   })
 })

--- a/packages/didcomm/src/modules/connections/__tests__/did-rotate.test.ts
+++ b/packages/didcomm/src/modules/connections/__tests__/did-rotate.test.ts
@@ -436,12 +436,13 @@ describe('Rotation E2E tests', () => {
 
     test('Event emitted after processing hangup', async () => {
       // Send message to initial did
-      await bobAgent.modules.basicMessages.sendMessage(bobAliceConnection!.id, 'Hello initial did')
+      // biome-ignore lint/style/noNonNullAssertion: <explanation>
+      await bobAgent.modules.basicMessages.sendMessage(bobAliceConnection?.id!, 'Hello initial did')
 
       await waitForBasicMessage(aliceAgent, { content: 'Hello initial did' })
 
-      // Call hangup
-      await aliceAgent.modules.connections.hangup({ connectionId: aliceBobConnection!.id })
+      // biome-ignore lint/style/noNonNullAssertion: <explanation>
+      await aliceAgent.modules.connections.hangup({ connectionId: aliceBobConnection?.id! })
 
       // Catch did rotation event message from processHangup()
       const rotationEvent = await waitForDidRotate(bobAgent, {})

--- a/packages/didcomm/src/modules/connections/services/DidRotateService.ts
+++ b/packages/didcomm/src/modules/connections/services/DidRotateService.ts
@@ -132,9 +132,13 @@ export class DidRotateService {
       connection.previousTheirDids = [...connection.previousTheirDids, connection.theirDid]
     }
 
+    const previousTheirDid = connection.theirDid
     connection.theirDid = undefined
 
     await agentContext.dependencyManager.resolve(ConnectionService).update(agentContext, connection)
+    this.emitDidRotatedEvent(agentContext, connection, {
+      previousTheirDid,
+    })
   }
 
   /**


### PR DESCRIPTION
Emit a `didRotated` event from `processHangup` method so it can be captured by a client