### PR TITLE
fix(vc): allow selecting proof purpose for VPs

### DIFF
--- a/packages/core/src/modules/vc/W3cCredentialServiceOptions.ts
+++ b/packages/core/src/modules/vc/W3cCredentialServiceOptions.ts
@@ -125,7 +125,7 @@ interface W3cSignPresentationOptionsBase {
   /**
    * The challenge / nonce to be used in the proof to prevent replay attacks.
    */
-  challenge: string
+  challenge?: string
 
   /**
    * The domain / aud to be used in the proof to assert the intended recipient.

--- a/packages/core/src/modules/vc/data-integrity/W3cJsonLdCredentialService.ts
+++ b/packages/core/src/modules/vc/data-integrity/W3cJsonLdCredentialService.ts
@@ -216,6 +216,7 @@ export class W3cJsonLdCredentialService {
       suite: suite,
       challenge: options.challenge,
       domain: options.domain,
+      purpose: options.proofPurpose,
       documentLoader: this.w3cCredentialsModuleConfig.documentLoader(agentContext),
     })
 
@@ -270,6 +271,7 @@ export class W3cJsonLdCredentialService {
         suite: allSuites,
         challenge: options.challenge,
         domain: options.domain,
+        purpose: options.purpose,
         documentLoader: this.w3cCredentialsModuleConfig.documentLoader(agentContext),
       }
 


### PR DESCRIPTION
This is mainly to allow using `assertionMethod` proof purposes, which is needed in [Linked VPs](https://identity.foundation/linked-vp/) that are bound to a DID and not meant for authentication.

When we don't select any proof purpose, `@digitalcredentials/jsonld-signatures` library will take it as `authentication` and therefore require `challenge` and use `domain`. So this subtle change allows users to use any kind of proof purpose they want.

I'm not sure if this would be also useful for JWT credentials. Currently only implemented for JSON-LD because these are the ones we are creating for Linked VPs and did:webvh.