### PR TITLE
fix(vc): allow selecting proof purpose for VPs (backport #2390)

### DIFF
--- a/.changeset/all-mails-guess.md
+++ b/.changeset/all-mails-guess.md
@@ -1,0 +1,5 @@
+---
+'@credo-ts/core': patch
+---
+
+fix: allow selecting proof purpose for Verifiable Presentations

--- a/packages/core/src/modules/dif-presentation-exchange/DifPresentationExchangeService.ts
+++ b/packages/core/src/modules/dif-presentation-exchange/DifPresentationExchangeService.ts
@@ -40,12 +40,12 @@ import {
   W3cCredentialService,
   W3cPresentation,
 } from '../vc'
+import { purposes } from '../vc/data-integrity/libraries/jsonld-signatures'
 import {
   AnonCredsDataIntegrityServiceSymbol,
   ANONCREDS_DATA_INTEGRITY_CRYPTOSUITE,
 } from '../vc/data-integrity/models/IAnonCredsDataIntegrityService'
 
-import { purposes } from '../vc/data-integrity/libraries/jsonld-signatures'
 import { DifPresentationExchangeError } from './DifPresentationExchangeError'
 import { DifPresentationExchangeSubmissionLocation } from './models'
 import {

--- a/packages/core/src/modules/dif-presentation-exchange/DifPresentationExchangeService.ts
+++ b/packages/core/src/modules/dif-presentation-exchange/DifPresentationExchangeService.ts
@@ -45,6 +45,7 @@ import {
   ANONCREDS_DATA_INTEGRITY_CRYPTOSUITE,
 } from '../vc/data-integrity/models/IAnonCredsDataIntegrityService'
 
+import { purposes } from '../vc/data-integrity/libraries/jsonld-signatures'
 import { DifPresentationExchangeError } from './DifPresentationExchangeError'
 import { DifPresentationExchangeSubmissionLocation } from './models'
 import {
@@ -533,7 +534,7 @@ export class DifPresentationExchangeService {
           // as then we know when determining which VPs to submit already if the proof types are supported
           // by the verifier, and we can then just add this to the vpToCreate interface
           proofType: this.getProofTypeForLdpVc(agentContext, presentationDefinition, verificationMethod),
-          proofPurpose: 'authentication',
+          proofPurpose: new purposes.AuthenticationProofPurpose({ challenge, domain }),
           verificationMethod: verificationMethod.id,
           presentation: w3cPresentation,
           challenge,

--- a/packages/core/src/modules/vc/W3cCredentialServiceOptions.ts
+++ b/packages/core/src/modules/vc/W3cCredentialServiceOptions.ts
@@ -125,7 +125,7 @@ interface W3cSignPresentationOptionsBase {
   /**
    * The challenge / nonce to be used in the proof to prevent replay attacks.
    */
-  challenge: string
+  challenge?: string
 
   /**
    * The domain / aud to be used in the proof to assert the intended recipient.

--- a/packages/core/src/modules/vc/data-integrity/W3cJsonLdCredentialService.ts
+++ b/packages/core/src/modules/vc/data-integrity/W3cJsonLdCredentialService.ts
@@ -205,13 +205,20 @@ export class W3cJsonLdCredentialService {
       useNativeCanonize: false,
     })
 
-    const result = await vc.signPresentation({
+    const signOptions: Record<string, unknown> = {
       presentation: JsonTransformer.toJSON(options.presentation),
       suite: suite,
       challenge: options.challenge,
       domain: options.domain,
       documentLoader: this.w3cCredentialsModuleConfig.documentLoader(agentContext),
-    })
+    }
+
+    // this is a hack because vcjs throws if purpose is passed as undefined or null
+    if (options.proofPurpose) {
+      signOptions.purpose = options.proofPurpose
+    }
+
+    const result = await vc.signPresentation(signOptions)
 
     return JsonTransformer.fromJSON(result, W3cJsonLdVerifiablePresentation)
   }

--- a/packages/core/src/modules/vc/data-integrity/libraries/jsonld-signatures.ts
+++ b/packages/core/src/modules/vc/data-integrity/libraries/jsonld-signatures.ts
@@ -16,6 +16,8 @@ export interface Suites {
 
 export interface Purposes {
   AssertionProofPurpose: any
+  // biome-ignore lint/suspicious/noExplicitAny: <explanation>
+  AuthenticationProofPurpose: any
 }
 
 type Constants = any


### PR DESCRIPTION
Backporting #2390 for 0.5.x releases. 

Note that `challenge` field is now marked as optional in `W3cSignPresentationOptionsBase`. Could this interface change represent a breaking change? If so, I can change it to be mandatory even if not used (in such case, caller should just use an empty string).