### PR TITLE
fix: AgentMessageProcessed event listener leak

### DIFF
--- a/packages/node/src/transport/HttpInboundTransport.ts
+++ b/packages/node/src/transport/HttpInboundTransport.ts
@@ -12,7 +12,7 @@ import type { Server } from 'http'
 
 import { DidCommMimeType, CredoError, TransportService, utils, AgentEventTypes } from '@credo-ts/core'
 import express, { text } from 'express'
-import { filter, firstValueFrom, ReplaySubject, timeout } from 'rxjs'
+import { filter, firstValueFrom, ReplaySubject, take, timeout } from 'rxjs'
 
 const supportedContentTypes: string[] = [DidCommMimeType.V0, DidCommMimeType.V1]
 
@@ -83,7 +83,8 @@ export class HttpInboundTransport implements InboundTransport {
             timeout({
               first: this.processedMessageListenerTimeoutMs,
               meta: 'HttpInboundTransport.start',
-            })
+            }),
+            take(1)
           )
           .subscribe(subject)
 


### PR DESCRIPTION
This is the same fix for the memory leak recently found but targeting 0.5.x. (please ignore the branch version)

Auto unsubscribes the listener for the encrypted message filter after first match.