### PR TITLE
fix: wrap askar key operation with uint8array

### DIFF
--- a/.changeset/lucky-candies-visit.md
+++ b/.changeset/lucky-candies-visit.md
@@ -1,0 +1,5 @@
+---
+"@credo-ts/askar": patch
+---
+
+fix: wrap askar operations with Uint8array to fix encoding issues in react native

--- a/packages/askar/src/kms/crypto/decrypt.ts
+++ b/packages/askar/src/kms/crypto/decrypt.ts
@@ -20,11 +20,11 @@ export function aeadDecrypt(options: {
   }
 
   const decrypted = key.aeadDecrypt({
-    ciphertext: encrypted,
-    tag: decryption.tag,
-    aad: decryption.aad,
-    nonce: decryption.iv,
+    ciphertext: new Uint8Array(encrypted),
+    tag: new Uint8Array(decryption.tag),
+    aad: decryption.aad ? new Uint8Array(decryption.aad) : undefined,
+    nonce: new Uint8Array(decryption.iv),
   })
 
-  return decrypted
+  return new Uint8Array(decrypted)
 }

--- a/packages/askar/src/kms/crypto/deriveKey.ts
+++ b/packages/askar/src/kms/crypto/deriveKey.ts
@@ -52,8 +52,8 @@ export function deriveEncryptionKey(options: {
         keyAgreement.algorithm === 'ECDH-ES' ? encryption.algorithm : keyAgreement.algorithm
       ),
       receive: false,
-      apv: keyAgreement.apv ?? new Uint8Array([]),
-      apu: keyAgreement.apu ?? new Uint8Array([]),
+      apv: keyAgreement.apv ? new Uint8Array(keyAgreement.apv) : new Uint8Array([]),
+      apu: keyAgreement.apu ? new Uint8Array(keyAgreement.apu) : new Uint8Array([]),
       algorithm: askarKeyWrappingAlgorithm ?? askarEncryptionAlgorithm,
       ephemeralKey: senderKey,
       recipientKey: recipientKey,
@@ -70,9 +70,9 @@ export function deriveEncryptionKey(options: {
         other: contentEncryptionKey,
       })
       encryptedContentEncryptionKey = {
-        encrypted: wrappedKey.ciphertext,
-        iv: wrappedKey.nonce,
-        tag: wrappedKey.tag,
+        encrypted: new Uint8Array(wrappedKey.ciphertext),
+        iv: new Uint8Array(wrappedKey.nonce),
+        tag: new Uint8Array(wrappedKey.tag),
       }
     }
 
@@ -135,8 +135,8 @@ export function deriveDecryptionKey(options: {
         keyAgreement.algorithm === 'ECDH-ES' ? decryption.algorithm : keyAgreement.algorithm
       ),
       receive: true,
-      apv: keyAgreement.apv ?? new Uint8Array(),
-      apu: keyAgreement.apu ?? new Uint8Array(),
+      apv: keyAgreement.apv ? new Uint8Array(keyAgreement.apv) : new Uint8Array(),
+      apu: keyAgreement.apu ? new Uint8Array(keyAgreement.apu) : new Uint8Array(),
       algorithm: askarKeyWrappingAlgorithm ?? askarEncryptionAlgorithm,
       ephemeralKey: senderKey,
       recipientKey: recipientKey,
@@ -148,10 +148,10 @@ export function deriveDecryptionKey(options: {
     // Key unwrapping
     if (keyAgreement.algorithm !== 'ECDH-ES') {
       contentEncryptionKey = derivedKey.unwrapKey({
-        ciphertext: keyAgreement.encryptedKey.encrypted,
+        ciphertext: new Uint8Array(keyAgreement.encryptedKey.encrypted),
         algorithm: askarEncryptionAlgorithm,
-        nonce: keyAgreement.encryptedKey.iv,
-        tag: keyAgreement.encryptedKey.tag,
+        nonce: keyAgreement.encryptedKey.iv ? new Uint8Array(keyAgreement.encryptedKey.iv) : undefined,
+        tag: keyAgreement.encryptedKey.tag ? new Uint8Array(keyAgreement.encryptedKey.tag) : undefined,
       })
     }
 

--- a/packages/askar/src/kms/crypto/encrypt.ts
+++ b/packages/askar/src/kms/crypto/encrypt.ts
@@ -19,14 +19,14 @@ export function aeadEncrypt(options: {
   }
 
   const encrypted = key.aeadEncrypt({
-    message: data,
-    aad: 'aad' in encryption ? encryption.aad : undefined,
-    nonce: 'iv' in encryption ? encryption.iv : undefined,
+    message: new Uint8Array(data),
+    aad: encryption.aad ? new Uint8Array(encryption.aad) : undefined,
+    nonce: encryption.iv ? new Uint8Array(encryption.iv) : undefined,
   })
 
   return {
-    encrypted: encrypted.ciphertext,
-    iv: encrypted.nonce,
-    tag: encrypted.tag,
+    encrypted: new Uint8Array(encrypted.ciphertext),
+    iv: new Uint8Array(encrypted.nonce),
+    tag: new Uint8Array(encrypted.tag),
   }
 }


### PR DESCRIPTION
Fixes issues in React Native with Buffers being passed to the askar library.

I've been hoping to replace the JS buffer library for a while (since it's not maintained). And with React Native now supporting `TextDecoder`, we're getting there (we still need `TextDecoder`). 

So this may seem a bit hacky, but i've verified it to work in React Native