### PR TITLE
chore: update didwebvh-ts to version 2.5.2 in package.json

### DIFF
--- a/packages/webvh/package.json
+++ b/packages/webvh/package.json
@@ -24,7 +24,7 @@
     "@credo-ts/core": "workspace:*",
     "class-transformer": "^0.5.1",
     "class-validator": "0.14.1",
-    "didwebvh-ts": "^2.5.0",
+    "didwebvh-ts": "^2.5.2",
     "json-canonicalize": "^1.0.6",
     "tsyringe": "^4.8.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -932,8 +932,8 @@ importers:
         specifier: 0.14.1
         version: 0.14.1
       didwebvh-ts:
-        specifier: ^2.5.0
-        version: 2.5.0
+        specifier: ^2.5.2
+        version: 2.5.2
       json-canonicalize:
         specifier: ^1.0.6
         version: 1.0.6
@@ -4158,8 +4158,8 @@ packages:
   did-resolver@4.1.0:
     resolution: {integrity: sha512-S6fWHvCXkZg2IhS4RcVHxwuyVejPR7c+a4Go0xbQ9ps5kILa8viiYQgrM4gfTyeTjJ0ekgJH9gk/BawTpmkbZA==}
 
-  didwebvh-ts@2.5.0:
-    resolution: {integrity: sha512-6wBHXnWKwJeSkGrPS0wghARDzFdFT0CYcm4JmjWd2bIeb8V23qnthQFhs26KCwUBYQPvBj3HweTy15H/NePaFw==}
+  didwebvh-ts@2.5.2:
+    resolution: {integrity: sha512-3aMzoYwqefEnat2eyVOiuCqndnYOxFpRsgaXLI4X//GGitJRmhxKc5A4X1LQl7ARzAji5CD4LboQ7Df0aI8T2g==}
     hasBin: true
 
   diff-sequences@29.6.3:
@@ -12315,7 +12315,7 @@ snapshots:
 
   did-resolver@4.1.0: {}
 
-  didwebvh-ts@2.5.0:
+  didwebvh-ts@2.5.2:
     dependencies:
       '@noble/hashes': 1.8.0
       json-canonicalize: 1.0.6


### PR DESCRIPTION
hey @TimoGlastra @genaris I found a couple issues with the react-native build and this version resolves those issues along with #2366 for v0.5.x