### PR TITLE
feat!: drop label and connectionImageUrl from agent config

### DIFF
--- a/demo-openid/src/BaseAgent.ts
+++ b/demo-openid/src/BaseAgent.ts
@@ -35,7 +35,6 @@ export class BaseAgent<AgentModules extends ModulesMap> {
     this.app = express()
 
     const config = {
-      label: name,
       allowInsecureHttpUrls: true,
       logger: new ConsoleLogger(LogLevel.off),
     } satisfies InitConfig

--- a/demo/src/Alice.ts
+++ b/demo/src/Alice.ts
@@ -26,7 +26,9 @@ export class Alice extends BaseAgent {
   }
 
   private async receiveConnectionRequest(invitationUrl: string) {
-    const { connectionRecord } = await this.agent.modules.oob.receiveInvitationFromUrl(invitationUrl)
+    const { connectionRecord } = await this.agent.modules.oob.receiveInvitationFromUrl(invitationUrl, {
+      label: 'alice',
+    })
     if (!connectionRecord) {
       throw new Error(redText(Output.NoConnectionRecordFromOutOfBand))
     }

--- a/demo/src/BaseAgent.ts
+++ b/demo/src/BaseAgent.ts
@@ -1,4 +1,3 @@
-import type { InitConfig } from '@credo-ts/core'
 import type { DidCommModuleConfigOptions } from '@credo-ts/didcomm'
 import type { IndyVdrPoolConfig } from '@credo-ts/indy-vdr'
 
@@ -57,21 +56,14 @@ type DemoAgent = Agent<ReturnType<typeof getAskarAnonCredsIndyModules>>
 export class BaseAgent {
   public port: number
   public name: string
-  public config: InitConfig
   public agent: DemoAgent
 
   public constructor({ port, name }: { port: number; name: string }) {
     this.name = name
     this.port = port
 
-    const config = {
-      label: name,
-    } satisfies InitConfig
-
-    this.config = config
-
     this.agent = new Agent({
-      config,
+      config: {},
       dependencies: agentDependencies,
       modules: getAskarAnonCredsIndyModules({ endpoints: [`http://localhost:${this.port}`] }, { id: name, key: name }),
     })

--- a/packages/anoncreds/src/protocols/credentials/v1/__tests__/v1-connectionless-credentials.e2e.test.ts
+++ b/packages/anoncreds/src/protocols/credentials/v1/__tests__/v1-connectionless-credentials.e2e.test.ts
@@ -62,7 +62,7 @@ describe('V1 Connectionless Credentials', () => {
       domain: 'https://a-domain.com',
     })
 
-    await aliceAgent.modules.oob.receiveInvitationFromUrl(invitationUrl)
+    await aliceAgent.modules.oob.receiveInvitationFromUrl(invitationUrl, { label: 'alice' })
 
     let aliceCredentialRecord = await waitForCredentialRecordSubject(aliceReplay, {
       threadId: faberCredentialRecord.threadId,
@@ -163,7 +163,7 @@ describe('V1 Connectionless Credentials', () => {
     })
 
     // Receive Message
-    await aliceAgent.modules.oob.receiveInvitationFromUrl(invitationUrl)
+    await aliceAgent.modules.oob.receiveInvitationFromUrl(invitationUrl, { label: 'alice' })
 
     // Wait for it to be processed
     let aliceCredentialRecord = await waitForCredentialRecordSubject(aliceReplay, {

--- a/packages/anoncreds/src/protocols/proofs/v1/__tests__/v1-connectionless-proofs.e2e.test.ts
+++ b/packages/anoncreds/src/protocols/proofs/v1/__tests__/v1-connectionless-proofs.e2e.test.ts
@@ -121,7 +121,7 @@ describe('V1 Proofs - Connectionless - Indy', () => {
       messages: [message],
       handshake: false,
     })
-    await aliceAgent.modules.oob.receiveInvitation(outOfBandRecord.outOfBandInvitation)
+    await aliceAgent.modules.oob.receiveInvitation(outOfBandRecord.outOfBandInvitation, { label: 'alice' })
 
     testLogger.test('Alice waits for presentation request from Faber')
     let aliceProofExchangeRecord = await waitForProofExchangeRecordSubject(aliceReplay, {
@@ -241,7 +241,7 @@ describe('V1 Proofs - Connectionless - Indy', () => {
       domain: 'https://a-domain.com',
     })
 
-    await aliceAgent.modules.oob.receiveInvitationFromUrl(invitationUrl)
+    await aliceAgent.modules.oob.receiveInvitationFromUrl(invitationUrl, { label: 'alice' })
 
     await waitForProofExchangeRecordSubject(aliceReplay, {
       state: ProofState.Done,
@@ -335,7 +335,7 @@ describe('V1 Proofs - Connectionless - Indy', () => {
       await faberAgent.modules.didcomm.unregisterOutboundTransport(transport)
     }
 
-    await aliceAgent.modules.oob.receiveInvitationFromUrl(invitationUrl)
+    await aliceAgent.modules.oob.receiveInvitationFromUrl(invitationUrl, { label: 'alice' })
 
     await waitForProofExchangeRecordSubject(aliceReplay, {
       state: ProofState.Done,
@@ -531,7 +531,7 @@ describe('V1 Proofs - Connectionless - Indy', () => {
       },
     })
 
-    await aliceAgent.modules.oob.receiveInvitationFromUrl(invitationUrl)
+    await aliceAgent.modules.oob.receiveInvitationFromUrl(invitationUrl, { label: 'alice' })
 
     await waitForProofExchangeRecordSubject(aliceReplay, {
       state: ProofState.Done,

--- a/packages/anoncreds/src/updates/__tests__/0.3.test.ts
+++ b/packages/anoncreds/src/updates/__tests__/0.3.test.ts
@@ -37,9 +37,7 @@ describe('UpdateAssistant | AnonCreds | v0.3.1 - v0.4', () => {
 
     const agent = new Agent(
       {
-        config: {
-          label: 'Test Agent',
-        },
+        config: {},
         dependencies: agentDependencies,
         modules: {
           // We need to include the AnonCredsModule to run the updates
@@ -109,9 +107,7 @@ describe('UpdateAssistant | AnonCreds | v0.3.1 - v0.4', () => {
 
     const agent = new Agent(
       {
-        config: {
-          label: 'Test Agent',
-        },
+        config: {},
         dependencies: agentDependencies,
         modules: {
           // We need to include the AnonCredsModule to run the updates

--- a/packages/anoncreds/src/updates/__tests__/0.4.test.ts
+++ b/packages/anoncreds/src/updates/__tests__/0.4.test.ts
@@ -49,9 +49,7 @@ describe('UpdateAssistant | AnonCreds | v0.4 - v0.5', () => {
 
     const agent = new Agent(
       {
-        config: {
-          label: 'Test Agent',
-        },
+        config: {},
         dependencies: agentDependencies,
         modules: {
           cache: new CacheModule({

--- a/packages/askar/tests/askar-postgres.e2e.test.ts
+++ b/packages/askar/tests/askar-postgres.e2e.test.ts
@@ -6,6 +6,7 @@ import { Subject } from 'rxjs'
 import { SubjectInboundTransport } from '../../../tests/transport/SubjectInboundTransport'
 import { SubjectOutboundTransport } from '../../../tests/transport/SubjectOutboundTransport'
 
+import { getDefaultDidcommModules } from '@credo-ts/didcomm'
 import { askarPostgresStorageConfig, e2eTest, getAskarPostgresAgentOptions } from './helpers'
 
 const alicePostgresAgentOptions = getAskarPostgresAgentOptions(
@@ -22,8 +23,8 @@ const bobPostgresAgentOptions = getAskarPostgresAgentOptions(
 )
 
 describe('Askar Postgres agents', () => {
-  let aliceAgent: Agent<(typeof alicePostgresAgentOptions)['modules']>
-  let bobAgent: Agent<(typeof bobPostgresAgentOptions)['modules']>
+  let aliceAgent: Agent<ReturnType<typeof getDefaultDidcommModules>>
+  let bobAgent: Agent<ReturnType<typeof getDefaultDidcommModules>>
 
   test('Postgres Askar wallets E2E test', async () => {
     const aliceMessages = new Subject<SubjectMessage>()

--- a/packages/askar/tests/helpers.ts
+++ b/packages/askar/tests/helpers.ts
@@ -42,7 +42,6 @@ export function getAskarPostgresAgentOptions(
 ) {
   const random = utils.uuid().slice(0, 4)
   const config: InitConfig = {
-    label: `PostgresAgent: ${name} - ${random}`,
     autoUpdateStorageOnStartup: false,
     logger: new TestLogger(LogLevel.off, name),
     ...extraConfig,
@@ -75,7 +74,6 @@ export function getAskarSqliteAgentOptions(
 ) {
   const random = utils.uuid().slice(0, 4)
   const config: InitConfig = {
-    label: `SQLiteAgent: ${name} - ${random}`,
     autoUpdateStorageOnStartup: false,
     logger: new TestLogger(LogLevel.off, name),
     ...extraConfig,
@@ -105,13 +103,19 @@ export function getAskarSqliteAgentOptions(
  * @param senderAgent
  * @param receiverAgent
  */
-export async function e2eTest(senderAgent: Agent, receiverAgent: Agent) {
+export async function e2eTest(
+  senderAgent: Agent<ReturnType<typeof getDefaultDidcommModules>>,
+  receiverAgent: Agent<ReturnType<typeof getDefaultDidcommModules>>
+) {
   const senderReceiverOutOfBandRecord = await senderAgent.modules.oob.createInvitation({
     handshakeProtocols: [HandshakeProtocol.Connections],
   })
 
   const { connectionRecord: bobConnectionAtReceiversender } = await receiverAgent.modules.oob.receiveInvitation(
-    senderReceiverOutOfBandRecord.outOfBandInvitation
+    senderReceiverOutOfBandRecord.outOfBandInvitation,
+    {
+      label: 'receiver',
+    }
   )
   if (!bobConnectionAtReceiversender) throw new Error('Connection not created')
 

--- a/packages/core/src/agent/AgentConfig.ts
+++ b/packages/core/src/agent/AgentConfig.ts
@@ -6,13 +6,11 @@ import { ConsoleLogger, LogLevel } from '../logger'
 
 export class AgentConfig {
   private initConfig: InitConfig
-  public label: string
   public logger: Logger
   public readonly agentDependencies: AgentDependencies
 
   public constructor(initConfig: InitConfig, agentDependencies: AgentDependencies) {
     this.initConfig = initConfig
-    this.label = initConfig.label
     this.logger = initConfig.logger ?? new ConsoleLogger(LogLevel.off)
     this.agentDependencies = agentDependencies
   }
@@ -26,10 +24,7 @@ export class AgentConfig {
   }
 
   public extend(config: Partial<InitConfig>): AgentConfig {
-    return new AgentConfig(
-      { ...this.initConfig, logger: this.logger, label: this.label, ...config },
-      this.agentDependencies
-    )
+    return new AgentConfig({ ...this.initConfig, logger: this.logger, ...config }, this.agentDependencies)
   }
 
   public toJSON() {
@@ -37,7 +32,6 @@ export class AgentConfig {
       ...this.initConfig,
       logger: this.logger.logLevel,
       agentDependencies: Boolean(this.agentDependencies),
-      label: this.label,
     }
   }
 }

--- a/packages/core/src/agent/__tests__/AgentConfig.test.ts
+++ b/packages/core/src/agent/__tests__/AgentConfig.test.ts
@@ -1,31 +1,13 @@
-import { agentDependencies, getAgentConfig } from '../../../tests/helpers'
+import { agentDependencies } from '../../../tests/helpers'
 import { AgentConfig } from '../AgentConfig'
 
 describe('AgentConfig', () => {
-  describe('label', () => {
-    it('should return new label after setter is called', async () => {
-      expect.assertions(2)
-      const newLabel = 'Agent: Agent Class Test 2'
-
-      const agentConfig = getAgentConfig(
-        'AgentConfig Test',
-        {},
-        {
-          label: 'Test',
-        }
-      )
-      expect(agentConfig.label).toBe('Test')
-
-      agentConfig.label = newLabel
-      expect(agentConfig.label).toBe(newLabel)
-    })
-  })
-
   describe('extend()', () => {
     it('extends the existing AgentConfig', () => {
       const agentConfig = new AgentConfig(
         {
-          label: 'hello',
+          allowInsecureHttpUrls: true,
+          autoUpdateStorageOnStartup: true,
         },
         agentDependencies
       )
@@ -33,24 +15,28 @@ describe('AgentConfig', () => {
       const newAgentConfig = agentConfig.extend({})
 
       expect(newAgentConfig).toMatchObject({
-        label: 'hello',
+        allowInsecureHttpUrls: true,
+        autoUpdateStorageOnStartup: true,
       })
     })
 
     it('takes the init config from the extend method', () => {
       const agentConfig = new AgentConfig(
         {
-          label: 'hello',
+          allowInsecureHttpUrls: false,
+          autoUpdateStorageOnStartup: false,
         },
         agentDependencies
       )
 
       const newAgentConfig = agentConfig.extend({
-        label: 'anotherLabel',
+        allowInsecureHttpUrls: false,
+        autoUpdateStorageOnStartup: true,
       })
 
       expect(newAgentConfig).toMatchObject({
-        label: 'anotherLabel',
+        allowInsecureHttpUrls: false,
+        autoUpdateStorageOnStartup: true,
       })
     })
   })

--- a/packages/core/src/storage/migration/__tests__/0.1.test.ts
+++ b/packages/core/src/storage/migration/__tests__/0.1.test.ts
@@ -30,7 +30,7 @@ describe('UpdateAssistant | v0.1 - v0.2', () => {
 
     for (const mediationRoleUpdateStrategy of mediationRoleUpdateStrategies) {
       const agent = new Agent({
-        config: { label: 'Test Agent' },
+        config: {},
         dependencies,
         modules: {
           inMemory: new InMemoryWalletModule(),
@@ -88,7 +88,7 @@ describe('UpdateAssistant | v0.1 - v0.2', () => {
     )
 
     const agent = new Agent({
-      config: { label: 'Test Agent' },
+      config: {},
       dependencies,
       modules: {
         inMemory: new InMemoryWalletModule(),
@@ -146,7 +146,7 @@ describe('UpdateAssistant | v0.1 - v0.2', () => {
     )
 
     const agent = new Agent({
-      config: { label: 'Test Agent', autoUpdateStorageOnStartup: true },
+      config: { autoUpdateStorageOnStartup: true },
       dependencies,
       modules: {
         inMemory: new InMemoryWalletModule(),
@@ -205,7 +205,6 @@ describe('UpdateAssistant | v0.1 - v0.2', () => {
 
     const agent = new Agent({
       config: {
-        label: 'Test Agent',
         autoUpdateStorageOnStartup: true,
       },
       modules: {

--- a/packages/core/src/storage/migration/__tests__/0.2.test.ts
+++ b/packages/core/src/storage/migration/__tests__/0.2.test.ts
@@ -26,9 +26,7 @@ describe('UpdateAssistant | v0.2 - v0.3.1', () => {
     )
 
     const agent = new Agent({
-      config: {
-        label: 'Test Agent',
-      },
+      config: {},
       dependencies: agentDependencies,
       modules: {
         inMemory: new InMemoryWalletModule(),
@@ -91,7 +89,6 @@ describe('UpdateAssistant | v0.2 - v0.3.1', () => {
 
     const agent = new Agent({
       config: {
-        label: 'Test Agent',
         autoUpdateStorageOnStartup: true,
       },
       modules: {
@@ -129,7 +126,6 @@ describe('UpdateAssistant | v0.2 - v0.3.1', () => {
 
     const agent = new Agent({
       config: {
-        label: 'Test Agent',
         autoUpdateStorageOnStartup: true,
       },
       dependencies: agentDependencies,

--- a/packages/core/src/storage/migration/__tests__/0.3.test.ts
+++ b/packages/core/src/storage/migration/__tests__/0.3.test.ts
@@ -24,9 +24,7 @@ describe('UpdateAssistant | v0.3.1 - v0.4', () => {
     )
 
     const agent = new Agent({
-      config: {
-        label: 'Test Agent',
-      },
+      config: {},
       dependencies: agentDependencies,
       modules: {
         inMemory: new InMemoryWalletModule(),
@@ -83,9 +81,7 @@ describe('UpdateAssistant | v0.3.1 - v0.4', () => {
     )
 
     const agent = new Agent({
-      config: {
-        label: 'Test Agent',
-      },
+      config: {},
       dependencies: agentDependencies,
       modules: {
         inMemory: new InMemoryWalletModule(),

--- a/packages/core/src/storage/migration/__tests__/0.4.test.ts
+++ b/packages/core/src/storage/migration/__tests__/0.4.test.ts
@@ -26,9 +26,7 @@ describe('UpdateAssistant | v0.4 - v0.5', () => {
     )
 
     const agent = new Agent({
-      config: {
-        label: 'Test Agent',
-      },
+      config: {},
       dependencies: agentDependencies,
       modules: {
         inMemory: new InMemoryWalletModule(),
@@ -89,9 +87,7 @@ describe('UpdateAssistant | v0.4 - v0.5', () => {
 
     // We need core DIDComm modules for this update to fully work
     const agent = new Agent({
-      config: {
-        label: 'Test Agent',
-      },
+      config: {},
       modules: { ...getDefaultDidcommModules(), inMemory: new InMemoryWalletModule() },
       dependencies: agentDependencies,
     })
@@ -144,9 +140,7 @@ describe('UpdateAssistant | v0.4 - v0.5', () => {
 
     // We need core DIDComm modules for this update to fully work
     const agent = new Agent({
-      config: {
-        label: 'Test Agent',
-      },
+      config: {},
       modules: { ...getDefaultDidcommModules(), inMemory: new InMemoryWalletModule() },
       dependencies: agentDependencies,
     })

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -2,10 +2,6 @@ import { Kms } from '.'
 import type { Logger } from './logger'
 
 export interface InitConfig {
-  /**
-   * Agent public endpoints, sorted by priority (higher priority first)
-   */
-  label: string
   logger?: Logger
   autoUpdateStorageOnStartup?: boolean
 

--- a/packages/core/tests/agents.test.ts
+++ b/packages/core/tests/agents.test.ts
@@ -50,7 +50,8 @@ describe('agents', () => {
     })
 
     const { connectionRecord: bobConnectionAtBobAlice } = await bobAgent.modules.oob.receiveInvitation(
-      aliceBobOutOfBandRecord.outOfBandInvitation
+      aliceBobOutOfBandRecord.outOfBandInvitation,
+      { label: 'alice' }
     )
     bobConnection = await bobAgent.modules.connections.returnWhenIsConnected(bobConnectionAtBobAlice?.id)
 

--- a/packages/core/tests/connections.test.ts
+++ b/packages/core/tests/connections.test.ts
@@ -96,8 +96,10 @@ describe('connections', () => {
     const invitationUrl = invitation.toUrl({ domain: 'https://example.com' })
 
     // Receive invitation with alice agent
-    let { connectionRecord: aliceFaberConnection } =
-      await aliceAgent.modules.oob.receiveInvitationFromUrl(invitationUrl)
+    let { connectionRecord: aliceFaberConnection } = await aliceAgent.modules.oob.receiveInvitationFromUrl(
+      invitationUrl,
+      { label: 'alice' }
+    )
     // biome-ignore lint/style/noNonNullAssertion: <explanation>
     aliceFaberConnection = await aliceAgent.modules.connections.returnWhenIsConnected(aliceFaberConnection?.id!)
     expect(aliceFaberConnection.state).toBe(DidExchangeState.Completed)
@@ -117,8 +119,10 @@ describe('connections', () => {
     const invitationUrl = invitation.toUrl({ domain: 'https://example.com' })
 
     // Receive invitation first time with alice agent
-    let { connectionRecord: aliceFaberConnection } =
-      await aliceAgent.modules.oob.receiveInvitationFromUrl(invitationUrl)
+    let { connectionRecord: aliceFaberConnection } = await aliceAgent.modules.oob.receiveInvitationFromUrl(
+      invitationUrl,
+      { label: 'alice' }
+    )
     // biome-ignore lint/style/noNonNullAssertion: <explanation>
     aliceFaberConnection = await aliceAgent.modules.connections.returnWhenIsConnected(aliceFaberConnection?.id!)
     expect(aliceFaberConnection.state).toBe(DidExchangeState.Completed)
@@ -127,6 +131,7 @@ describe('connections', () => {
     let { connectionRecord: acmeFaberConnection } = await acmeAgent.modules.oob.receiveInvitationFromUrl(
       invitationUrl,
       {
+        label: 'acme',
         reuseConnection: false,
       }
     )
@@ -160,8 +165,10 @@ describe('connections', () => {
     const invitationUrl = invitation.toUrl({ domain: 'https://example.com' })
 
     // Receive invitation first time with alice agent
-    let { connectionRecord: aliceFaberConnection } =
-      await aliceAgent.modules.oob.receiveInvitationFromUrl(invitationUrl)
+    let { connectionRecord: aliceFaberConnection } = await aliceAgent.modules.oob.receiveInvitationFromUrl(
+      invitationUrl,
+      { label: 'alice' }
+    )
     // biome-ignore lint/style/noNonNullAssertion: <explanation>
     aliceFaberConnection = await aliceAgent.modules.connections.returnWhenIsConnected(aliceFaberConnection?.id!)
     expect(aliceFaberConnection.state).toBe(DidExchangeState.Completed)
@@ -211,8 +218,10 @@ describe('connections', () => {
     const invitationUrl = invitation.toUrl({ domain: 'https://example.com' })
 
     // Create first connection
-    let { connectionRecord: aliceFaberConnection1 } =
-      await aliceAgent.modules.oob.receiveInvitationFromUrl(invitationUrl)
+    let { connectionRecord: aliceFaberConnection1 } = await aliceAgent.modules.oob.receiveInvitationFromUrl(
+      invitationUrl,
+      { label: 'alice' }
+    )
 
     // biome-ignore lint/style/noNonNullAssertion: <explanation>
     aliceFaberConnection1 = await aliceAgent.modules.connections.returnWhenIsConnected(aliceFaberConnection1?.id!)
@@ -222,6 +231,7 @@ describe('connections', () => {
     let { connectionRecord: aliceFaberConnection2 } = await aliceAgent.modules.oob.receiveInvitationFromUrl(
       invitationUrl,
       {
+        label: 'agent',
         reuseConnection: false,
       }
     )
@@ -248,7 +258,9 @@ describe('connections', () => {
   it('agent using mediator should be able to make multiple connections using a multi use invite', async () => {
     // Make Faber use a mediator
     const { outOfBandInvitation: mediatorOutOfBandInvitation } = await mediatorAgent.modules.oob.createInvitation({})
-    let { connectionRecord } = await faberAgent.modules.oob.receiveInvitation(mediatorOutOfBandInvitation)
+    let { connectionRecord } = await faberAgent.modules.oob.receiveInvitation(mediatorOutOfBandInvitation, {
+      label: 'faber',
+    })
     // biome-ignore lint/style/noNonNullAssertion: <explanation>
     connectionRecord = await faberAgent.modules.connections.returnWhenIsConnected(connectionRecord?.id!)
 
@@ -282,8 +294,10 @@ describe('connections', () => {
     const invitationUrl = invitation.toUrl({ domain: 'https://example.com' })
 
     // Receive invitation first time with alice agent
-    let { connectionRecord: aliceFaberConnection } =
-      await aliceAgent.modules.oob.receiveInvitationFromUrl(invitationUrl)
+    let { connectionRecord: aliceFaberConnection } = await aliceAgent.modules.oob.receiveInvitationFromUrl(
+      invitationUrl,
+      { label: 'alice' }
+    )
     // biome-ignore lint/style/noNonNullAssertion: <explanation>
     aliceFaberConnection = await aliceAgent.modules.connections.returnWhenIsConnected(aliceFaberConnection?.id!)
     expect(aliceFaberConnection.state).toBe(DidExchangeState.Completed)
@@ -292,6 +306,7 @@ describe('connections', () => {
     let { connectionRecord: acmeFaberConnection } = await acmeAgent.modules.oob.receiveInvitationFromUrl(
       invitationUrl,
       {
+        label: 'acme',
         reuseConnection: false,
       }
     )

--- a/packages/core/tests/helpers.ts
+++ b/packages/core/tests/helpers.ts
@@ -112,9 +112,8 @@ export function getAgentOptions<AgentModules extends AgentModulesInput | EmptyMo
   dependencies: AgentDependencies
   inMemory?: boolean
 } {
-  const random = uuid().slice(0, 4)
+  const _random = uuid().slice(0, 4)
   const config: InitConfig = {
-    label: `Agent: ${name} - ${random}`,
     // TODO: determine the log level based on an environment variable. This will make it
     // possible to run e.g. failed github actions in debug mode for extra logs
     logger: TestLogger.fromLogger(testLogger, name),
@@ -726,7 +725,8 @@ export async function makeConnection(agentA: Agent<DefaultAgentModulesInput>, ag
   })
 
   let { connectionRecord: agentBConnection } = await agentB.modules.oob.receiveInvitation(
-    agentAOutOfBand.outOfBandInvitation
+    agentAOutOfBand.outOfBandInvitation,
+    { label: '' }
   )
 
   // biome-ignore lint/style/noNonNullAssertion: <explanation>

--- a/packages/core/tests/multi-protocol-version.test.ts
+++ b/packages/core/tests/multi-protocol-version.test.ts
@@ -57,6 +57,7 @@ describe('multi version protocols', () => {
 
     const { outOfBandInvitation, id } = await aliceAgent.modules.oob.createInvitation()
     let { connectionRecord: bobConnection } = await bobAgent.modules.oob.receiveInvitation(outOfBandInvitation, {
+      label: 'bob',
       autoAcceptConnection: true,
       autoAcceptInvitation: true,
     })

--- a/packages/core/tests/oob-mediation-provision.test.ts
+++ b/packages/core/tests/oob-mediation-provision.test.ts
@@ -73,7 +73,9 @@ describe('out of band with mediation set up with provision method', () => {
     const mediationOutOfBandRecord = await mediatorAgent.modules.oob.createInvitation(makeConnectionConfig)
     mediatorOutOfBandInvitation = mediationOutOfBandRecord.outOfBandInvitation
 
-    let { connectionRecord } = await aliceAgent.modules.oob.receiveInvitation(mediatorOutOfBandInvitation)
+    let { connectionRecord } = await aliceAgent.modules.oob.receiveInvitation(mediatorOutOfBandInvitation, {
+      label: 'alice',
+    })
     // biome-ignore lint/style/noNonNullAssertion: <explanation>
     connectionRecord = await aliceAgent.modules.connections.returnWhenIsConnected(connectionRecord?.id!)
     // biome-ignore lint/style/noNonNullAssertion: <explanation>
@@ -97,7 +99,9 @@ describe('out of band with mediation set up with provision method', () => {
     const { outOfBandInvitation } = outOfBandRecord
     const urlMessage = outOfBandInvitation.toUrl({ domain: 'http://example.com' })
 
-    let { connectionRecord: aliceFaberConnection } = await aliceAgent.modules.oob.receiveInvitationFromUrl(urlMessage)
+    let { connectionRecord: aliceFaberConnection } = await aliceAgent.modules.oob.receiveInvitationFromUrl(urlMessage, {
+      label: 'alice',
+    })
 
     // biome-ignore lint/style/noNonNullAssertion: <explanation>
     aliceFaberConnection = await aliceAgent.modules.connections.returnWhenIsConnected(aliceFaberConnection?.id!)

--- a/packages/core/tests/oob-mediation.test.ts
+++ b/packages/core/tests/oob-mediation.test.ts
@@ -1,5 +1,5 @@
 import type { SubjectMessage } from '../../../tests/transport/SubjectInboundTransport'
-import type { AgentMessageProcessedEvent } from '../../didcomm/src'
+import type { AgentMessageProcessedEvent, getDefaultDidcommModules } from '../../didcomm/src'
 import type { OutOfBandDidCommService } from '../../didcomm/src/modules/oob'
 
 import { Subject, filter, firstValueFrom, map, timeout } from 'rxjs'
@@ -62,9 +62,9 @@ describe('out of band with mediation', () => {
     multiUseInvitation: false,
   }
 
-  let faberAgent: Agent
-  let aliceAgent: Agent
-  let mediatorAgent: Agent
+  let faberAgent: Agent<ReturnType<typeof getDefaultDidcommModules>>
+  let aliceAgent: Agent<ReturnType<typeof getDefaultDidcommModules>>
+  let mediatorAgent: Agent<ReturnType<typeof getDefaultDidcommModules>>
 
   beforeAll(async () => {
     const faberMessages = new Subject<SubjectMessage>()
@@ -96,8 +96,10 @@ describe('out of band with mediation', () => {
     const { outOfBandInvitation: mediatorOutOfBandInvitation } = mediationOutOfBandRecord
     const mediatorUrlMessage = mediatorOutOfBandInvitation.toUrl({ domain: 'http://example.com' })
 
-    let { connectionRecord: aliceMediatorConnection } =
-      await aliceAgent.modules.oob.receiveInvitationFromUrl(mediatorUrlMessage)
+    let { connectionRecord: aliceMediatorConnection } = await aliceAgent.modules.oob.receiveInvitationFromUrl(
+      mediatorUrlMessage,
+      { label: 'alice' }
+    )
 
     aliceMediatorConnection = await aliceAgent.modules.connections.returnWhenIsConnected(aliceMediatorConnection?.id)
     expect(aliceMediatorConnection.state).toBe(DidExchangeState.Completed)
@@ -145,7 +147,9 @@ describe('out of band with mediation', () => {
     const { outOfBandInvitation } = outOfBandRecord
     const urlMessage = outOfBandInvitation.toUrl({ domain: 'http://example.com' })
 
-    let { connectionRecord: aliceFaberConnection } = await aliceAgent.modules.oob.receiveInvitationFromUrl(urlMessage)
+    let { connectionRecord: aliceFaberConnection } = await aliceAgent.modules.oob.receiveInvitationFromUrl(urlMessage, {
+      label: 'alice',
+    })
 
     aliceFaberConnection = await aliceAgent.modules.connections.returnWhenIsConnected(aliceFaberConnection?.id)
     expect(aliceFaberConnection.state).toBe(DidExchangeState.Completed)

--- a/packages/core/tests/oob.test.ts
+++ b/packages/core/tests/oob.test.ts
@@ -80,6 +80,7 @@ describe('out of band', () => {
   }
 
   const receiveInvitationConfig = {
+    label: 'alice',
     autoAcceptConnection: false,
   }
 
@@ -298,6 +299,7 @@ describe('out of band', () => {
 
       const { outOfBandRecord: receivedOutOfBandRecord, connectionRecord } =
         await aliceAgent.modules.oob.receiveInvitation(outOfBandInvitation, {
+          label: 'alice',
           autoAcceptInvitation: false,
           autoAcceptConnection: false,
         })
@@ -314,7 +316,7 @@ describe('out of band', () => {
       const urlMessage = outOfBandInvitation.toUrl({ domain: 'http://example.com' })
 
       let { outOfBandRecord: receivedOutOfBandRecord, connectionRecord: aliceFaberConnection } =
-        await aliceAgent.modules.oob.receiveInvitationFromUrl(urlMessage)
+        await aliceAgent.modules.oob.receiveInvitationFromUrl(urlMessage, { label: 'alice' })
       expect(receivedOutOfBandRecord.state).toBe(OutOfBandState.PrepareResponse)
 
       // biome-ignore lint/style/noNonNullAssertion: <explanation>
@@ -340,7 +342,10 @@ describe('out of band', () => {
       const { outOfBandInvitation } = outOfBandRecord
       const urlMessage = outOfBandInvitation.toUrl({ domain: 'http://example.com' })
 
-      let { connectionRecord: aliceFaberConnection } = await aliceAgent.modules.oob.receiveInvitationFromUrl(urlMessage)
+      let { connectionRecord: aliceFaberConnection } = await aliceAgent.modules.oob.receiveInvitationFromUrl(
+        urlMessage,
+        { label: 'alice' }
+      )
 
       // biome-ignore lint/style/noNonNullAssertion: <explanation>
       aliceFaberConnection = await aliceAgent.modules.connections.returnWhenIsConnected(aliceFaberConnection?.id!)
@@ -359,7 +364,10 @@ describe('out of band', () => {
       const { outOfBandRecord, invitation } = await faberAgent.modules.oob.createLegacyInvitation(makeConnectionConfig)
       const urlMessage = invitation.toUrl({ domain: 'http://example.com' })
 
-      let { connectionRecord: aliceFaberConnection } = await aliceAgent.modules.oob.receiveInvitationFromUrl(urlMessage)
+      let { connectionRecord: aliceFaberConnection } = await aliceAgent.modules.oob.receiveInvitationFromUrl(
+        urlMessage,
+        { label: 'alice' }
+      )
 
       // biome-ignore lint/style/noNonNullAssertion: <explanation>
       aliceFaberConnection = await aliceAgent.modules.connections.returnWhenIsConnected(aliceFaberConnection?.id!)
@@ -450,7 +458,10 @@ describe('out of band', () => {
       })
 
       // First, we crate a connection but we won't accept it, therefore it won't be ready
-      await aliceAgent.modules.oob.receiveInvitation(outOfBandInvitation, { autoAcceptConnection: false })
+      await aliceAgent.modules.oob.receiveInvitation(outOfBandInvitation, {
+        label: 'alice',
+        autoAcceptConnection: false,
+      })
 
       // Event should not be emitted because an agent must wait until the connection is ready
       expect(eventListener).toHaveBeenCalledTimes(0)
@@ -470,6 +481,7 @@ describe('out of band', () => {
       const { outOfBandRecord: aliceFaberOutOfBandRecord } = await aliceAgent.modules.oob.receiveInvitation(
         outOfBandInvitation,
         {
+          label: 'alice',
           autoAcceptInvitation: false,
           autoAcceptConnection: false,
         }
@@ -511,7 +523,8 @@ describe('out of band', () => {
       // Create first connection
       const outOfBandRecord = await faberAgent.modules.oob.createInvitation(makeConnectionConfig)
       let { connectionRecord: firstAliceFaberConnection } = await aliceAgent.modules.oob.receiveInvitation(
-        outOfBandRecord.outOfBandInvitation
+        outOfBandRecord.outOfBandInvitation,
+        { label: 'alice' }
       )
       firstAliceFaberConnection = await aliceAgent.modules.connections.returnWhenIsConnected(
         // biome-ignore lint/style/noNonNullAssertion: <explanation>
@@ -535,6 +548,7 @@ describe('out of band', () => {
         connectionRecord: secondAliceFaberConnection,
         outOfBandRecord: { id: secondOobRecordId },
       } = await aliceAgent.modules.oob.receiveInvitation(outOfBandRecord2.outOfBandInvitation, {
+        label: 'alice',
         reuseConnection: true,
       })
 
@@ -588,7 +602,10 @@ describe('out of band', () => {
       // Create first connection
       const outOfBandRecord = await faberAgent.modules.oob.createInvitation(makeConnectionConfig)
       let { connectionRecord: firstAliceFaberConnection } = await aliceAgent.modules.oob.receiveInvitation(
-        outOfBandRecord.outOfBandInvitation
+        outOfBandRecord.outOfBandInvitation,
+        {
+          label: 'alice',
+        }
       )
       firstAliceFaberConnection = await aliceAgent.modules.connections.returnWhenIsConnected(
         // biome-ignore lint/style/noNonNullAssertion: <explanation>
@@ -603,7 +620,7 @@ describe('out of band', () => {
 
       const { connectionRecord: secondAliceFaberConnection } = await aliceAgent.modules.oob.receiveInvitation(
         outOfBandRecord2.outOfBandInvitation,
-        { reuseConnection: false }
+        { label: 'alice', reuseConnection: false }
       )
 
       aliceAgent.events.off(OutOfBandEventTypes.HandshakeReused, reuseListener)
@@ -638,8 +655,10 @@ describe('out of band', () => {
       const outOfBandRecord = await faberAgent.modules.oob.createInvitation(makeConnectionConfig)
       const { outOfBandInvitation } = outOfBandRecord
 
-      const { connectionRecord: aliceFaberConnection } =
-        await aliceAgent.modules.oob.receiveInvitation(outOfBandInvitation)
+      const { connectionRecord: aliceFaberConnection } = await aliceAgent.modules.oob.receiveInvitation(
+        outOfBandInvitation,
+        { label: 'alice' }
+      )
 
       // Wait until connection is ready
       // biome-ignore lint/style/noNonNullAssertion: <explanation>
@@ -649,7 +668,7 @@ describe('out of band', () => {
       await faberAgent.modules.connections.returnWhenIsConnected(faberAliceConnection?.id)
 
       // Try to receive the invitation again
-      await expect(aliceAgent.modules.oob.receiveInvitation(outOfBandInvitation)).rejects.toThrow(
+      await expect(aliceAgent.modules.oob.receiveInvitation(outOfBandInvitation, { label: 'alice' })).rejects.toThrow(
         new CredoError(
           `An out of band record with invitation ${outOfBandInvitation.id} has already been received. Invitations should have a unique id.`
         )
@@ -665,6 +684,7 @@ describe('out of band', () => {
       const { outOfBandRecord, connectionRecord } = await aliceAgent.modules.oob.receiveInvitation(
         outOfBandInvitation,
         {
+          label: 'alice',
           autoAcceptConnection: true,
           autoAcceptInvitation: true,
         }
@@ -710,14 +730,16 @@ describe('out of band', () => {
       })
       const { outOfBandInvitation } = outOfBandRecord
 
-      let { connectionRecord: firstAliceFaberConnection } =
-        await aliceAgent.modules.oob.receiveInvitation(outOfBandInvitation)
+      let { connectionRecord: firstAliceFaberConnection } = await aliceAgent.modules.oob.receiveInvitation(
+        outOfBandInvitation,
+        { label: 'alice' }
+      )
       firstAliceFaberConnection = await aliceAgent.modules.connections.returnWhenIsConnected(
         // biome-ignore lint/style/noNonNullAssertion: <explanation>
         firstAliceFaberConnection?.id!
       )
 
-      await aliceAgent.modules.oob.receiveInvitation(outOfBandInvitation)
+      await aliceAgent.modules.oob.receiveInvitation(outOfBandInvitation, { label: 'alice' })
 
       // TODO Somehow check agents throws an error or sends problem report
 
@@ -771,7 +793,8 @@ describe('out of band', () => {
       const outOfBandRecord1 = await faberAgent.modules.oob.createInvitation({})
 
       let { connectionRecord: aliceFaberConnection } = await aliceAgent.modules.oob.receiveInvitation(
-        outOfBandRecord1.outOfBandInvitation
+        outOfBandRecord1.outOfBandInvitation,
+        { label: 'alice' }
       )
 
       // biome-ignore lint/style/noNonNullAssertion: <explanation>
@@ -789,7 +812,8 @@ describe('out of band', () => {
       })
 
       let { connectionRecord: aliceFaberConnection2 } = await aliceAgent.modules.oob.receiveInvitation(
-        outOfBandRecord2.outOfBandInvitation
+        outOfBandRecord2.outOfBandInvitation,
+        { label: 'alice' }
       )
       // biome-ignore lint/style/noNonNullAssertion: <explanation>
       aliceFaberConnection2 = await aliceAgent.modules.connections.returnWhenIsConnected(aliceFaberConnection2?.id!)
@@ -810,7 +834,7 @@ describe('out of band', () => {
       })
       const { outOfBandInvitation } = outOfBandRecord
 
-      await aliceAgent.modules.oob.receiveInvitation(outOfBandInvitation)
+      await aliceAgent.modules.oob.receiveInvitation(outOfBandInvitation, { label: 'alice' })
 
       const aliceCredentialRecordPromise = waitForCredentialRecord(aliceAgent, {
         state: CredentialState.OfferReceived,
@@ -845,7 +869,8 @@ describe('out of band', () => {
 
       // Create connection
       const { connectionRecord } = await aliceAgent.modules.oob.receiveInvitation(
-        connectionOutOfBandRecord.outOfBandInvitation
+        connectionOutOfBandRecord.outOfBandInvitation,
+        { label: 'alice' }
       )
       if (!connectionRecord) throw new Error('Connection record is undefined')
       await aliceAgent.modules.connections.returnWhenIsConnected(connectionRecord.id)
@@ -859,6 +884,7 @@ describe('out of band', () => {
       const { connectionRecord: offerConnectionRecord } = await aliceAgent.modules.oob.receiveInvitation(
         outOfBandRecord.outOfBandInvitation,
         {
+          label: 'alice',
           reuseConnection: true,
         }
       )
@@ -900,7 +926,7 @@ describe('out of band', () => {
       })
       const { outOfBandInvitation } = outOfBandRecord
 
-      await aliceAgent.modules.oob.receiveInvitation(outOfBandInvitation)
+      await aliceAgent.modules.oob.receiveInvitation(outOfBandInvitation, { label: 'alice' })
 
       const aliceCredentialRecordPromise = waitForCredentialRecord(aliceAgent, {
         state: CredentialState.OfferReceived,
@@ -936,6 +962,7 @@ describe('out of band', () => {
       const routing = await aliceAgent.modules.mediationRecipient.getRouting({})
 
       await aliceAgent.modules.oob.receiveInvitation(outOfBandInvitation, {
+        label: 'alice',
         routing,
       })
 
@@ -983,7 +1010,7 @@ describe('out of band', () => {
         threadId: message.threadId,
         timeoutMs: 10000,
       })
-      await aliceAgent.modules.oob.receiveInvitationFromUrl(invitationUrl)
+      await aliceAgent.modules.oob.receiveInvitationFromUrl(invitationUrl, { label: 'alice' })
 
       const aliceCredentialRecord = await aliceCredentialRecordPromise
       expect(aliceCredentialRecord.state).toBe(CredentialState.OfferReceived)
@@ -1017,7 +1044,7 @@ describe('out of band', () => {
         threadId: message.threadId,
         timeoutMs: 10000,
       })
-      await aliceAgent.modules.oob.receiveInvitationFromUrl(invitationUrl, { routing })
+      await aliceAgent.modules.oob.receiveInvitationFromUrl(invitationUrl, { label: 'alice', routing })
 
       const aliceCredentialRecord = await aliceCredentialRecordPromise
       expect(aliceCredentialRecord.state).toBe(CredentialState.OfferReceived)

--- a/packages/didcomm/src/DidCommModuleConfig.ts
+++ b/packages/didcomm/src/DidCommModuleConfig.ts
@@ -9,7 +9,6 @@ import { DidCommMimeType } from './types'
 export interface DidCommModuleConfigOptions {
   endpoints?: string[]
   useDidSovPrefixWhereAllowed?: boolean
-  connectionImageUrl?: string
   processDidCommMessagesConcurrently?: boolean
   didCommMimeType?: string
   useDidKeyInProtocols?: boolean
@@ -43,13 +42,6 @@ export class DidCommModuleConfig {
 
   public get useDidSovPrefixWhereAllowed() {
     return this.options.useDidSovPrefixWhereAllowed ?? false
-  }
-
-  /**
-   * @todo move to context configuration
-   */
-  public get connectionImageUrl() {
-    return this.options.connectionImageUrl
   }
 
   public get processDidCommMessagesConcurrently() {

--- a/packages/didcomm/src/modules/connections/ConnectionsApi.ts
+++ b/packages/didcomm/src/modules/connections/ConnectionsApi.ts
@@ -91,7 +91,7 @@ export class ConnectionsApi {
     outOfBandRecord: OutOfBandRecord,
     config: {
       autoAcceptConnection?: boolean
-      label?: string
+      label: string
       alias?: string
       imageUrl?: string
       protocol: HandshakeProtocol

--- a/packages/didcomm/src/modules/connections/DidExchangeProtocol.ts
+++ b/packages/didcomm/src/modules/connections/DidExchangeProtocol.ts
@@ -51,7 +51,7 @@ import {
 } from './services/helpers'
 
 interface DidExchangeRequestParams {
-  label?: string
+  label: string
   alias?: string
   goal?: string
   goalCode?: string
@@ -100,7 +100,7 @@ export class DidExchangeProtocol {
     const [invitationDid] = outOfBandInvitation.invitationDids
 
     // Create message
-    const label = params.label ?? agentContext.config.label
+    const label = params.label
 
     let didDocument: DidDocument
     let keys: DidDocumentKey[] | undefined

--- a/packages/didcomm/src/modules/connections/__tests__/ConnectionService.test.ts
+++ b/packages/didcomm/src/modules/connections/__tests__/ConnectionService.test.ts
@@ -119,12 +119,12 @@ describe('ConnectionService', () => {
       expect.assertions(5)
 
       const outOfBand = getMockOutOfBand({ state: OutOfBandState.PrepareResponse })
-      const config = { routing: myRouting, imageUrl: connectionImageUrl }
+      const config = { routing: myRouting, label: 'alice', imageUrl: connectionImageUrl }
 
       const { connectionRecord, message } = await connectionService.createRequest(agentContext, outOfBand, config)
 
       expect(connectionRecord.state).toBe(DidExchangeState.RequestSent)
-      expect(message.label).toBe(agentConfig.label)
+      expect(message.label).toBe('alice')
       expect(message.connection.did).toBe('XpwgBjsC2wh3eHcMW6ZRJT')
 
       const publicKey = new Ed25119Sig2018({
@@ -178,7 +178,7 @@ describe('ConnectionService', () => {
       expect.assertions(1)
 
       const outOfBand = getMockOutOfBand({ state: OutOfBandState.PrepareResponse })
-      const config = { imageUrl: 'custom-image-url', routing: myRouting }
+      const config = { imageUrl: 'custom-image-url', label: '', routing: myRouting }
 
       const { message } = await connectionService.createRequest(agentContext, outOfBand, config)
 
@@ -189,7 +189,7 @@ describe('ConnectionService', () => {
       expect.assertions(1)
 
       const outOfBand = getMockOutOfBand({ role: OutOfBandRole.Sender, state: OutOfBandState.PrepareResponse })
-      const config = { routing: myRouting }
+      const config = { label: '', routing: myRouting }
 
       return expect(connectionService.createRequest(agentContext, outOfBand, config)).rejects.toThrowError(
         `Invalid out-of-band record role ${OutOfBandRole.Sender}, expected is ${OutOfBandRole.Receiver}.`
@@ -203,7 +203,7 @@ describe('ConnectionService', () => {
         expect.assertions(1)
 
         const outOfBand = getMockOutOfBand({ state })
-        const config = { routing: myRouting }
+        const config = { label: '', routing: myRouting }
 
         return expect(connectionService.createRequest(agentContext, outOfBand, config)).rejects.toThrowError(
           `Invalid out-of-band record state ${state}, valid states are: ${OutOfBandState.PrepareResponse}.`

--- a/packages/didcomm/src/modules/connections/__tests__/ConnectionService.test.ts
+++ b/packages/didcomm/src/modules/connections/__tests__/ConnectionService.test.ts
@@ -58,7 +58,6 @@ const connectionImageUrl = 'https://example.com/image.png'
 const endpoint = 'http://agent.com:8080'
 const agentConfig = getAgentConfig('ConnectionServiceTest', {
   endpoints: [endpoint],
-  connectionImageUrl,
 })
 
 const outOfBandRepository = new OutOfBandRepositoryMock()
@@ -81,7 +80,7 @@ describe('ConnectionService', () => {
         [OutOfBandRepository, outOfBandRepository],
         [OutOfBandService, outOfBandService],
         [DidRepository, didRepository],
-        [DidCommModuleConfig, new DidCommModuleConfig({ endpoints: [endpoint], connectionImageUrl })],
+        [DidCommModuleConfig, new DidCommModuleConfig({ endpoints: [endpoint] })],
       ],
     })
     kms = agentContext.resolve(Kms.KeyManagementApi)
@@ -120,7 +119,7 @@ describe('ConnectionService', () => {
       expect.assertions(5)
 
       const outOfBand = getMockOutOfBand({ state: OutOfBandState.PrepareResponse })
-      const config = { routing: myRouting }
+      const config = { routing: myRouting, imageUrl: connectionImageUrl }
 
       const { connectionRecord, message } = await connectionService.createRequest(agentContext, outOfBand, config)
 
@@ -168,7 +167,7 @@ describe('ConnectionService', () => {
       expect.assertions(1)
 
       const outOfBand = getMockOutOfBand({ state: OutOfBandState.PrepareResponse, imageUrl: connectionImageUrl })
-      const config = { label: 'Custom label', routing: myRouting }
+      const config = { label: 'Custom label', connectionImageUrl, routing: myRouting }
 
       const { connectionRecord } = await connectionService.createRequest(agentContext, outOfBand, config)
 

--- a/packages/didcomm/src/modules/connections/__tests__/connection-manual.test.ts
+++ b/packages/didcomm/src/modules/connections/__tests__/connection-manual.test.ts
@@ -49,9 +49,7 @@ describe('Manual Connection Flow', () => {
       {
         endpoints: ['rxjs:alice'],
       },
-      {
-        label: 'alice',
-      },
+      {},
       {
         connections: new ConnectionsModule({
           autoAcceptConnections: false,
@@ -64,9 +62,7 @@ describe('Manual Connection Flow', () => {
       {
         endpoints: ['rxjs:bob'],
       },
-      {
-        label: 'bob',
-      },
+      {},
       {
         connections: new ConnectionsModule({
           autoAcceptConnections: false,
@@ -100,6 +96,7 @@ describe('Manual Connection Flow', () => {
     const faberOutOfBandRecord = await faberAgent.modules.oob.createInvitation({
       autoAcceptConnection: false,
       multiUseInvitation: true,
+      label: 'faber',
     })
 
     const waitForAliceRequest = waitForRequest(faberAgent, 'alice')
@@ -108,6 +105,7 @@ describe('Manual Connection Flow', () => {
     let { connectionRecord: aliceConnectionRecord } = await aliceAgent.modules.oob.receiveInvitation(
       faberOutOfBandRecord.outOfBandInvitation,
       {
+        label: 'alice',
         autoAcceptInvitation: true,
         autoAcceptConnection: false,
       }
@@ -116,6 +114,7 @@ describe('Manual Connection Flow', () => {
     let { connectionRecord: bobConnectionRecord } = await bobAgent.modules.oob.receiveInvitation(
       faberOutOfBandRecord.outOfBandInvitation,
       {
+        label: 'bob',
         autoAcceptInvitation: true,
         autoAcceptConnection: false,
       }

--- a/packages/didcomm/src/modules/connections/__tests__/didexchange-numalgo.test.ts
+++ b/packages/didcomm/src/modules/connections/__tests__/didexchange-numalgo.test.ts
@@ -99,9 +99,7 @@ async function didExchangeNumAlgoBaseTest(options: {
     {
       endpoints: ['rxjs:alice'],
     },
-    {
-      label: 'alice',
-    },
+    {},
     {
       connections: new ConnectionsModule({
         autoAcceptConnections: false,
@@ -172,6 +170,7 @@ async function didExchangeNumAlgoBaseTest(options: {
   let { connectionRecord: aliceConnectionRecord } = await aliceAgent.modules.oob.receiveInvitation(
     faberOutOfBandRecord.outOfBandInvitation,
     {
+      label: 'alice',
       autoAcceptInvitation: true,
       autoAcceptConnection: false,
       ourDid,

--- a/packages/didcomm/src/modules/connections/services/ConnectionService.ts
+++ b/packages/didcomm/src/modules/connections/services/ConnectionService.ts
@@ -123,13 +123,12 @@ export class ConnectionService {
     })
 
     const { label, imageUrl } = config
-    const didcommConfig = agentContext.dependencyManager.resolve(DidCommModuleConfig)
 
     const connectionRequest = new ConnectionRequestMessage({
       label: label ?? agentContext.config.label,
       did: didDoc.id,
       didDoc,
-      imageUrl: imageUrl ?? didcommConfig.connectionImageUrl,
+      imageUrl
     })
 
     connectionRequest.setThread({

--- a/packages/didcomm/src/modules/connections/services/ConnectionService.ts
+++ b/packages/didcomm/src/modules/connections/services/ConnectionService.ts
@@ -31,8 +31,6 @@ import {
 } from '@credo-ts/core'
 import { ReplaySubject, firstValueFrom } from 'rxjs'
 import { first, map, timeout } from 'rxjs/operators'
-
-import { DidCommModuleConfig } from '../../../DidCommModuleConfig'
 import { signData, unpackAndVerifySignatureDecorator } from '../../../decorators/signature/SignatureDecoratorUtils'
 import { Routing } from '../../../models'
 import { OutOfBandService } from '../../oob/OutOfBandService'
@@ -63,7 +61,7 @@ import {
 } from './helpers'
 
 export interface ConnectionRequestParams {
-  label?: string
+  label: string
   imageUrl?: string
   alias?: string
   routing: Routing
@@ -125,10 +123,10 @@ export class ConnectionService {
     const { label, imageUrl } = config
 
     const connectionRequest = new ConnectionRequestMessage({
-      label: label ?? agentContext.config.label,
+      label,
       did: didDoc.id,
       didDoc,
-      imageUrl
+      imageUrl,
     })
 
     connectionRequest.setThread({

--- a/packages/didcomm/src/modules/credentials/protocol/v2/__tests__/v2-connectionless-credentials.test.ts
+++ b/packages/didcomm/src/modules/credentials/protocol/v2/__tests__/v2-connectionless-credentials.test.ts
@@ -111,7 +111,7 @@ describe('V2 Connectionless Credentials', () => {
       domain: 'https://a-domain.com',
     })
 
-    await aliceAgent.modules.oob.receiveInvitationFromUrl(invitationUrl)
+    await aliceAgent.modules.oob.receiveInvitationFromUrl(invitationUrl, { label: 'alice' })
 
     let aliceCredentialRecord = await waitForCredentialRecordSubject(aliceReplay, {
       threadId: faberCredentialRecord.threadId,
@@ -211,7 +211,7 @@ describe('V2 Connectionless Credentials', () => {
     })
 
     // Receive Message
-    await aliceAgent.modules.oob.receiveInvitationFromUrl(invitationUrl)
+    await aliceAgent.modules.oob.receiveInvitationFromUrl(invitationUrl, { label: 'alice' })
 
     // Wait for it to be processed
     let aliceCredentialRecord = await waitForCredentialRecordSubject(aliceReplay, {

--- a/packages/didcomm/src/modules/credentials/protocol/v2/__tests__/v2.ldproof.connectionless-credentials.test.ts
+++ b/packages/didcomm/src/modules/credentials/protocol/v2/__tests__/v2.ldproof.connectionless-credentials.test.ts
@@ -110,7 +110,7 @@ describe('credentials', () => {
       domain: 'https://a-domain.com',
     })
 
-    await aliceAgent.modules.oob.receiveInvitationFromUrl(invitationUrl)
+    await aliceAgent.modules.oob.receiveInvitationFromUrl(invitationUrl, { label: 'alice' })
 
     let aliceCredentialRecord = await waitForCredentialRecordSubject(aliceReplay, {
       threadId: faberCredentialRecord.threadId,

--- a/packages/didcomm/src/modules/message-pickup/__tests__/pickup.test.ts
+++ b/packages/didcomm/src/modules/message-pickup/__tests__/pickup.test.ts
@@ -10,6 +10,7 @@ import {
   waitForAgentMessageProcessedEvent,
   waitForBasicMessage,
 } from '../../../../../core/tests/helpers'
+import { getDefaultDidcommModules } from '../../../util/modules'
 import { HandshakeProtocol } from '../../connections'
 import { MediatorModule } from '../../routing'
 import { MessageForwardingStrategy } from '../../routing/MessageForwardingStrategy'
@@ -35,8 +36,8 @@ const mediatorOptions = getAgentOptions(
 )
 
 describe('E2E Pick Up protocol', () => {
-  let recipientAgent: Agent
-  let mediatorAgent: Agent
+  let recipientAgent: Agent<ReturnType<typeof getDefaultDidcommModules>>
+  let mediatorAgent: Agent<ReturnType<typeof getDefaultDidcommModules>>
 
   afterEach(async () => {
     await recipientAgent.modules.mediationRecipient.stopMessagePickup()
@@ -74,11 +75,12 @@ describe('E2E Pick Up protocol', () => {
     const mediatorInvitation = mediatorOutOfBandRecord.outOfBandInvitation
 
     let { connectionRecord: recipientMediatorConnection } = await recipientAgent.modules.oob.receiveInvitationFromUrl(
-      mediatorInvitation.toUrl({ domain: 'https://example.com/ssi' })
+      mediatorInvitation.toUrl({ domain: 'https://example.com/ssi' }),
+      { label: 'recipient' }
     )
 
     recipientMediatorConnection = await recipientAgent.modules.connections.returnWhenIsConnected(
-      recipientMediatorConnection.id
+      recipientMediatorConnection?.id
     )
 
     let [mediatorRecipientConnection] = await mediatorAgent.modules.connections.findAllByOutOfBandId(
@@ -137,7 +139,8 @@ describe('E2E Pick Up protocol', () => {
     const mediatorInvitation = mediatorOutOfBandRecord.outOfBandInvitation
 
     let { connectionRecord: recipientMediatorConnection } = await recipientAgent.modules.oob.receiveInvitationFromUrl(
-      mediatorInvitation.toUrl({ domain: 'https://example.com/ssi' })
+      mediatorInvitation.toUrl({ domain: 'https://example.com/ssi' }),
+      { label: 'recipient' }
     )
 
     recipientMediatorConnection = await recipientAgent.modules.connections.returnWhenIsConnected(
@@ -205,7 +208,8 @@ describe('E2E Pick Up protocol', () => {
     const mediatorInvitation = mediatorOutOfBandRecord.outOfBandInvitation
 
     let { connectionRecord: recipientMediatorConnection } = await recipientAgent.modules.oob.receiveInvitationFromUrl(
-      mediatorInvitation.toUrl({ domain: 'https://example.com/ssi' })
+      mediatorInvitation.toUrl({ domain: 'https://example.com/ssi' }),
+      { label: 'recipient' }
     )
 
     recipientMediatorConnection = await recipientAgent.modules.connections.returnWhenIsConnected(
@@ -290,7 +294,8 @@ describe('E2E Pick Up protocol', () => {
     const mediatorInvitation = mediatorOutOfBandRecord.outOfBandInvitation
 
     let { connectionRecord: recipientMediatorConnection } = await recipientAgent.modules.oob.receiveInvitationFromUrl(
-      mediatorInvitation.toUrl({ domain: 'https://example.com/ssi' })
+      mediatorInvitation.toUrl({ domain: 'https://example.com/ssi' }),
+      { label: 'recipient' }
     )
 
     recipientMediatorConnection = await recipientAgent.modules.connections.returnWhenIsConnected(

--- a/packages/didcomm/src/modules/oob/OutOfBandApi.ts
+++ b/packages/didcomm/src/modules/oob/OutOfBandApi.ts
@@ -84,7 +84,7 @@ export interface CreateLegacyInvitationConfig {
 }
 
 interface BaseReceiveOutOfBandInvitationConfig {
-  label?: string
+  label: string
   alias?: string
   imageUrl?: string
   autoAcceptInvitation?: boolean
@@ -161,7 +161,7 @@ export class OutOfBandApi {
     const autoAcceptConnection = config.autoAcceptConnection ?? this.connectionsApi.config.autoAcceptConnections
     // We don't want to treat an empty array as messages being provided
     const messages = config.messages && config.messages.length > 0 ? config.messages : undefined
-    const label = config.label ?? this.agentContext.config.label
+    const label = config.label
     const imageUrl = config.imageUrl
     const appendedAttachments =
       config.appendedAttachments && config.appendedAttachments.length > 0 ? config.appendedAttachments : undefined
@@ -335,7 +335,7 @@ export class OutOfBandApi {
    * @param config configuration of how out-of-band invitation should be processed
    * @returns out-of-band record and connection record if one has been created
    */
-  public async receiveInvitationFromUrl(invitationUrl: string, config: ReceiveOutOfBandInvitationConfig = {}) {
+  public async receiveInvitationFromUrl(invitationUrl: string, config: ReceiveOutOfBandInvitationConfig) {
     const message = await this.parseInvitation(invitationUrl)
 
     return this.receiveInvitation(message, config)
@@ -373,7 +373,7 @@ export class OutOfBandApi {
    */
   public async receiveInvitation(
     invitation: OutOfBandInvitation | ConnectionInvitationMessage,
-    config: ReceiveOutOfBandInvitationConfig = {}
+    config: ReceiveOutOfBandInvitationConfig
   ): Promise<{ outOfBandRecord: OutOfBandRecord; connectionRecord?: ConnectionRecord }> {
     return this._receiveInvitation(invitation, config)
   }
@@ -415,7 +415,7 @@ export class OutOfBandApi {
    */
   private async _receiveInvitation(
     invitation: OutOfBandInvitation | ConnectionInvitationMessage,
-    config: BaseReceiveOutOfBandInvitationConfig = {}
+    config: BaseReceiveOutOfBandInvitationConfig
   ): Promise<{ outOfBandRecord: OutOfBandRecord; connectionRecord?: ConnectionRecord }> {
     // Convert to out of band invitation if needed
     const outOfBandInvitation =
@@ -427,7 +427,7 @@ export class OutOfBandApi {
     const autoAcceptInvitation = config.autoAcceptInvitation ?? true
     const autoAcceptConnection = config.autoAcceptConnection ?? true
     const reuseConnection = config.reuseConnection ?? false
-    const label = config.label ?? this.agentContext.config.label
+    const label = config.label
     const alias = config.alias
     const imageUrl = config.imageUrl
 
@@ -523,7 +523,7 @@ export class OutOfBandApi {
     config: {
       autoAcceptConnection?: boolean
       reuseConnection?: boolean
-      label?: string
+      label: string
       alias?: string
       imageUrl?: string
       /**

--- a/packages/didcomm/src/modules/oob/OutOfBandApi.ts
+++ b/packages/didcomm/src/modules/oob/OutOfBandApi.ts
@@ -21,7 +21,6 @@ import {
 } from '@credo-ts/core'
 import { EmptyError, catchError, first, firstValueFrom, map, of, timeout } from 'rxjs'
 
-import { DidCommModuleConfig } from '../../DidCommModuleConfig'
 import { AgentEventTypes, type AgentMessageReceivedEvent } from '../../Events'
 import { MessageHandlerRegistry } from '../../MessageHandlerRegistry'
 import { MessageSender } from '../../MessageSender'
@@ -163,8 +162,7 @@ export class OutOfBandApi {
     // We don't want to treat an empty array as messages being provided
     const messages = config.messages && config.messages.length > 0 ? config.messages : undefined
     const label = config.label ?? this.agentContext.config.label
-    const didcommConfig = this.agentContext.dependencyManager.resolve(DidCommModuleConfig)
-    const imageUrl = config.imageUrl ?? didcommConfig.connectionImageUrl
+    const imageUrl = config.imageUrl
     const appendedAttachments =
       config.appendedAttachments && config.appendedAttachments.length > 0 ? config.appendedAttachments : undefined
 
@@ -431,8 +429,7 @@ export class OutOfBandApi {
     const reuseConnection = config.reuseConnection ?? false
     const label = config.label ?? this.agentContext.config.label
     const alias = config.alias
-    const didcommConfig = this.agentContext.dependencyManager.resolve(DidCommModuleConfig)
-    const imageUrl = config.imageUrl ?? didcommConfig.connectionImageUrl
+    const imageUrl = config.imageUrl
 
     const messages = outOfBandInvitation.getRequests()
 

--- a/packages/didcomm/src/modules/oob/__tests__/connect-to-self.test.ts
+++ b/packages/didcomm/src/modules/oob/__tests__/connect-to-self.test.ts
@@ -46,7 +46,7 @@ describe('out of band', () => {
       const urlMessage = outOfBandInvitation.toUrl({ domain: 'http://example.com' })
 
       let { outOfBandRecord: receivedOutOfBandRecord, connectionRecord: receiverSenderConnection } =
-        await faberAgent.modules.oob.receiveInvitationFromUrl(urlMessage)
+        await faberAgent.modules.oob.receiveInvitationFromUrl(urlMessage, { label: 'faber' })
       expect(receivedOutOfBandRecord.state).toBe(OutOfBandState.PrepareResponse)
 
       receiverSenderConnection = await faberAgent.modules.connections.returnWhenIsConnected(
@@ -72,7 +72,7 @@ describe('out of band', () => {
       const urlMessage = outOfBandInvitation.toUrl({ domain: 'http://example.com' })
 
       let { outOfBandRecord: receivedOutOfBandRecord, connectionRecord: receiverSenderConnection } =
-        await faberAgent.modules.oob.receiveInvitationFromUrl(urlMessage)
+        await faberAgent.modules.oob.receiveInvitationFromUrl(urlMessage, { label: 'faber' })
       expect(receivedOutOfBandRecord.state).toBe(OutOfBandState.PrepareResponse)
 
       receiverSenderConnection = await faberAgent.modules.connections.returnWhenIsConnected(
@@ -98,7 +98,7 @@ describe('out of band', () => {
       const urlMessage = outOfBandInvitation.toUrl({ domain: 'http://example.com' })
 
       let { outOfBandRecord: receivedOutOfBandRecord, connectionRecord: receiverSenderConnection } =
-        await faberAgent.modules.oob.receiveInvitationFromUrl(urlMessage)
+        await faberAgent.modules.oob.receiveInvitationFromUrl(urlMessage, { label: 'faber' })
       expect(receivedOutOfBandRecord.state).toBe(OutOfBandState.PrepareResponse)
 
       receiverSenderConnection = await faberAgent.modules.connections.returnWhenIsConnected(

--- a/packages/didcomm/src/modules/oob/__tests__/implicit.test.ts
+++ b/packages/didcomm/src/modules/oob/__tests__/implicit.test.ts
@@ -112,6 +112,7 @@ describe('out of band implicit', () => {
       // biome-ignore lint/style/noNonNullAssertion: <explanation>
       did: serviceUrl!,
       alias: 'Faber public',
+      label: 'alice',
       handshakeProtocols: [HandshakeProtocol.DidExchange],
     })
 
@@ -128,7 +129,7 @@ describe('out of band implicit', () => {
 
     expect(aliceFaberConnection).toBeConnectedWith(faberAliceConnection)
     expect(faberAliceConnection).toBeConnectedWith(aliceFaberConnection)
-    expect(faberAliceConnection.theirLabel).toBe(aliceAgent.config.label)
+    expect(faberAliceConnection.theirLabel).toBe('alice')
     expect(aliceFaberConnection.theirLabel).toBe('Faber public')
     expect(aliceFaberConnection.invitationDid).toBe(serviceUrl)
 
@@ -142,6 +143,7 @@ describe('out of band implicit', () => {
 
     let { connectionRecord: aliceFaberConnection } = await aliceAgent.modules.oob.receiveImplicitInvitation({
       did: inMemoryDid,
+      label: 'alice',
       alias: 'Faber public',
       handshakeProtocols: [HandshakeProtocol.Connections],
     })
@@ -159,7 +161,7 @@ describe('out of band implicit', () => {
 
     expect(aliceFaberConnection).toBeConnectedWith(faberAliceConnection)
     expect(faberAliceConnection).toBeConnectedWith(aliceFaberConnection)
-    expect(faberAliceConnection.theirLabel).toBe(aliceAgent.config.label)
+    expect(faberAliceConnection.theirLabel).toBe('alice')
     expect(aliceFaberConnection.theirLabel).toBe('Faber public')
     expect(aliceFaberConnection.invitationDid).toBe(inMemoryDid)
 
@@ -171,6 +173,7 @@ describe('out of band implicit', () => {
     await expect(
       aliceAgent.modules.oob.receiveImplicitInvitation({
         did: 'did:sov:ZSEqSci581BDZCFPa29ScB',
+        label: 'alice',
         alias: 'Faber public',
         handshakeProtocols: [HandshakeProtocol.DidExchange],
       })
@@ -182,6 +185,7 @@ describe('out of band implicit', () => {
 
     let { connectionRecord: aliceFaberConnection } = await aliceAgent.modules.oob.receiveImplicitInvitation({
       did: inMemoryDid,
+      label: 'alice',
       alias: 'Faber public',
       handshakeProtocols: [HandshakeProtocol.Connections],
     })
@@ -199,7 +203,7 @@ describe('out of band implicit', () => {
 
     expect(aliceFaberConnection).toBeConnectedWith(faberAliceConnection)
     expect(faberAliceConnection).toBeConnectedWith(aliceFaberConnection)
-    expect(faberAliceConnection.theirLabel).toBe(aliceAgent.config.label)
+    expect(faberAliceConnection.theirLabel).toBe('alice')
     expect(aliceFaberConnection.theirLabel).toBe('Faber public')
     expect(aliceFaberConnection.invitationDid).toBe(inMemoryDid)
 

--- a/packages/didcomm/src/modules/proofs/protocol/v2/__tests__/v2-indy-connectionless-proofs.e2e.test.ts
+++ b/packages/didcomm/src/modules/proofs/protocol/v2/__tests__/v2-indy-connectionless-proofs.e2e.test.ts
@@ -122,7 +122,7 @@ describe('V2 Connectionless Proofs - Indy', () => {
       domain: 'https://a-domain.com',
     })
 
-    await aliceAgent.modules.oob.receiveInvitationFromUrl(invitationUrl)
+    await aliceAgent.modules.oob.receiveInvitationFromUrl(invitationUrl, { label: 'alice' })
 
     testLogger.test('Alice waits for presentation request from Faber')
     let aliceProofExchangeRecord = await waitForProofExchangeRecordSubject(aliceReplay, {
@@ -246,7 +246,7 @@ describe('V2 Connectionless Proofs - Indy', () => {
         domain: 'https://a-domain.com',
       })
 
-    await aliceAgent.modules.oob.receiveInvitationFromUrl(invitationUrl)
+    await aliceAgent.modules.oob.receiveInvitationFromUrl(invitationUrl, { label: 'alice' })
 
     await waitForProofExchangeRecordSubject(aliceReplay, {
       state: ProofState.Done,
@@ -441,7 +441,7 @@ describe('V2 Connectionless Proofs - Indy', () => {
       },
     })
 
-    await aliceAgent.modules.oob.receiveInvitationFromUrl(invitationUrl)
+    await aliceAgent.modules.oob.receiveInvitationFromUrl(invitationUrl, { label: 'alice' })
 
     await waitForProofExchangeRecordSubject(aliceReplay, {
       state: ProofState.Done,
@@ -538,7 +538,7 @@ describe('V2 Connectionless Proofs - Indy', () => {
       await faberAgent.modules.didcomm.unregisterOutboundTransport(transport)
     }
 
-    await aliceAgent.modules.oob.receiveInvitationFromUrl(invitationUrl)
+    await aliceAgent.modules.oob.receiveInvitationFromUrl(invitationUrl, { label: 'alice' })
     await waitForProofExchangeRecordSubject(aliceReplay, {
       state: ProofState.Done,
       threadId: requestMessage.threadId,
@@ -627,7 +627,7 @@ describe('V2 Connectionless Proofs - Indy', () => {
       state: ProofState.RequestReceived,
     })
 
-    await aliceAgent.modules.oob.receiveInvitationFromUrl(invitationUrl)
+    await aliceAgent.modules.oob.receiveInvitationFromUrl(invitationUrl, { label: 'alice' })
     const aliceProofExchangeRecord = await aliceProofExchangeRecordPromise
 
     await aliceAgent.modules.proofs.declineRequest({

--- a/packages/didcomm/src/modules/routing/MediationRecipientModule.ts
+++ b/packages/didcomm/src/modules/routing/MediationRecipientModule.ts
@@ -98,6 +98,7 @@ export class MediationRecipientModule implements Module {
 
       agentContext.config.logger.debug('Routing created', routing)
       const { connectionRecord: newConnection } = await oobApi.receiveInvitation(outOfBandInvitation, {
+        label: '',
         routing,
       })
       agentContext.config.logger.debug('Mediation invitation processed', { outOfBandInvitation })

--- a/packages/didcomm/src/modules/routing/__tests__/mediation.test.ts
+++ b/packages/didcomm/src/modules/routing/__tests__/mediation.test.ts
@@ -147,7 +147,8 @@ describe('mediator establishment', () => {
     const recipientInvitation = recipientOutOfBandRecord.outOfBandInvitation
 
     let { connectionRecord: senderRecipientConnection } = await senderAgent.modules.oob.receiveInvitationFromUrl(
-      recipientInvitation.toUrl({ domain: 'https://example.com/ssi' })
+      recipientInvitation.toUrl({ domain: 'https://example.com/ssi' }),
+      { label: 'senderAgent' }
     )
 
     if (!senderRecipientConnection) {
@@ -276,7 +277,8 @@ describe('mediator establishment', () => {
     const recipientInvitation = recipientOutOfBandRecord.outOfBandInvitation
 
     let { connectionRecord: senderRecipientConnection } = await senderAgent.modules.oob.receiveInvitationFromUrl(
-      recipientInvitation.toUrl({ domain: 'https://example.com/ssi' })
+      recipientInvitation.toUrl({ domain: 'https://example.com/ssi' }),
+      { label: 'alice' }
     )
 
     if (!senderRecipientConnection) {

--- a/packages/didcomm/src/modules/routing/services/__tests__/MediationRecipientService.test.ts
+++ b/packages/didcomm/src/modules/routing/services/__tests__/MediationRecipientService.test.ts
@@ -39,12 +39,9 @@ const EventEmitterMock = EventEmitter as jest.Mock<EventEmitter>
 jest.mock('../../../../MessageSender')
 const MessageSenderMock = MessageSender as jest.Mock<MessageSender>
 
-const connectionImageUrl = 'https://example.com/image.png'
-
 describe('MediationRecipientService', () => {
   const config = getAgentConfig('MediationRecipientServiceTest', {
     endpoints: ['http://agent.com:8080'],
-    connectionImageUrl,
   })
 
   let mediationRepository: MediationRepository

--- a/packages/indy-sdk-to-askar-migration/tests/migrate.test.ts
+++ b/packages/indy-sdk-to-askar-migration/tests/migrate.test.ts
@@ -14,7 +14,6 @@ import { IndySdkToAskarMigrationError } from '../src/errors/IndySdkToAskarMigrat
 describe('Indy SDK To Askar Migration', () => {
   test('indy-sdk sqlite to aries-askar sqlite successful migration', async () => {
     const indySdkAndAskarConfig: InitConfig = {
-      label: 'indy | indy-sdk sqlite to aries-askar sqlite successful migration',
       autoUpdateStorageOnStartup: true,
     }
 
@@ -81,9 +80,7 @@ describe('Indy SDK To Askar Migration', () => {
    *  - Check if the record can still be accessed
    */
   test('indy-sdk sqlite to aries-askar sqlite fails and restores', async () => {
-    const indySdkAndAskarConfig: InitConfig = {
-      label: 'indy | indy-sdk sqlite to aries-askar sqlite fails and restores',
-    }
+    const indySdkAndAskarConfig: InitConfig = {}
 
     const indySdkAgentDbPath = `${homedir()}/.indy_client/wallet/indy-sdk sqlite to aries-askar sqlite fails and restores/sqlite.db`
     const indySdkWalletTestPath = path.join(__dirname, 'indy-sdk-040-wallet.db')

--- a/packages/openid4vc/src/openid4vc-holder/__tests__/openid4vci-holder.test.ts
+++ b/packages/openid4vc/src/openid4vc-holder/__tests__/openid4vci-holder.test.ts
@@ -11,9 +11,7 @@ import { transformPrivateKeyToPrivateJwk } from '../../../../askar/src'
 import { animoOpenIdPlaygroundDraft11SdJwtVc, matrrLaunchpadDraft11JwtVcJson, waltIdDraft11JwtVcJson } from './fixtures'
 
 const holder = new Agent({
-  config: {
-    label: 'OpenId4VcHolder Test28',
-  },
+  config: {},
   dependencies: agentDependencies,
   modules: {
     openId4VcHolder: new OpenId4VcHolderModule(),

--- a/packages/openid4vc/src/openid4vc-issuer/__tests__/openid4vc-issuer.test.ts
+++ b/packages/openid4vc/src/openid4vc-issuer/__tests__/openid4vc-issuer.test.ts
@@ -138,17 +138,13 @@ const createCredentialRequest = async (
 }
 
 const issuer = new Agent({
-  config: {
-    label: 'OpenId4VcIssuer Test323',
-  },
+  config: {},
   dependencies: agentDependencies,
   modules,
 })
 
 const holder = new Agent({
-  config: {
-    label: 'OpenId4VciIssuer(Holder) Test323',
-  },
+  config: {},
   dependencies: agentDependencies,
   modules,
 })

--- a/packages/openid4vc/src/openid4vc-verifier/__tests__/openid4vc-verifier.test.ts
+++ b/packages/openid4vc/src/openid4vc-verifier/__tests__/openid4vc-verifier.test.ts
@@ -15,7 +15,7 @@ describe('OpenId4VcVerifier', () => {
   let verifier: AgentType<typeof modules>
 
   beforeEach(async () => {
-    verifier = await createAgentFromModules('verifier', modules, '96213c3d7fc8d4d6754c7a0fd969598f')
+    verifier = await createAgentFromModules(modules, '96213c3d7fc8d4d6754c7a0fd969598f')
   })
 
   afterEach(async () => {

--- a/packages/openid4vc/tests/openid4vc-batch-issuance.e2e.test.ts
+++ b/packages/openid4vc/tests/openid4vc-batch-issuance.e2e.test.ts
@@ -34,7 +34,7 @@ describe('OpenId4Vc Batch Issuance', () => {
   beforeEach(async () => {
     expressApp = express()
 
-    issuer = await createAgentFromModules('issuer', {
+    issuer = await createAgentFromModules({
       openId4VcIssuer: new OpenId4VcIssuerModule({
         baseUrl: issuerBaseUrl,
         credentialRequestToCredentialMapper: async ({ credentialRequestFormat, holderBinding }) => {
@@ -68,7 +68,7 @@ describe('OpenId4Vc Batch Issuance', () => {
       inMemory: new InMemoryWalletModule(),
     })
 
-    holder = await createAgentFromModules('holder', {
+    holder = await createAgentFromModules({
       openId4VcHolder: new OpenId4VcHolderModule(),
       inMemory: new InMemoryWalletModule(),
     })

--- a/packages/openid4vc/tests/openid4vc-presentation-during-issuance.e2e.test.ts
+++ b/packages/openid4vc/tests/openid4vc-presentation-during-issuance.e2e.test.ts
@@ -133,7 +133,7 @@ describe('OpenId4Vc Presentation During Issuance', () => {
   beforeEach(async () => {
     expressApp = express()
 
-    issuer = await createAgentFromModules('issuer', {
+    issuer = await createAgentFromModules({
       openId4VcIssuer: new OpenId4VcIssuerModule({
         baseUrl: issuerBaseUrl,
         getVerificationSessionForIssuanceSessionAuthorization:
@@ -193,7 +193,7 @@ describe('OpenId4Vc Presentation During Issuance', () => {
       inMemory: new InMemoryWalletModule(),
     })
 
-    holder = await createAgentFromModules('holder', {
+    holder = await createAgentFromModules({
       openId4VcHolder: new OpenId4VcHolderModule(),
       inMemory: new InMemoryWalletModule(),
     })

--- a/packages/openid4vc/tests/openid4vc-wallet-key-attestation.e2e.test.ts
+++ b/packages/openid4vc/tests/openid4vc-wallet-key-attestation.e2e.test.ts
@@ -63,7 +63,7 @@ describe('OpenId4Vc Wallet and Key Attestations', () => {
   beforeEach(async () => {
     expressApp = express()
 
-    issuer = await createAgentFromModules('issuer', {
+    issuer = await createAgentFromModules({
       openId4VcVerifier: new OpenId4VcVerifierModule({
         baseUrl: verifierBaseUrl,
       }),
@@ -162,7 +162,7 @@ describe('OpenId4Vc Wallet and Key Attestations', () => {
       inMemory: new InMemoryWalletModule({}),
     })
 
-    holder = await createAgentFromModules('holder', {
+    holder = await createAgentFromModules({
       openId4VcHolder: new OpenId4VcHolderModule(),
       inMemory: new InMemoryWalletModule({}),
     })

--- a/packages/openid4vc/tests/openid4vci-deferred.e2e.test.ts
+++ b/packages/openid4vc/tests/openid4vci-deferred.e2e.test.ts
@@ -70,7 +70,6 @@ describe('OpenId4Vci (Deferred)', () => {
     expressApp = express()
 
     issuer = (await createAgentFromModules(
-      'issuer',
       {
         x509: new X509Module(),
         inMemory: new InMemoryWalletModule(),
@@ -149,7 +148,6 @@ describe('OpenId4Vci (Deferred)', () => {
     issuer1 = await createTenantForAgent(issuer.agent, 'iTenant1')
 
     holder = (await createAgentFromModules(
-      'holder',
       {
         openId4VcHolder: new OpenId4VcHolderModule(),
         inMemory: new InMemoryWalletModule(),

--- a/packages/openid4vc/tests/openid4vci.e2e.test.ts
+++ b/packages/openid4vc/tests/openid4vci.e2e.test.ts
@@ -62,7 +62,6 @@ describe('OpenId4Vc', () => {
     expressApp = express()
 
     issuer = (await createAgentFromModules(
-      'issuer',
       {
         x509: new X509Module(),
         inMemory: new InMemoryWalletModule(),
@@ -121,7 +120,6 @@ describe('OpenId4Vc', () => {
     issuer1 = await createTenantForAgent(issuer.agent, 'iTenant1')
 
     holder = (await createAgentFromModules(
-      'holder',
       {
         openId4VcHolder: new OpenId4VcHolderModule(),
         inMemory: new InMemoryWalletModule(),

--- a/packages/openid4vc/tests/openid4vp-dcapi.e2e.test.ts
+++ b/packages/openid4vc/tests/openid4vp-dcapi.e2e.test.ts
@@ -155,7 +155,6 @@ describe('OpenId4VP DC API', () => {
 
   beforeEach(async () => {
     holder = (await createAgentFromModules(
-      'holder',
       {
         openId4VcHolder: new OpenId4VcHolderModule(),
         inMemory: new InMemoryWalletModule(),
@@ -164,7 +163,6 @@ describe('OpenId4VP DC API', () => {
     )) as unknown as typeof holder
 
     verifier = (await createAgentFromModules(
-      'verifier',
       {
         openId4VcVerifier: new OpenId4VcVerifierModule({
           baseUrl: verificationBaseUrl,

--- a/packages/openid4vc/tests/openid4vp-draft21.e2e.test.ts
+++ b/packages/openid4vc/tests/openid4vp-draft21.e2e.test.ts
@@ -30,7 +30,6 @@ describe('OpenID4VP Draft 21', () => {
     expressApp = express()
 
     holder = (await createAgentFromModules(
-      'holder',
       {
         openId4VcHolder: new OpenId4VcHolderModule(),
         inMemory: new InMemoryWalletModule(),
@@ -40,7 +39,6 @@ describe('OpenID4VP Draft 21', () => {
     )) as unknown as typeof holder
 
     verifier = (await createAgentFromModules(
-      'verifier',
       {
         openId4VcVerifier: new OpenId4VcVerifierModule({
           baseUrl: verificationBaseUrl,

--- a/packages/openid4vc/tests/openid4vp-draft24.e2e.test.ts
+++ b/packages/openid4vc/tests/openid4vp-draft24.e2e.test.ts
@@ -48,7 +48,6 @@ describe('OpenID4VP Draft 24', () => {
     expressApp = express()
 
     holder = (await createAgentFromModules(
-      'holder',
       {
         openId4VcHolder: new OpenId4VcHolderModule(),
         inMemory: new InMemoryWalletModule(),
@@ -74,7 +73,6 @@ pUGCFdfNLQIgHGSa5u5ZqUtCrnMiaEageO71rjzBlov0YUH4+6ELioY=
     holder1 = await createTenantForAgent(holder.agent, 'hTenant1')
 
     verifier = (await createAgentFromModules(
-      'verifier',
       {
         openId4VcVerifier: new OpenId4VcVerifierModule({
           baseUrl: verificationBaseUrl,

--- a/packages/openid4vc/tests/openid4vp-multi-mdoc-devcie-response.e2e.test.ts
+++ b/packages/openid4vc/tests/openid4vp-multi-mdoc-devcie-response.e2e.test.ts
@@ -12,7 +12,7 @@ describe('OpenId4Vc', () => {
   }>
 
   beforeEach(async () => {
-    verifier = (await createAgentFromModules('verifier', {
+    verifier = (await createAgentFromModules({
       openId4VcVerifier: new OpenId4VcVerifierModule({
         baseUrl,
       }),

--- a/packages/openid4vc/tests/openid4vp-v1.e2e.test.ts
+++ b/packages/openid4vc/tests/openid4vp-v1.e2e.test.ts
@@ -47,7 +47,6 @@ describe('OpenID4VP 1.0', () => {
     expressApp = express()
 
     holder = (await createAgentFromModules(
-      'holder',
       {
         openId4VcHolder: new OpenId4VcHolderModule(),
         inMemory: new InMemoryWalletModule(),
@@ -73,7 +72,6 @@ pUGCFdfNLQIgHGSa5u5ZqUtCrnMiaEageO71rjzBlov0YUH4+6ELioY=
     holder1 = await createTenantForAgent(holder.agent, 'hTenant1')
 
     verifier = (await createAgentFromModules(
-      'verifier',
       {
         openId4VcVerifier: new OpenId4VcVerifierModule({
           baseUrl: verificationBaseUrl,

--- a/packages/openid4vc/tests/utils.ts
+++ b/packages/openid4vc/tests/utils.ts
@@ -21,14 +21,12 @@ import {
 import { OpenId4VcIssuerEvents, OpenId4VcIssuerModule, OpenId4VcVerifierEvents, OpenId4VcVerifierModule } from '../src'
 
 export async function createAgentFromModules<MM extends ModulesMap>(
-  label: string,
   modulesMap: MM,
   secretKey?: string,
   customFetch?: typeof global.fetch
 ) {
   const agent = new Agent<MM>({
     config: {
-      label,
       allowInsecureHttpUrls: true,
       logger: new TestLogger(LogLevel.off),
     },

--- a/packages/tenants/src/TenantsApi.ts
+++ b/packages/tenants/src/TenantsApi.ts
@@ -65,7 +65,7 @@ export class TenantsApi<AgentModules extends ModulesMap = DefaultAgentModules> {
   }
 
   public async createTenant(options: CreateTenantOptions) {
-    this.logger.debug(`Creating tenant with label ${options.config.label}`)
+    this.logger.debug('Creating tenant')
 
     const tenantRecord = await this.tenantRecordService.createTenant(this.rootAgentContext, options.config)
 

--- a/packages/tenants/src/__tests__/TenantsApi.test.ts
+++ b/packages/tenants/src/__tests__/TenantsApi.test.ts
@@ -29,9 +29,7 @@ describe('TenantsApi', () => {
       const tenantAgentContext = getAgentContext({
         contextCorrelationId: 'tenant-id',
         dependencyManager: tenantDependencyManager,
-        agentConfig: rootAgent.config.extend({
-          label: 'tenant-agent',
-        }),
+        agentConfig: rootAgent.config.extend({}),
       })
       tenantDependencyManager.registerInstance(AgentContext, tenantAgentContext)
 
@@ -40,7 +38,6 @@ describe('TenantsApi', () => {
       const tenantAgent = await tenantsApi.getTenantAgent({ tenantId: 'tenant-id' })
 
       expect(tenantAgent.isInitialized).toBe(true)
-      expect(tenantAgent.config.label).toEqual('tenant-agent')
 
       expect(agentContextProvider.getAgentContextForContextCorrelationId).toHaveBeenCalledWith('tenant-tenant-id', {
         provisionContext: false,
@@ -54,15 +51,13 @@ describe('TenantsApi', () => {
 
   describe('withTenantAgent', () => {
     test('gets context from agent context provider and initializes tenant agent instance', async () => {
-      expect.assertions(6)
+      expect.assertions(5)
 
       const tenantDependencyManager = rootAgent.dependencyManager.createChild()
       const tenantAgentContext = getAgentContext({
         contextCorrelationId: 'tenant-id',
         dependencyManager: tenantDependencyManager,
-        agentConfig: rootAgent.config.extend({
-          label: 'tenant-agent',
-        }),
+        agentConfig: rootAgent.config.extend({}),
       })
       tenantDependencyManager.registerInstance(AgentContext, tenantAgentContext)
 
@@ -72,7 +67,6 @@ describe('TenantsApi', () => {
       await tenantsApi.withTenantAgent({ tenantId: 'tenant-id' }, async (tenantAgent) => {
         endSessionSpy = jest.spyOn(tenantAgent, 'endSession')
         expect(tenantAgent.isInitialized).toBe(true)
-        expect(tenantAgent.config.label).toEqual('tenant-agent')
 
         expect(agentContextProvider.getAgentContextForContextCorrelationId).toHaveBeenCalledWith('tenant-tenant-id', {
           provisionContext: false,
@@ -85,15 +79,13 @@ describe('TenantsApi', () => {
     })
 
     test('endSession is called even if the tenant agent callback throws an error', async () => {
-      expect.assertions(7)
+      expect.assertions(6)
 
       const tenantDependencyManager = rootAgent.dependencyManager.createChild()
       const tenantAgentContext = getAgentContext({
         contextCorrelationId: 'tenant-id',
         dependencyManager: tenantDependencyManager,
-        agentConfig: rootAgent.config.extend({
-          label: 'tenant-agent',
-        }),
+        agentConfig: rootAgent.config.extend({}),
       })
       tenantDependencyManager.registerInstance(AgentContext, tenantAgentContext)
 
@@ -104,7 +96,6 @@ describe('TenantsApi', () => {
         tenantsApi.withTenantAgent({ tenantId: 'tenant-id' }, async (tenantAgent) => {
           endSessionSpy = jest.spyOn(tenantAgent, 'endSession')
           expect(tenantAgent.isInitialized).toBe(true)
-          expect(tenantAgent.config.label).toEqual('tenant-agent')
 
           expect(agentContextProvider.getAgentContextForContextCorrelationId).toHaveBeenCalledWith('tenant-tenant-id', {
             provisionContext: false,

--- a/packages/tenants/src/context/TenantSessionCoordinator.ts
+++ b/packages/tenants/src/context/TenantSessionCoordinator.ts
@@ -303,9 +303,7 @@ export class TenantSessionCoordinator {
 
   private async createAgentContext(tenantRecord: TenantRecord, { provisionContext }: { provisionContext: boolean }) {
     const tenantDependencyManager = this.rootAgentContext.dependencyManager.createChild()
-    const tenantConfig = this.rootAgentContext.config.extend({
-      label: tenantRecord.config.label,
-    })
+    const tenantConfig = this.rootAgentContext.config.extend({})
 
     const agentContext = new AgentContext({
       contextCorrelationId: this.getContextCorrelationIdForTenantId(tenantRecord.id),

--- a/packages/tenants/src/context/__tests__/TenantSessionCoordinator.test.ts
+++ b/packages/tenants/src/context/__tests__/TenantSessionCoordinator.test.ts
@@ -99,7 +99,7 @@ describe('TenantSessionCoordinator', () => {
       const tenantAgentContext = await tenantSessionCoordinator.getContextForSession(tenantRecord)
 
       expect(tenantSessionMutexMock.acquireSession).toHaveBeenCalledTimes(1)
-      expect(extendSpy).toHaveBeenCalledWith(tenantRecord.config)
+      expect(extendSpy).toHaveBeenCalledWith({})
       expect(createChildSpy).toHaveBeenCalledWith()
       expect(tenantDependencyManager.registerInstance).toHaveBeenCalledWith(AgentContext, expect.any(AgentContext))
       expect(tenantDependencyManager.registerInstance).toHaveBeenCalledWith(AgentConfig, expect.any(AgentConfig))

--- a/packages/tenants/src/models/TenantConfig.ts
+++ b/packages/tenants/src/models/TenantConfig.ts
@@ -1,4 +1,3 @@
-import type { InitConfig } from '@credo-ts/core'
-
-// TODO: remove label from tenant config
-export type TenantConfig = Pick<InitConfig, 'label'>
+export type TenantConfig = {
+  label: string
+}

--- a/packages/tenants/src/services/__tests__/TenantService.test.ts
+++ b/packages/tenants/src/services/__tests__/TenantService.test.ts
@@ -21,20 +21,16 @@ describe('TenantRecordService', () => {
     jest.clearAllMocks()
   })
 
-  // FIXME: connectionImageUrl is now part of DIDComm module. Tenants records do not currently
-  // store data related to module config
   describe('createTenant', () => {
     test('creates a tenant record and stores it in the tenant repository', async () => {
       const tenantRecord = await tenantRecordService.createTenant(agentContext, {
         label: 'Test Tenant',
-        //connectionImageUrl: 'https://example.com/connection.png',
       })
 
       expect(tenantRecord).toMatchObject({
         id: expect.any(String),
         config: {
           label: 'Test Tenant',
-          //connectionImageUrl: 'https://example.com/connection.png',
         },
       })
 

--- a/packages/tenants/src/updates/__tests__/0.4.test.ts
+++ b/packages/tenants/src/updates/__tests__/0.4.test.ts
@@ -25,9 +25,7 @@ describe('UpdateAssistant | Tenants | v0.4 - v0.5', () => {
 
     const agent = new Agent(
       {
-        config: {
-          label: 'Test Agent',
-        },
+        config: {},
         dependencies: agentDependencies,
         modules: {
           // We need to include the TenantsModule to run the updates

--- a/packages/tenants/tests/tenant-sessions.test.ts
+++ b/packages/tenants/tests/tenant-sessions.test.ts
@@ -11,7 +11,6 @@ import { getDefaultDidcommModules } from '../../didcomm/src/util/modules'
 import { TenantsModule } from '@credo-ts/tenants'
 
 const agentConfig: InitConfig = {
-  label: 'Tenant Agent 1',
   logger: testLogger,
 }
 

--- a/packages/tenants/tests/tenants-askar-profiles.test.ts
+++ b/packages/tenants/tests/tenants-askar-profiles.test.ts
@@ -13,7 +13,6 @@ import { AskarStoreManager } from '../../askar/src/AskarStoreManager'
 describe('Tenants Askar database schemes E2E', () => {
   test('uses AskarWallet for all wallets and tenants when database schema is DatabasePerWallet', async () => {
     const agentConfig: InitConfig = {
-      label: 'Tenant Agent 1',
       logger: testLogger,
     }
 
@@ -66,7 +65,6 @@ describe('Tenants Askar database schemes E2E', () => {
 
   test('uses AskarWallet for main agent, and ProfileAskarWallet for tenants', async () => {
     const agentConfig: InitConfig = {
-      label: 'Tenant Agent 1',
       logger: testLogger,
     }
 

--- a/packages/tenants/tests/tenants-storage-update.test.ts
+++ b/packages/tenants/tests/tenants-storage-update.test.ts
@@ -14,7 +14,6 @@ import { TenantSessionCoordinator } from '../src/context/TenantSessionCoordinato
 import { TenantsModule } from '@credo-ts/tenants'
 
 const agentConfig = {
-  label: 'Tenant Agent',
   logger: testLogger,
 } satisfies InitConfig
 

--- a/packages/tenants/tests/tenants.test.ts
+++ b/packages/tenants/tests/tenants.test.ts
@@ -21,7 +21,6 @@ import { getAskarStoreConfig, testLogger } from '../../core/tests'
 import { TenantsModule } from '../src/TenantsModule'
 
 const agent1Config: InitConfig = {
-  label: 'Tenant Agent 1',
   logger: testLogger,
 }
 
@@ -30,7 +29,6 @@ const agent1DidcommConfig: DidCommModuleConfigOptions = {
 }
 
 const agent2Config: InitConfig = {
-  label: 'Tenant Agent 2',
   logger: testLogger,
 }
 
@@ -191,7 +189,10 @@ describe('Tenants E2E', () => {
     // Create and receive oob invitation in scope of tenants
     const outOfBandRecord = await tenantAgent1.modules.oob.createInvitation()
     const { connectionRecord: tenant2ConnectionRecord } = await tenantAgent2.modules.oob.receiveInvitation(
-      outOfBandRecord.outOfBandInvitation
+      outOfBandRecord.outOfBandInvitation,
+      {
+        label: 'Tenant 2',
+      }
     )
 
     // Retrieve all oob records for the base and tenant agent, only the
@@ -242,7 +243,10 @@ describe('Tenants E2E', () => {
     // Create and receive oob invitation in scope of tenants
     const outOfBandRecord = await tenantAgent1.modules.oob.createInvitation()
     const { connectionRecord: tenant2ConnectionRecord } = await tenantAgent2.modules.oob.receiveInvitation(
-      outOfBandRecord.outOfBandInvitation
+      outOfBandRecord.outOfBandInvitation,
+      {
+        label: 'Agent 2 Tenant 1',
+      }
     )
 
     if (!tenant2ConnectionRecord) throw new Error('Receive invitation did not return connection record')
@@ -274,7 +278,6 @@ describe('Tenants E2E', () => {
 
       expect(outOfBandRecord).toBeInstanceOf(OutOfBandRecord)
       expect(tenantAgent.context.contextCorrelationId).toBe(`tenant-${tenantRecord.id}`)
-      expect(tenantAgent.config.label).toBe('Agent 1 Tenant 1')
     })
 
     await agent1.modules.tenants.deleteTenantById(tenantRecord.id)

--- a/samples/extension-module/requester.ts
+++ b/samples/extension-module/requester.ts
@@ -25,7 +25,6 @@ const run = async () => {
   // Setup the agent
   const agent = new Agent({
     config: {
-      label: 'Dummy-powered agent - requester',
       logger: new ConsoleLogger(LogLevel.info),
     },
     modules: {
@@ -58,7 +57,9 @@ const run = async () => {
 
   // Connect to responder using its invitation endpoint
   const invitationUrl = await (await agentDependencies.fetch(`http://localhost:${port}/invitation`)).text()
-  const { connectionRecord } = await agent.modules.oob.receiveInvitationFromUrl(invitationUrl)
+  const { connectionRecord } = await agent.modules.oob.receiveInvitationFromUrl(invitationUrl, {
+    label: 'requester',
+  })
   if (!connectionRecord) {
     throw new CredoError('Connection record for out-of-band invitation was not created.')
   }

--- a/samples/extension-module/responder.ts
+++ b/samples/extension-module/responder.ts
@@ -24,7 +24,6 @@ const run = async () => {
   // Setup the agent
   const agent = new Agent({
     config: {
-      label: 'Dummy-powered agent - responder',
       logger: new ConsoleLogger(LogLevel.debug),
     },
     modules: {

--- a/samples/mediator.ts
+++ b/samples/mediator.ts
@@ -47,7 +47,6 @@ const endpoints = process.env.AGENT_ENDPOINTS?.split(',') ?? [`http://localhost:
 const logger = new TestLogger(LogLevel.info)
 
 const agentConfig: InitConfig = {
-  label: process.env.AGENT_LABEL || 'Credo Mediator',
   logger,
 }
 


### PR DESCRIPTION
Another task from https://github.com/openwallet-foundation/credo-ts/issues/2160. 

For `connectionImageUrl` there is no major issue but for label there are some concerns that could result on a problem:
- Some connection invitation related API methods now require label to be specified (if users do not want to set anything, they can just set them to "")
- In processes that are handling DIDComm connection protocols automatically, we won't be able to let users to specify their particular label. We'll always have the possibility to disable automatic connection/invitation acceptance, but it will not be the case for the auto-provisioning mechanism (i.e. when `mediationInvitationUrl` is defined). In all those cases, a default empty label will be used
- Label in Tenants is kept left for the moment, since probably it can be useful to identify tenants in a friendlier manner than their ID. Also I'm not sure how to deal with existing tenant records that include this field 
