### PR TITLE
fix: Set pickup delivery to prefer websocket transport

### DIFF
--- a/packages/core/src/modules/message-pickup/MessagePickupApi.ts
+++ b/packages/core/src/modules/message-pickup/MessagePickupApi.ts
@@ -233,7 +233,7 @@ export class MessagePickupApi<MPPs extends MessagePickupProtocol[] = [V1MessageP
           filter((e) => e.payload.connection.id === connectionRecord.id),
           // Only wait for first event that matches the criteria
           first(),
-          // If we don't receive all messages within timeoutMs miliseconds (no response, not supported, etc...) error
+          // If we don't receive all messages within timeoutMs milliseconds (no response, not supported, etc...) error
           timeout({
             first: options.awaitCompletionTimeoutMs ?? 10000,
             meta: 'MessagePickupApi.pickupMessages',

--- a/packages/core/src/modules/message-pickup/MessagePickupApi.ts
+++ b/packages/core/src/modules/message-pickup/MessagePickupApi.ts
@@ -152,7 +152,7 @@ export class MessagePickupApi<MPPs extends MessagePickupProtocol[] = [V1MessageP
           agentContext: this.agentContext,
           connection: connectionRecord,
         }),
-        { transportPriority: { schemes: ['wss', 'ws'], restrictive: true } }
+        { transportPriority: { schemes: ['wss', 'ws'] } }
       )
     }
   }
@@ -191,7 +191,7 @@ export class MessagePickupApi<MPPs extends MessagePickupProtocol[] = [V1MessageP
           agentContext: this.agentContext,
           connection: connectionRecord,
         }),
-        { transportPriority: { schemes: ['wss', 'ws'], restrictive: true } }
+        { transportPriority: { schemes: ['wss', 'ws'] } }
       )
     }
   }
@@ -243,7 +243,7 @@ export class MessagePickupApi<MPPs extends MessagePickupProtocol[] = [V1MessageP
     }
 
     // For picking up messages we prefer a long-lived transport session, so we will set a higher priority to
-    // WebSocket endpoints. However, it is not extrictly required.
+    // WebSocket endpoints. However, it is not explicitly required.
     await this.messageSender.sendMessage(outboundMessageContext, { transportPriority: { schemes: ['wss', 'ws'] } })
 
     if (options.awaitCompletion) {

--- a/packages/core/src/modules/message-pickup/MessagePickupApi.ts
+++ b/packages/core/src/modules/message-pickup/MessagePickupApi.ts
@@ -151,7 +151,8 @@ export class MessagePickupApi<MPPs extends MessagePickupProtocol[] = [V1MessageP
         new OutboundMessageContext(createDeliveryReturn.message, {
           agentContext: this.agentContext,
           connection: connectionRecord,
-        })
+        }),
+        { transportPriority: { schemes: ['wss', 'ws'], restrictive: true } }
       )
     }
   }
@@ -189,7 +190,8 @@ export class MessagePickupApi<MPPs extends MessagePickupProtocol[] = [V1MessageP
         new OutboundMessageContext(deliverMessagesReturn.message, {
           agentContext: this.agentContext,
           connection: connectionRecord,
-        })
+        }),
+        { transportPriority: { schemes: ['wss', 'ws'], restrictive: true } }
       )
     }
   }

--- a/packages/core/src/modules/message-pickup/__tests__/MessagePickupApi.test.ts
+++ b/packages/core/src/modules/message-pickup/__tests__/MessagePickupApi.test.ts
@@ -133,7 +133,7 @@ describe('MessagePickupApi', () => {
     expect(outboundCtx.message.type).toEqual(V2MessageDeliveryMessage.type.messageTypeUri)
     expect(outboundCtx.connection).toEqual(mockConnection)
     expect(options).toEqual({
-      transportPriority: { schemes: ['wss', 'ws'], restrictive: true },
+      transportPriority: { schemes: ['wss', 'ws'] },
     })
   })
 
@@ -171,7 +171,7 @@ describe('MessagePickupApi', () => {
     expect(outboundCtx.message.type).toEqual(V2MessageDeliveryMessage.type.messageTypeUri)
     expect(outboundCtx.connection).toEqual(mockConnection)
     expect(options).toEqual({
-      transportPriority: { schemes: ['wss', 'ws'], restrictive: true },
+      transportPriority: { schemes: ['wss', 'ws'] },
     })
   })
 

--- a/packages/core/src/modules/message-pickup/__tests__/MessagePickupApi.test.ts
+++ b/packages/core/src/modules/message-pickup/__tests__/MessagePickupApi.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import type { EncryptedMessage } from '../../../../build/types'
+import type { EncryptedMessage } from '../../../../../core/src/types'
 import type { MessagePickupSession } from '../MessagePickupSession'
 import type { MessagePickupProtocol } from '../protocol/MessagePickupProtocol'
 

