### PR TITLE
feat(did): extend Dids API with findAllByQuery for tag search

### DIFF
--- a/packages/core/src/modules/dids/DidsApi.ts
+++ b/packages/core/src/modules/dids/DidsApi.ts
@@ -2,12 +2,13 @@ import { parseDid } from '@sphereon/ssi-types'
 import { AgentContext } from '../../agent'
 import { CredoError, RecordNotFoundError } from '../../error'
 import { injectable } from '../../plugins'
+import type { Query, QueryOptions } from '../../storage/StorageService'
 import { KeyManagementApi } from '../kms'
 import type { ImportDidOptions } from './DidsApiOptions'
 import { DidsModuleConfig } from './DidsModuleConfig'
 import { type DidPurpose, getPublicJwkFromVerificationMethod } from './domain'
 import { getAlternativeDidsForPeerDid, isValidPeerDid } from './methods'
-import { type CustomDidTags, DidRecord, DidRepository } from './repository'
+import { DidRecord, DidRepository } from './repository'
 import { DidRegistrarService, DidResolverService } from './services'
 import type {
   DidCreateOptions,
@@ -101,8 +102,15 @@ export class DidsApi {
    *
    * You can call `${@link DidsModule.resolve} to resolve the did document based on the did itself.
    */
-  public getCreatedDids({ method, did, tags }: { method?: string; did?: string; tags?: Partial<CustomDidTags> } = {}) {
-    return this.didRepository.getCreatedDids(this.agentContext, { method, did, tags })
+  public getCreatedDids({ method, did }: { method?: string; did?: string } = {}) {
+    return this.didRepository.getCreatedDids(this.agentContext, { method, did })
+  }
+
+  /**
+   * Find all did records by query.
+   */
+  public async findAllByQuery(query: Query<DidRecord>, queryOptions?: QueryOptions): Promise<Array<DidRecord>> {
+    return await this.didRepository.findByQuery(this.agentContext, query, queryOptions)
   }
 
   /**

--- a/packages/core/src/modules/dids/DidsApi.ts
+++ b/packages/core/src/modules/dids/DidsApi.ts
@@ -101,15 +101,7 @@ export class DidsApi {
    *
    * You can call `${@link DidsModule.resolve} to resolve the did document based on the did itself.
    */
-  public getCreatedDids({
-    method,
-    did,
-    tags,
-  }: {
-    method?: string
-    did?: string
-    tags?: Partial<CustomDidTags>
-  } = {}) {
+  public getCreatedDids({ method, did, tags }: { method?: string; did?: string; tags?: Partial<CustomDidTags> } = {}) {
     return this.didRepository.getCreatedDids(this.agentContext, { method, did, tags })
   }
 

--- a/packages/core/src/modules/dids/DidsApi.ts
+++ b/packages/core/src/modules/dids/DidsApi.ts
@@ -7,7 +7,7 @@ import type { ImportDidOptions } from './DidsApiOptions'
 import { DidsModuleConfig } from './DidsModuleConfig'
 import { type DidPurpose, getPublicJwkFromVerificationMethod } from './domain'
 import { getAlternativeDidsForPeerDid, isValidPeerDid } from './methods'
-import { DidRecord, DidRepository } from './repository'
+import { type CustomDidTags, DidRecord, DidRepository } from './repository'
 import { DidRegistrarService, DidResolverService } from './services'
 import type {
   DidCreateOptions,
@@ -101,8 +101,16 @@ export class DidsApi {
    *
    * You can call `${@link DidsModule.resolve} to resolve the did document based on the did itself.
    */
-  public getCreatedDids({ method, did }: { method?: string; did?: string } = {}) {
-    return this.didRepository.getCreatedDids(this.agentContext, { method, did })
+  public getCreatedDids({
+    method,
+    did,
+    tags,
+  }: {
+    method?: string
+    did?: string
+    tags?: Partial<CustomDidTags>
+  } = {}) {
+    return this.didRepository.getCreatedDids(this.agentContext, { method, did, tags })
   }
 
   /**

--- a/packages/core/src/modules/dids/__tests__/DidsApi.test.ts
+++ b/packages/core/src/modules/dids/__tests__/DidsApi.test.ts
@@ -186,7 +186,7 @@ describe('DidsApi', () => {
     expect(createdDidsOverwrite[0].didDocument?.service).toHaveLength(1)
   })
 
-  test('getCreatedDids can filter by custom tags', async () => {
+  test('findAllByQuery can filter by custom tags', async () => {
     const did = 'did:example:tag-filter'
     const didRepository = agent.context.dependencyManager.resolve(DidRepository)
 
@@ -201,14 +201,16 @@ describe('DidsApi', () => {
     didRecord.setTags({ domain: 'alice:foo' })
     await didRepository.update(agent.context, didRecord)
 
-    const matching = await agent.dids.getCreatedDids({
+    const matching = await agent.dids.findAllByQuery({
       method: 'example',
-      tags: { domain: 'alice:foo' },
+      role: 'created',
+      domain: 'alice:foo',
     })
 
-    const nonMatching = await agent.dids.getCreatedDids({
+    const nonMatching = await agent.dids.findAllByQuery({
       method: 'example',
-      tags: { domain: 'alice:bar' },
+      role: 'created',
+      domain: 'alice:bar',
     })
 
     expect(matching.some((record) => record.did === did)).toBe(true)

--- a/packages/core/src/modules/dids/__tests__/DidsApi.test.ts
+++ b/packages/core/src/modules/dids/__tests__/DidsApi.test.ts
@@ -9,6 +9,7 @@ import {
 import { transformPrivateKeyToPrivateJwk } from '../../../../../askar/src'
 import { getAgentOptions } from '../../../../tests/helpers'
 import { Agent } from '../../../agent/Agent'
+import { DidRepository } from '../repository'
 import { isLongFormDidPeer4, isShortFormDidPeer4 } from '../methods/peer/peerDidNumAlgo4'
 
 const agentOptions = getAgentOptions('DidsApi', undefined, undefined, undefined, { requireDidcomm: true })
@@ -183,6 +184,35 @@ describe('DidsApi', () => {
     // Should not have stored the updated record
     const createdDidsOverwrite = await agent.dids.getCreatedDids({ did })
     expect(createdDidsOverwrite[0].didDocument?.service).toHaveLength(1)
+  })
+
+  test('getCreatedDids can filter by custom tags', async () => {
+    const did = 'did:example:tag-filter'
+    const didRepository = agent.context.dependencyManager.resolve(DidRepository)
+
+    await agent.dids.import({
+      did,
+      didDocument: new DidDocument({ id: did }),
+    })
+
+    const didRecord = await didRepository.findCreatedDid(agent.context, did)
+    if (!didRecord) throw new Error(`Expected did record ${did} to exist`)
+
+    didRecord.setTags({ domain: 'alice:foo' })
+    await didRepository.update(agent.context, didRecord)
+
+    const matching = await agent.dids.getCreatedDids({
+      method: 'example',
+      tags: { domain: 'alice:foo' },
+    })
+
+    const nonMatching = await agent.dids.getCreatedDids({
+      method: 'example',
+      tags: { domain: 'alice:bar' },
+    })
+
+    expect(matching.some((record) => record.did === did)).toBe(true)
+    expect(nonMatching.some((record) => record.did === did)).toBe(false)
   })
 
   test('create and resolve did:peer:4 in short and long form', async () => {

--- a/packages/core/src/modules/dids/__tests__/DidsApi.test.ts
+++ b/packages/core/src/modules/dids/__tests__/DidsApi.test.ts
@@ -9,6 +9,7 @@ import {
 import { transformPrivateKeyToPrivateJwk } from '../../../../../askar/src'
 import { getAgentOptions } from '../../../../tests/helpers'
 import { Agent } from '../../../agent/Agent'
+import { DidDocumentRole } from '../domain/DidDocumentRole'
 import { isLongFormDidPeer4, isShortFormDidPeer4 } from '../methods/peer/peerDidNumAlgo4'
 import { DidRepository } from '../repository'
 
@@ -203,13 +204,13 @@ describe('DidsApi', () => {
 
     const matching = await agent.dids.findAllByQuery({
       method: 'example',
-      role: 'created',
+      role: DidDocumentRole.Created,
       domain: 'alice:foo',
     })
 
     const nonMatching = await agent.dids.findAllByQuery({
       method: 'example',
-      role: 'created',
+      role: DidDocumentRole.Created,
       domain: 'alice:bar',
     })
 

--- a/packages/core/src/modules/dids/__tests__/DidsApi.test.ts
+++ b/packages/core/src/modules/dids/__tests__/DidsApi.test.ts
@@ -9,8 +9,8 @@ import {
 import { transformPrivateKeyToPrivateJwk } from '../../../../../askar/src'
 import { getAgentOptions } from '../../../../tests/helpers'
 import { Agent } from '../../../agent/Agent'
-import { DidRepository } from '../repository'
 import { isLongFormDidPeer4, isShortFormDidPeer4 } from '../methods/peer/peerDidNumAlgo4'
+import { DidRepository } from '../repository'
 
 const agentOptions = getAgentOptions('DidsApi', undefined, undefined, undefined, { requireDidcomm: true })
 

--- a/packages/core/src/modules/dids/repository/DidRepository.ts
+++ b/packages/core/src/modules/dids/repository/DidRepository.ts
@@ -64,8 +64,20 @@ export class DidRepository extends Repository<DidRecord> {
     })
   }
 
-  public getCreatedDids(agentContext: AgentContext, { method, did }: { method?: string; did?: string }) {
+  public getCreatedDids(
+    agentContext: AgentContext,
+    {
+      method,
+      did,
+      tags,
+    }: {
+      method?: string
+      did?: string
+      tags?: Partial<CustomDidTags>
+    }
+  ) {
     return this.findByQuery(agentContext, {
+      ...(tags ?? {}),
       role: DidDocumentRole.Created,
       method,
       $or: did ? [{ alternativeDids: [did] }, { did }] : undefined,

--- a/packages/core/src/modules/dids/repository/DidRepository.ts
+++ b/packages/core/src/modules/dids/repository/DidRepository.ts
@@ -64,20 +64,8 @@ export class DidRepository extends Repository<DidRecord> {
     })
   }
 
-  public getCreatedDids(
-    agentContext: AgentContext,
-    {
-      method,
-      did,
-      tags,
-    }: {
-      method?: string
-      did?: string
-      tags?: Partial<CustomDidTags>
-    }
-  ) {
+  public getCreatedDids(agentContext: AgentContext, { method, did }: { method?: string; did?: string }) {
     return this.findByQuery(agentContext, {
-      ...(tags ?? {}),
       role: DidDocumentRole.Created,
       method,
       $or: did ? [{ alternativeDids: [did] }, { did }] : undefined,


### PR DESCRIPTION
Without tags, querying DID records is currently O(n) requiring full retrieval and filtering

Added `findAllByQuery` to Dids API to reduce consumer tag search to O(1) + unit test

