### PR TITLE
chore: update the `replaceError` to better handle react native serialization

### DIFF
--- a/.changeset/little-windows-check.md
+++ b/.changeset/little-windows-check.md
@@ -1,0 +1,5 @@
+---
+"@credo-ts/core": minor
+---
+
+chore: update the `replaceError` to better handle react native serialization

--- a/packages/core/src/logger/replaceError.ts
+++ b/packages/core/src/logger/replaceError.ts
@@ -2,8 +2,18 @@
  * The replacer parameter allows you to specify a function that replaces values with your own. We can use it to control what gets stringified.
  */
 export function replaceError(_: unknown, value: unknown) {
+  /**
+   * This special handling for error classes is mostly to not hide error messages in React Native.
+   * The error serialization works differently from node, so a lot of times you get `error: {}`, which
+   * really compliactes debugging.
+   */
   if (value instanceof Error) {
-    return value.toString()
+    return {
+      serialized: 'toJSON' in value && typeof value.toJSON === 'function' ? value.toJSON() : value.toString(),
+      message: value.message,
+      name: value.name,
+      stack: value.stack,
+    }
   }
 
   return value


### PR DESCRIPTION
We keep seeing issues in React Native with error serialization, making it hard to debug without adding a lot of console.logs in node_modules. I have verified this in our wallet, and it improves the error serialization, for errors that don't implement `toString`.

