### PR TITLE
fix(didcomm): transport ordering when using non-restrictve priority

### DIFF
--- a/packages/didcomm/src/DidCommMessageSender.ts
+++ b/packages/didcomm/src/DidCommMessageSender.ts
@@ -548,13 +548,16 @@ export class DidCommMessageSender {
       })
     }
 
-    // If transport priority is set we will sort services by our priority
+    // If transport priority is set we will sort services by our priority.
+    // Services whose scheme is not listed in the priority list are kept but
+    // sorted after any prioritized ones (indexOf returns -1 for them, which
+    // would otherwise incorrectly rank them first).
     if (transportPriority?.schemes) {
-      services = services.sort((a, b) => {
-        const aScheme = utils.getProtocolScheme(a.serviceEndpoint)
-        const bScheme = utils.getProtocolScheme(b.serviceEndpoint)
-        return transportPriority?.schemes.indexOf(aScheme) - transportPriority?.schemes.indexOf(bScheme)
-      })
+      const schemePriority = (endpoint: string) => {
+        const index = transportPriority.schemes.indexOf(utils.getProtocolScheme(endpoint))
+        return index === -1 ? Number.MAX_SAFE_INTEGER : index
+      }
+      services = services.sort((a, b) => schemePriority(a.serviceEndpoint) - schemePriority(b.serviceEndpoint))
     }
 
     agentContext.config.logger.debug(

--- a/packages/didcomm/src/__tests__/DidCommMessageSender.test.ts
+++ b/packages/didcomm/src/__tests__/DidCommMessageSender.test.ts
@@ -531,9 +531,7 @@ describe('DidCommMessageSender', () => {
       // The wss service must be tried first, not the https one, even though
       // https is not listed in the priority schemes.
       expect(wsSendSpy).toHaveBeenCalledTimes(1)
-      expect(wsSendSpy).toHaveBeenCalledWith(
-        expect.objectContaining({ endpoint: wssService.serviceEndpoint })
-      )
+      expect(wsSendSpy).toHaveBeenCalledWith(expect.objectContaining({ endpoint: wssService.serviceEndpoint }))
       expect(httpSendSpy).not.toHaveBeenCalled()
     })
   })

--- a/packages/didcomm/src/__tests__/DidCommMessageSender.test.ts
+++ b/packages/didcomm/src/__tests__/DidCommMessageSender.test.ts
@@ -494,6 +494,48 @@ describe('DidCommMessageSender', () => {
         },
       })
     })
+
+    test('prioritizes services whose scheme is listed in transportPriority over ones that are not', async () => {
+      // Simulate a DID Document exposing both https and wss service endpoints,
+      // where the https one is returned first by the resolver.
+      const httpsService = new DidCommV1Service({
+        id: '<did>;https',
+        serviceEndpoint: 'https://www.example.com',
+        recipientKeys: ['#authentication-1'],
+      })
+      const wssService = new DidCommV1Service({
+        id: '<did>;wss',
+        serviceEndpoint: 'wss://www.example.com',
+        recipientKeys: ['#authentication-1'],
+      })
+
+      resolveCreatedDidDocumentWithKeysMock.mockResolvedValue({
+        didDocument: getMockDidDocument({ service: [httpsService, wssService] }),
+        keys: [],
+      })
+      didResolverServiceResolveDidServicesMock.mockResolvedValue([
+        getMockResolvedDidService(httpsService),
+        getMockResolvedDidService(wssService),
+      ])
+
+      const httpTransport = new DummyHttpOutboundTransport()
+      const wsTransport = new DummyWsOutboundTransport()
+      didCommModuleConfig.outboundTransports = [httpTransport, wsTransport]
+      const httpSendSpy = vi.spyOn(httpTransport, 'sendMessage')
+      const wsSendSpy = vi.spyOn(wsTransport, 'sendMessage')
+
+      await messageSender.sendMessage(outboundMessageContext, {
+        transportPriority: { schemes: ['wss', 'ws'] },
+      })
+
+      // The wss service must be tried first, not the https one, even though
+      // https is not listed in the priority schemes.
+      expect(wsSendSpy).toHaveBeenCalledTimes(1)
+      expect(wsSendSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ endpoint: wssService.serviceEndpoint })
+      )
+      expect(httpSendSpy).not.toHaveBeenCalled()
+    })
   })
 
   describe('sendMessageToService', () => {


### PR DESCRIPTION
Something I've just noticed when a DIDComm mediator supports both WS and HTTP, and for some strange reason Credo was choosing HTTP for Message Pickup V2's status-request message (but not for live-delivery-change, restricted to WS).