### PR TITLE
fix(openid4vc): restore detailed mdoc error

### DIFF
--- a/.changeset/large-wombats-notice.md
+++ b/.changeset/large-wombats-notice.md
@@ -1,0 +1,5 @@
+---
+"@credo-ts/openid4vc": patch
+---
+
+Restore detailed mdoc verification error.

--- a/packages/openid4vc/src/openid4vc-verifier/OpenId4VpVerifierService.ts
+++ b/packages/openid4vc/src/openid4vc-verifier/OpenId4VpVerifierService.ts
@@ -574,7 +574,9 @@ export class OpenId4VpVerifierService {
         const errorMessages = presentationVerificationResults
           .flatMap(([credentialId, presentations], index) =>
             presentations.map((result) =>
-              !result.verified ? `\t- ${credentialId}[${index}]: ${result.reason}` : undefined
+              !result.verified
+                ? `\t- ${credentialId}[${index}]: ${[result.reason, result.cause?.message].filter((i) => i !== undefined).join(', ')}`
+                : undefined
             )
           )
           .filter((i) => i !== undefined)


### PR DESCRIPTION
The new mdoc updates made it such that some of the verification errors got swollen up and not added to the verification error message. This fixes that by ensuring that the error message for the verification session has more detail.