### PR TITLE
fix(didcomm): tolerate base64url in signed attachment payloads

### DIFF
--- a/packages/didcomm/src/decorators/attachment/DidCommAttachment.ts
+++ b/packages/didcomm/src/decorators/attachment/DidCommAttachment.ts
@@ -138,27 +138,25 @@ export class DidCommAttachment {
   /*
    * Helper function returning the raw bytes of a base64 attachment payload.
    *
-   * Although the DIDComm specification mandates standard base64 for `data.base64`,
-   * many peers (including earlier Credo versions) emit the payload using the
-   * base64url alphabet, with or without padding. To preserve interoperability we
-   * accept both alphabets here — this is the only place such leniency lives, so
-   * the underlying `TypedArrayEncoder.fromBase64` can remain strictly spec-compliant
-   * for every other caller.
+   * The DIDComm/Aries RFC 0017 spec mandates base64url for `data.base64`, so we try
+   * decoding it as base64url first. Credo itself (and other implementations) has
+   * historically emitted standard base64 with `+`/`/` and `=` padding, so we fall
+   * back to that to preserve interop with older agents.
    */
   public getDataAsUint8Array(): Uint8Array {
     if (typeof this.data.base64 !== 'string') {
       throw new CredoError('No base64 attachment data found.')
     }
     try {
-      return TypedArrayEncoder.fromBase64(this.data.base64)
-    } catch (strictError) {
+      // `fromBase64Url` expects the no-padding variant, strip trailing `=` so
+      // both padded and unpadded base64url inputs are accepted.
+      return TypedArrayEncoder.fromBase64Url(this.data.base64.replace(/=+$/, ''))
+    } catch (base64UrlError) {
       try {
-        // `fromBase64Url` expects the no-padding variant. Strip any trailing
-        // `=` so we accept both padded and unpadded base64url inputs.
-        return TypedArrayEncoder.fromBase64Url(this.data.base64.replace(/=+$/, ''))
+        return TypedArrayEncoder.fromBase64(this.data.base64)
       } catch {
-        throw new CredoError('Could not decode attachment data as base64 or base64url string.', {
-          cause: strictError,
+        throw new CredoError('Could not decode attachment data as base64url or base64 string.', {
+          cause: base64UrlError,
         })
       }
     }

--- a/packages/didcomm/src/decorators/attachment/DidCommAttachment.ts
+++ b/packages/didcomm/src/decorators/attachment/DidCommAttachment.ts
@@ -1,6 +1,6 @@
 import type { JwsDetachedFormat, JwsFlattenedDetachedFormat, JwsGeneralFormat } from '@credo-ts/core'
 
-import { CredoError, JsonEncoder, type JsonValue, utils } from '@credo-ts/core'
+import { CredoError, JsonEncoder, type JsonValue, TypedArrayEncoder, utils } from '@credo-ts/core'
 import { Expose, Type } from 'class-transformer'
 import { IsDate, IsHash, IsInstance, IsInt, IsMimeType, IsOptional, IsString, ValidateNested } from 'class-validator'
 
@@ -136,11 +136,40 @@ export class DidCommAttachment {
   public data!: DidCommAttachmentData
 
   /*
+   * Helper function returning the raw bytes of a base64 attachment payload.
+   *
+   * Although the DIDComm specification mandates standard base64 for `data.base64`,
+   * many peers (including earlier Credo versions) emit the payload using the
+   * base64url alphabet, with or without padding. To preserve interoperability we
+   * accept both alphabets here — this is the only place such leniency lives, so
+   * the underlying `TypedArrayEncoder.fromBase64` can remain strictly spec-compliant
+   * for every other caller.
+   */
+  public getDataAsUint8Array(): Uint8Array {
+    if (typeof this.data.base64 !== 'string') {
+      throw new CredoError('No base64 attachment data found.')
+    }
+    try {
+      return TypedArrayEncoder.fromBase64(this.data.base64)
+    } catch (strictError) {
+      try {
+        // `fromBase64Url` expects the no-padding variant. Strip any trailing
+        // `=` so we accept both padded and unpadded base64url inputs.
+        return TypedArrayEncoder.fromBase64Url(this.data.base64.replace(/=+$/, ''))
+      } catch {
+        throw new CredoError('Could not decode attachment data as base64 or base64url string.', {
+          cause: strictError,
+        })
+      }
+    }
+  }
+
+  /*
    * Helper function returning JSON representation of attachment data (if present). Tries to obtain the data from .base64 or .json, throws an error otherwise
    */
   public getDataAsJson<T>(): T {
     if (typeof this.data.base64 === 'string') {
-      return JsonEncoder.fromBase64(this.data.base64) as T
+      return JsonEncoder.fromUint8Array(this.getDataAsUint8Array()) as T
     }
     if (this.data.json) {
       return this.data.json as T

--- a/packages/didcomm/src/decorators/attachment/__tests__/Attachment.test.ts
+++ b/packages/didcomm/src/decorators/attachment/__tests__/Attachment.test.ts
@@ -129,13 +129,13 @@ describe('Decorators | DidCommAttachment', () => {
       expect(() => attachment.getDataAsUint8Array()).toThrow(/No base64 attachment data found/)
     })
 
-    it('throws a clear error for genuinely invalid input, preserving the strict base64 error as cause', () => {
+    it('throws a clear error for genuinely invalid input', () => {
       const attachment = new DidCommAttachment({
         id: 'some-uuid',
         data: new DidCommAttachmentData({ base64: 'this is definitely not base64 $$$' }),
       })
       expect(() => attachment.getDataAsUint8Array()).toThrow(
-        /Could not decode attachment data as base64 or base64url string/
+        /Could not decode attachment data as base64url or base64 string/
       )
     })
 

--- a/packages/didcomm/src/decorators/attachment/__tests__/Attachment.test.ts
+++ b/packages/didcomm/src/decorators/attachment/__tests__/Attachment.test.ts
@@ -2,6 +2,7 @@ import * as didJwsz6Mkf from '../../../../../core/src/crypto/__tests__/__fixture
 import * as didJwsz6Mkv from '../../../../../core/src/crypto/__tests__/__fixtures__/didJwsz6Mkv'
 import { JsonEncoder } from '../../../../../core/src/utils/JsonEncoder'
 import { JsonTransformer } from '../../../../../core/src/utils/JsonTransformer'
+import { TypedArrayEncoder } from '../../../../../core/src/utils/TypedArrayEncoder'
 import { DidCommAttachment, DidCommAttachmentData } from '../DidCommAttachment'
 
 const mockJson = {
@@ -94,6 +95,60 @@ describe('Decorators | DidCommAttachment', () => {
 
     const gotData = decorator.getDataAsJson()
     expect(mockJson.data.json).toEqual(gotData)
+  })
+
+  describe('getDataAsUint8Array', () => {
+    // Bytes chosen so their base64 encoding exercises both `+` and `/` characters
+    // (the ones that differ between the standard and url-safe alphabets) *and*
+    // requires `=` padding. This way the url-alphabet / no-padding variants
+    // below are genuinely different strings from the canonical base64, not
+    // no-ops.
+    const payload = new Uint8Array([0xff, 0xe0, 0x3f, 0xff, 0xfe])
+    const padded = TypedArrayEncoder.toBase64(payload) // has '+', '/', and '=' padding
+    const unpadded = padded.replace(/=+$/, '')
+    const urlPadded = padded.replace(/\+/g, '-').replace(/\//g, '_')
+    const urlUnpadded = unpadded.replace(/\+/g, '-').replace(/\//g, '_')
+
+    test.each([
+      ['standard base64 with padding', padded],
+      ['base64url with padding', urlPadded],
+      ['base64url without padding', urlUnpadded],
+    ])('decodes %s', (_label, encoded) => {
+      const attachment = new DidCommAttachment({
+        id: 'some-uuid',
+        data: new DidCommAttachmentData({ base64: encoded }),
+      })
+      expect(attachment.getDataAsUint8Array()).toEqual(payload)
+    })
+
+    it('throws when no base64 payload is present', () => {
+      const attachment = new DidCommAttachment({
+        id: 'some-uuid',
+        data: new DidCommAttachmentData({ json: { hello: 'world' } }),
+      })
+      expect(() => attachment.getDataAsUint8Array()).toThrow(/No base64 attachment data found/)
+    })
+
+    it('throws a clear error for genuinely invalid input, preserving the strict base64 error as cause', () => {
+      const attachment = new DidCommAttachment({
+        id: 'some-uuid',
+        data: new DidCommAttachmentData({ base64: 'this is definitely not base64 $$$' }),
+      })
+      expect(() => attachment.getDataAsUint8Array()).toThrow(
+        /Could not decode attachment data as base64 or base64url string/
+      )
+    })
+
+    it('getDataAsJson delegates to getDataAsUint8Array, accepting base64url-without-padding too', () => {
+      const json = { hello: 'world' }
+      const standardPadded = JsonEncoder.toBase64(json)
+      const urlNoPad = standardPadded.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+      const attachment = new DidCommAttachment({
+        id: 'some-uuid',
+        data: new DidCommAttachmentData({ base64: urlNoPad }),
+      })
+      expect(attachment.getDataAsJson()).toEqual(json)
+    })
   })
 
   describe('addJws', () => {

--- a/packages/didcomm/src/modules/connections/DidExchangeProtocol.ts
+++ b/packages/didcomm/src/modules/connections/DidExchangeProtocol.ts
@@ -570,7 +570,7 @@ export class DidExchangeProtocol {
         throw new CredoError('DID Rotate attachment is missing base64 property for signed did.')
       }
 
-      const payload = TypedArrayEncoder.fromBase64(didRotateAttachment.data.base64)
+      const payload = didRotateAttachment.getDataAsUint8Array()
       // JWS payload must be base64url encoded
 
       const signedDid = TypedArrayEncoder.toUtf8String(payload)
@@ -675,7 +675,7 @@ export class DidExchangeProtocol {
     const { isValid, jwsSigners } = await this.jwsService.verifyJws(agentContext, {
       jws: {
         ...jws,
-        payload: TypedArrayEncoder.toBase64Url(TypedArrayEncoder.fromBase64(didDocumentAttachment.data.base64)),
+        payload: TypedArrayEncoder.toBase64Url(didDocumentAttachment.getDataAsUint8Array()),
       },
       allowedJwsSignerMethods: ['did'],
       resolveJwsSigner: ({ jws: { header } }) => {
@@ -692,7 +692,7 @@ export class DidExchangeProtocol {
       },
     })
 
-    const json = JsonEncoder.fromBase64(didDocumentAttachment.data.base64)
+    const json = didDocumentAttachment.getDataAsJson()
     const didDocument = JsonTransformer.fromJSON(json, DidDocument)
     const didDocumentKeys = didDocument.authentication
       ?.map((authentication) => {


### PR DESCRIPTION
`data.base64` in signed attachments is spec'd as standard base64, but peers routinely emit base64url (padded or not). Earlier Credo versions, AFJ 0.5.x, ACA-Py. Credo 0.7's `TypedArrayEncoder.fromBase64` uses `@scure/base` which is strict, so DID Exchange responses (and any other signed-attachment flow) fail with:

```
Could not decode data from base64 string
  cause: padding: invalid, string should have whole number of bytes
```

So here we are creating some new helpers and updates in `DidCommAttachment` that do strict base64 first, fall back to base64url (stripping `=` to cover both padded and unpadded). DidExchangeProtocol makes use of this logic.