--- a/packages/core/src/modules/message-pickup/__tests__/MessagePickupApi.test.ts
+++ b/packages/core/src/modules/message-pickup/__tests__/MessagePickupApi.test.ts
@@ -1,0 +1,195 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import type { EncryptedMessage } from '../../../../build/types'
+import type { MessagePickupSession } from '../MessagePickupSession'
+import type { MessagePickupProtocol } from '../protocol/MessagePickupProtocol'
+
+import { Subject } from 'rxjs'
+
+import { getAgentContext, getMockConnection, mockFunction } from '../../../../tests/helpers'
+import { EventEmitter } from '../../../agent/EventEmitter'
+import { MessageSender } from '../../../agent/MessageSender'
+import { InjectionSymbols } from '../../../constants'
+import { CredoError } from '../../../error/CredoError'
+import { DidExchangeState } from '../../connections/models/DidExchangeState'
+import { ConnectionService } from '../../connections/services/ConnectionService'
+import { MessagePickupApi } from '../MessagePickupApi'
+import { MessagePickupModuleConfig } from '../MessagePickupModuleConfig'
+import { V1MessagePickupProtocol, V2MessageDeliveryMessage, V2MessagePickupProtocol } from '../protocol'
+import { MessagePickupSessionService } from '../services/MessagePickupSessionService'
+import { InMemoryMessagePickupRepository } from '../storage/InMemoryMessagePickupRepository'
+
+const mockConnection = getMockConnection({
+  state: DidExchangeState.Completed,
+})
+
+jest.mock('../storage/InMemoryMessagePickupRepository')
+jest.mock('../../../agent/EventEmitter')
+jest.mock('../../../agent/MessageSender')
+jest.mock('../../connections/services/ConnectionService')
+jest.mock('../services/MessagePickupSessionService')
+
+const InMessageRepositoryMock = InMemoryMessagePickupRepository as jest.Mock<InMemoryMessagePickupRepository>
+const EventEmitterMock = EventEmitter as jest.Mock<EventEmitter>
+const MessageSenderMock = MessageSender as jest.Mock<MessageSender>
+const ConnectionServiceMock = ConnectionService as jest.Mock<ConnectionService>
+const MessagePickupSessionServiceMock = MessagePickupSessionService as jest.Mock<MessagePickupSessionService>
+
+const messagePickupModuleConfig = new MessagePickupModuleConfig({
+  maximumBatchSize: 10,
+  protocols: [new V1MessagePickupProtocol(), new V2MessagePickupProtocol()],
+})
+
+// Mock classes
+const messagePickupRepository = new InMessageRepositoryMock()
+const eventEmitter = new EventEmitterMock()
+const messageSender = new MessageSenderMock()
+const connectionService = new ConnectionServiceMock()
+const messagePickupSessionService = new MessagePickupSessionServiceMock()
+
+// Mock typed object
+const agentContext = getAgentContext({
+  registerInstances: [
+    [InjectionSymbols.MessagePickupRepository, messagePickupRepository],
+    [EventEmitter, eventEmitter],
+    [MessageSender, messageSender],
+    [ConnectionService, connectionService],
+    [MessagePickupModuleConfig, messagePickupModuleConfig],
+    [MessagePickupSessionService, messagePickupSessionService],
+  ],
+})
+
+const encryptedMessage: EncryptedMessage = {
+  protected: 'base64url',
+  iv: 'base64url',
+  ciphertext: 'base64url',
+  tag: 'base64url',
+}
+
+const queuedMessages = [
+  { id: '1', encryptedMessage },
+  { id: '2', encryptedMessage },
+  { id: '3', encryptedMessage },
+]
+
+describe('MessagePickupApi', () => {
+  jest.resetAllMocks()
+
+  let api: MessagePickupApi<MessagePickupProtocol[]>
+  let mockLogger: any
+  let stop$: Subject<boolean>
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+    mockLogger = { debug: jest.fn() }
+    stop$ = new Subject()
+
+    api = new MessagePickupApi(
+      messageSender,
+      agentContext,
+      connectionService,
+      eventEmitter,
+      messagePickupSessionService,
+      messagePickupModuleConfig,
+      stop$,
+      mockLogger
+    )
+  })
+
+  it('throws if deliverMessages has no active session', async () => {
+    mockFunction(messagePickupSessionService.getLiveSession).mockReturnValue(undefined)
+
+    await expect(api.deliverMessages({ pickupSessionId: 'bad', messages: [] })).rejects.toThrow(CredoError)
+
+    expect(connectionService.getById).not.toHaveBeenCalled()
+    expect(messageSender.sendMessage).not.toHaveBeenCalled()
+  })
+
+  it('sends delivery message if session is found with ws priority', async () => {
+    mockFunction(messagePickupSessionService.getLiveSession).mockReturnValue({
+      connectionId: mockConnection.id,
+      protocolVersion: 'v2',
+    } as MessagePickupSession)
+    mockFunction(connectionService.getById).mockResolvedValue(mockConnection)
+
+    await api.deliverMessages({
+      pickupSessionId: 'pickup-1',
+      messages: [
+        {
+          id: 'abc',
+          encryptedMessage: {
+            protected: 'mock-protected',
+            iv: 'mock-iv',
+            ciphertext: 'mock-ciphertext',
+            tag: 'mock-tag',
+          },
+        },
+      ],
+    })
+
+    const sendMessageMock = messageSender.sendMessage as jest.Mock
+    const [outboundCtx, options] = sendMessageMock.mock.calls[0]
+
+    expect(messageSender.sendMessage).toHaveBeenCalledTimes(1)
+    expect(outboundCtx.message.type).toEqual(V2MessageDeliveryMessage.type.messageTypeUri)
+    expect(outboundCtx.connection).toEqual(mockConnection)
+    expect(options).toEqual({
+      transportPriority: { schemes: ['wss', 'ws'], restrictive: true },
+    })
+  })
+
+  it('throws if no active session is found', async () => {
+    mockFunction(messagePickupSessionService.getLiveSession).mockReturnValue(undefined)
+
+    await expect(
+      api.deliverMessagesFromQueue({
+        pickupSessionId: 'pickup-1',
+        recipientDid: 'did:key:z6MkjFake',
+        batchSize: 10,
+      })
+    ).rejects.toThrow(CredoError)
+  })
+
+  it('sends delivery message via websocket transport when session is found', async () => {
+    mockFunction(messagePickupSessionService.getLiveSession).mockReturnValue({
+      id: 'pickup-1',
+      connectionId: mockConnection.id,
+      protocolVersion: 'v2',
+    } as MessagePickupSession)
+    mockFunction(connectionService.getById).mockResolvedValue(mockConnection)
+    mockFunction(messagePickupRepository.takeFromQueue).mockReturnValue(queuedMessages)
+
+    await api.deliverMessagesFromQueue({
+      pickupSessionId: 'pickup-1',
+      recipientDid: 'did:key:z6MkjFake',
+      batchSize: 5,
+    })
+
+    const sendMessageMock = messageSender.sendMessage as jest.Mock
+    const [outboundCtx, options] = sendMessageMock.mock.calls[0]
+
+    expect(messageSender.sendMessage).toHaveBeenCalledTimes(1)
+    expect(outboundCtx.message.type).toEqual(V2MessageDeliveryMessage.type.messageTypeUri)
+    expect(outboundCtx.connection).toEqual(mockConnection)
+    expect(options).toEqual({
+      transportPriority: { schemes: ['wss', 'ws'], restrictive: true },
+    })
+  })
+
+  it('does not send message if the session does not exist', async () => {
+    mockFunction(messagePickupSessionService.getLiveSession).mockReturnValue({
+      id: 'pickup-0', // Different session id
+      connectionId: mockConnection.id,
+      protocolVersion: 'v2',
+    } as MessagePickupSession)
+    mockFunction(messagePickupRepository.takeFromQueue).mockReturnValue([])
+    mockFunction(connectionService.getById).mockResolvedValue(mockConnection)
+
+    await api.deliverMessagesFromQueue({
+      pickupSessionId: 'pickup-1',
+      recipientDid: 'did:key:z6MkjFake',
+      batchSize: 2,
+    })
+
+    expect(messageSender.sendMessage).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/modules/message-pickup/__tests__/MessagePickupSessionService.test.ts
+++ b/packages/core/src/modules/message-pickup/__tests__/MessagePickupSessionService.test.ts
@@ -1,0 +1,121 @@
+import type { TransportSession } from '../../../agent/TransportService'
+import type { AgentContext } from '../../../agent/context/AgentContext'
+import type { TransportSessionRemovedEvent } from '../../../transport'
+
+import { Subject } from 'rxjs'
+
+import { agentDependencies, getAgentContext } from '../../../../tests/helpers'
+import { AgentMessage } from '../../../agent/AgentMessage'
+import { EventEmitter } from '../../../agent/EventEmitter'
+import { InjectionSymbols } from '../../../constants'
+import { TransportEventTypes } from '../../../transport/TransportEventTypes'
+import { MessagePickupSessionService } from '../services/MessagePickupSessionService'
+
+describe('start listener remove live sessions', () => {
+  let instance: MessagePickupSessionService
+  let agentContext: AgentContext
+  let stop$: Subject<boolean>
+  let eventEmitter: EventEmitter
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+
+    stop$ = new Subject<boolean>()
+    eventEmitter = new EventEmitter(agentDependencies, stop$)
+    agentContext = getAgentContext({
+      registerInstances: [
+        [EventEmitter, eventEmitter],
+        [InjectionSymbols.Stop$, stop$],
+      ],
+    })
+    instance = new MessagePickupSessionService()
+    jest.spyOn(instance, 'removeLiveSession').mockImplementation()
+  })
+
+  test('removes live session on WebSocket transport event', () => {
+    instance.start(agentContext)
+
+    const session: TransportSession = {
+      id: '1',
+      type: 'WebSocket',
+      keys: {
+        recipientKeys: [],
+        routingKeys: [],
+        senderKey: null,
+      },
+      inboundMessage: new AgentMessage(),
+      connectionId: 'conn-123',
+      send: jest.fn(),
+      close: jest.fn(),
+    }
+
+    eventEmitter.emit<TransportSessionRemovedEvent>(agentContext, {
+      type: TransportEventTypes.TransportSessionRemoved,
+      payload: {
+        session: session,
+      },
+    })
+
+    expect(instance.removeLiveSession).toHaveBeenCalledWith(agentContext, {
+      connectionId: 'conn-123',
+    })
+  })
+
+  test('does not remove live session on non-WebSocket transport event', () => {
+    instance.start(agentContext)
+
+    const session: TransportSession = {
+      id: '1',
+      type: 'http',
+      keys: {
+        recipientKeys: [],
+        routingKeys: [],
+        senderKey: null,
+      },
+      inboundMessage: new AgentMessage(),
+      connectionId: 'conn-123',
+      send: jest.fn(),
+      close: jest.fn(),
+    }
+
+    eventEmitter.emit<TransportSessionRemovedEvent>(agentContext, {
+      type: TransportEventTypes.TransportSessionRemoved,
+      payload: {
+        session: session,
+      },
+    })
+
+    expect(instance.removeLiveSession).not.toHaveBeenCalledWith(agentContext, {
+      connectionId: 'conn-123',
+    })
+  })
+
+  test('stops listening when stop$ emits', () => {
+    instance.start(agentContext)
+
+    stop$.next(true)
+
+    const session: TransportSession = {
+      id: '1',
+      type: 'WebSocket',
+      keys: {
+        recipientKeys: [],
+        routingKeys: [],
+        senderKey: null,
+      },
+      inboundMessage: new AgentMessage(),
+      connectionId: 'conn-123',
+      send: jest.fn(),
+      close: jest.fn(),
+    }
+
+    eventEmitter.emit<TransportSessionRemovedEvent>(agentContext, {
+      type: TransportEventTypes.TransportSessionRemoved,
+      payload: {
+        session: session,
+      },
+    })
+
+    expect(instance.removeLiveSession).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/modules/message-pickup/services/MessagePickupSessionService.ts
+++ b/packages/core/src/modules/message-pickup/services/MessagePickupSessionService.ts
@@ -35,7 +35,7 @@ export class MessagePickupSessionService {
     eventEmitter
       .observable<TransportSessionRemovedEvent>(TransportEventTypes.TransportSessionRemoved)
       .pipe(
-        filter((e) => e.payload.session.type === 'Websocket'),
+        filter((e) => e.payload.session.type === 'WebSocket'),
         takeUntil(stop$)
       )
       .subscribe({

--- a/packages/core/src/modules/message-pickup/services/MessagePickupSessionService.ts
+++ b/packages/core/src/modules/message-pickup/services/MessagePickupSessionService.ts
@@ -3,7 +3,7 @@ import type { TransportSessionRemovedEvent } from '../../../transport'
 import type { MessagePickupLiveSessionRemovedEvent, MessagePickupLiveSessionSavedEvent } from '../MessagePickupEvents'
 import type { MessagePickupSession, MessagePickupSessionRole } from '../MessagePickupSession'
 
-import { takeUntil, type Subject } from 'rxjs'
+import { filter, takeUntil, type Subject } from 'rxjs'
 
 import { EventEmitter } from '../../../agent/EventEmitter'
 import { InjectionSymbols } from '../../../constants'
@@ -34,7 +34,10 @@ export class MessagePickupSessionService {
 
     eventEmitter
       .observable<TransportSessionRemovedEvent>(TransportEventTypes.TransportSessionRemoved)
-      .pipe(takeUntil(stop$))
+      .pipe(
+        filter((e) => e.payload.session.type === 'Websocket'),
+        takeUntil(stop$)
+      )
       .subscribe({
         next: (e) => {
           const connectionId = e.payload.session.connectionId


### PR DESCRIPTION
This is to fix a couple problems we've been having with live mode and both http and ws sessions. I don't know much about the outbound context session id but I changed the preference to choose the session by connection id first, and then use the websocket session if it is in the session table.

Then for the removing of the pickup session when in live mode delivery, I changed this to only happen when websocket sessions close. All other delivery modes close pickup sessions on every session closed event.


TODO: Automated testing