### PR TITLE
fix(openid4vc): fallback to anon auth with refresh tokens

### DIFF
--- a/.changeset/shaky-emus-invite.md
+++ b/.changeset/shaky-emus-invite.md
@@ -1,0 +1,5 @@
+---
+"@credo-ts/openid4vc": patch
+---
+
+Fallback to anonymous authentication when doing client authentication with refresh token endpoint.

--- a/packages/openid4vc/src/openid4vc-holder/OpenId4VciHolderService.ts
+++ b/packages/openid4vc/src/openid4vc-holder/OpenId4VciHolderService.ts
@@ -26,6 +26,7 @@ import {
   clientAuthenticationNone,
   getAuthorizationServerMetadataFromList,
   preAuthorizedCodeGrantIdentifier,
+  refreshTokenGrantIdentifier,
 } from '@openid4vc/oauth2'
 import {
   DeferredCredentialResponse,
@@ -1310,6 +1311,12 @@ export class OpenId4VciHolderService {
           url === authorizationServerMetadata.token_endpoint &&
           body.grant_type === preAuthorizedCodeGrantIdentifier
         ) {
+          return clientAuthenticationAnonymous()(options)
+        }
+
+        // Refresh token flow defaults to anonymous auth if there is neither a client attestation or client id
+        // is present.
+        if (body.grant_type === refreshTokenGrantIdentifier) {
           return clientAuthenticationAnonymous()(options)
         }
 

--- a/packages/openid4vc/src/openid4vc-issuer/router/credentialEndpoint.ts
+++ b/packages/openid4vc/src/openid4vc-issuer/router/credentialEndpoint.ts
@@ -174,11 +174,16 @@ export function configureCredentialEndpoint(router: Router, config: OpenId4VcIss
       else if (Date.now() > expiresAt.getTime()) {
         issuanceSession.errorMessage = 'Credential offer has expired'
         await openId4VcIssuerService.updateState(agentContext, issuanceSession, OpenId4VcIssuanceSessionState.Error)
-        throw new Oauth2ServerErrorResponseError({
-          // What is the best error here?
-          error: Oauth2ErrorCodes.CredentialRequestDenied,
-          error_description: 'Session expired',
-        })
+        return sendOauth2ErrorResponse(
+          response,
+          next,
+          agentContext.config.logger,
+          new Oauth2ServerErrorResponseError({
+            // What is the best error here?
+            error: Oauth2ErrorCodes.CredentialRequestDenied,
+            error_description: 'Session expired',
+          })
+        )
       } else {
         issuanceSession.authorization = {
           ...issuanceSession.authorization,

--- a/packages/openid4vc/src/openid4vc-issuer/router/deferredCredentialEndpoint.ts
+++ b/packages/openid4vc/src/openid4vc-issuer/router/deferredCredentialEndpoint.ts
@@ -166,11 +166,16 @@ export function configureDeferredCredentialEndpoint(router: Router, config: Open
       if (Date.now() > expiresAt.getTime()) {
         issuanceSession.errorMessage = 'Credential offer has expired'
         await openId4VcIssuerService.updateState(agentContext, issuanceSession, OpenId4VcIssuanceSessionState.Error)
-        throw new Oauth2ServerErrorResponseError({
-          // What is the best error here?
-          error: Oauth2ErrorCodes.CredentialRequestDenied,
-          error_description: 'Session expired',
-        })
+        return sendOauth2ErrorResponse(
+          response,
+          next,
+          agentContext.config.logger,
+          new Oauth2ServerErrorResponseError({
+            // What is the best error here?
+            error: Oauth2ErrorCodes.CredentialRequestDenied,
+            error_description: 'Session expired',
+          })
+        )
       }
 
       try {


### PR DESCRIPTION
From my tests, this seems to be necessary in some flows where neither a client id or wallet attestation has been used.