### PR TITLE
fix(openid4vc): return type of credential mappers

### DIFF
--- a/.changeset/beige-deer-cross.md
+++ b/.changeset/beige-deer-cross.md
@@ -1,0 +1,5 @@
+---
+"@credo-ts/openid4vc": patch
+---
+
+Fix the return type of the credential mappers.

--- a/packages/openid4vc/src/openid4vc-issuer/OpenId4VcIssuerServiceOptions.ts
+++ b/packages/openid4vc/src/openid4vc-issuer/OpenId4VcIssuerServiceOptions.ts
@@ -304,7 +304,7 @@ export interface OpenId4VciCredentialRequestToCredentialMapperOptions {
 
 export type OpenId4VciCredentialRequestToCredentialMapper = (
   options: OpenId4VciCredentialRequestToCredentialMapperOptions
-) => CanBePromise<OpenId4VciSignCredentials> | CanBePromise<OpenId4VciDeferredCredentials>
+) => CanBePromise<OpenId4VciSignCredentials | OpenId4VciDeferredCredentials>
 
 export interface OpenId4VciDeferredCredentialRequestToCredentialMapperOptions {
   agentContext: AgentContext
@@ -328,7 +328,7 @@ export interface OpenId4VciDeferredCredentialRequestToCredentialMapperOptions {
 
 export type OpenId4VciDeferredCredentialRequestToCredentialMapper = (
   options: OpenId4VciDeferredCredentialRequestToCredentialMapperOptions
-) => CanBePromise<OpenId4VciSignCredentials> | CanBePromise<OpenId4VciDeferredCredentials>
+) => CanBePromise<OpenId4VciSignCredentials | OpenId4VciDeferredCredentials>
 
 export type OpenId4VciSignCredentials =
   | OpenId4VciSignSdJwtCredentials


### PR DESCRIPTION
Fixes the return type of the credential mappers.

cc @TimoGlastra 