### PR TITLE
feat(webvh): enhance revocation status list handling in WebVhAnonCredsRegistry

### DIFF
--- a/packages/webvh/src/anoncreds/utils/transform.ts
+++ b/packages/webvh/src/anoncreds/utils/transform.ts
@@ -68,6 +68,24 @@ export class WebVhRevRegDefContent {
   }
 }
 
+export class WebVhRevocationStatusListContent {
+  @IsString()
+  public issuerId!: string
+
+  @IsString()
+  public revRegDefId!: string
+
+  @IsArray()
+  @IsNumber({}, { each: true })
+  public revocationList!: number[]
+
+  @IsString()
+  public currentAccumulator!: string
+
+  @IsNumber()
+  public timestamp!: number
+}
+
 export class WebVhProof {
   @IsString()
   public type!: string
@@ -110,7 +128,7 @@ export class WebVhResource {
     }
     return value
   })
-  public content!: WebVhSchemaContent | WebVhCredDefContent | WebVhRevRegDefContent
+  public content!: WebVhSchemaContent | WebVhCredDefContent | WebVhRevRegDefContent | WebVhRevocationStatusListContent
 
   @ValidateNested()
   @Type(() => WebVhProof)


### PR DESCRIPTION
for 0.5.x

- Implemented logic to retrieve and validate revocation entries based on timestamp.
- Introduced WebVhRevocationStatusListContent class for structured revocation status data.
- Improved error handling for missing revocation entries and logging for resolution attempts.