### PR TITLE
fix(CI): Local DID document to avoid Indy ledger resolution in CI

### DIFF
--- a/packages/core/tests/helpers.ts
+++ b/packages/core/tests/helpers.ts
@@ -53,7 +53,16 @@ import type { AnyDrizzleDatabase } from '../../drizzle-storage/src/DrizzleStorag
 import { didcommBundle } from '../../drizzle-storage/src/didcomm/bundle'
 import { agentDependencies, NodeInMemoryKeyManagementStorage, NodeKeyManagementService } from '../../node/src'
 import type { Agent, AgentDependencies, BaseEvent, InitConfig, InjectionToken, KeyDidCreateOptions } from '../src'
-import { AgentConfig, AgentContext, DependencyManager, DidDocument, DidsApi, Kms, TypedArrayEncoder, X509Api } from '../src'
+import {
+  AgentConfig,
+  AgentContext,
+  DependencyManager,
+  DidDocument,
+  DidsApi,
+  Kms,
+  TypedArrayEncoder,
+  X509Api,
+} from '../src'
 import type { AgentModulesInput, EmptyModuleMap } from '../src/agent/AgentModules'
 import { DidKey } from '../src/modules/dids/methods/key'
 import { KeyManagementApi, type KeyManagementService, PublicJwk } from '../src/modules/kms'

--- a/packages/core/tests/helpers.ts
+++ b/packages/core/tests/helpers.ts
@@ -53,7 +53,7 @@ import type { AnyDrizzleDatabase } from '../../drizzle-storage/src/DrizzleStorag
 import { didcommBundle } from '../../drizzle-storage/src/didcomm/bundle'
 import { agentDependencies, NodeInMemoryKeyManagementStorage, NodeKeyManagementService } from '../../node/src'
 import type { Agent, AgentDependencies, BaseEvent, InitConfig, InjectionToken, KeyDidCreateOptions } from '../src'
-import { AgentConfig, AgentContext, DependencyManager, DidsApi, Kms, TypedArrayEncoder, X509Api } from '../src'
+import { AgentConfig, AgentContext, DependencyManager, DidDocument, DidsApi, Kms, TypedArrayEncoder, X509Api } from '../src'
 import type { AgentModulesInput, EmptyModuleMap } from '../src/agent/AgentModules'
 import { DidKey } from '../src/modules/dids/methods/key'
 import { KeyManagementApi, type KeyManagementService, PublicJwk } from '../src/modules/kms'
@@ -199,10 +199,26 @@ export async function importExistingIndyDidFromPrivateKey(agent: Agent, privateK
 
   // did is first 16 bytes of public key encoded as base58
   const unqualifiedIndyDid = TypedArrayEncoder.toBase58(publicJwk.publicKey.publicKey.slice(0, 16))
+  const did = `did:indy:pool:localtest:${unqualifiedIndyDid}`
+
+  // Import with a local DID document to avoid resolver/ledger calls during test setup.
+  const didDocument = new DidDocument({
+    id: did,
+    verificationMethod: [
+      {
+        id: `${did}#verkey`,
+        type: 'Ed25519VerificationKey2018',
+        controller: did,
+        publicKeyBase58: TypedArrayEncoder.toBase58(publicJwk.publicKey.publicKey),
+      },
+    ],
+    authentication: [`${did}#verkey`],
+  })
 
   // import the did in the wallet so it can be used
   await agent.dids.import({
-    did: `did:indy:pool:localtest:${unqualifiedIndyDid}`,
+    did,
+    didDocument,
     keys: [
       {
         didDocumentRelativeKeyId: '#verkey',


### PR DESCRIPTION
E2E (24) but not E2E (22) failed on recent PR due to setup race condition

Test harness seeds during container startup, E2E begins immediately with no check gate, E2E (24) races

`indy-vdr-anoncreds-registry` suite runs early, `helpers.ts` imports did:indy without `didDocument` forcing resolution through `DidsApi.ts` which fails in beforeAll - race condition

Later test `indy-vdr-did-register` used same seed/DID and passed, meaning DID was resolvable at this later stage

Fix changes `helpers.ts` to pass an in-memory didDocument
