### PR TITLE
fix(webvh): decouple webvh from anoncreds

### DIFF
--- a/packages/webvh/package.json
+++ b/packages/webvh/package.json
@@ -1,8 +1,12 @@
 {
   "name": "@credo-ts/webvh",
   "exports": {
-    "cli": "./build/index.mjs",
-    "import": "./src/index.ts"
+    ".": {
+      "cli": "./build/index.mjs",
+      "import": "./src/index.ts"
+    },
+    "./core": "./src/core.ts",
+    "./anoncreds": "./src/anoncreds/index.ts"
   },
   "version": "0.7.0",
   "description": "Credo WebVH DID method implementation",
@@ -21,7 +25,17 @@
     "module": "./build/index.mjs",
     "exports": {
       ".": "./build/index.mjs",
-      "./package.json": "./package.json"
+      "./package.json": "./package.json",
+      "./core": {
+        "import": "./build/core.mjs",
+        "require": "./build/core.mjs",
+        "types": "./build/core.d.mts"
+      },
+      "./anoncreds": {
+        "import": "./build/anoncreds/index.mjs",
+        "require": "./build/anoncreds/index.mjs",
+        "types": "./build/anoncreds/index.d.mts"
+      }
     }
   },
   "scripts": {

--- a/packages/webvh/package.json
+++ b/packages/webvh/package.json
@@ -6,7 +6,8 @@
       "import": "./src/index.ts"
     },
     "./core": "./src/core.ts",
-    "./anoncreds": "./src/anoncreds/index.ts"
+    "./anoncreds": "./src/anoncreds/index.ts",
+    "./resources": "./src/resources/index.ts"
   },
   "version": "0.7.0",
   "description": "Credo WebVH DID method implementation",
@@ -35,6 +36,11 @@
         "import": "./build/anoncreds/index.mjs",
         "require": "./build/anoncreds/index.mjs",
         "types": "./build/anoncreds/index.d.mts"
+      },
+      "./resources": {
+        "import": "./build/resources/index.mjs",
+        "require": "./build/resources/index.mjs",
+        "types": "./build/resources/index.d.mts"
       }
     }
   },

--- a/packages/webvh/src/anoncreds/index.ts
+++ b/packages/webvh/src/anoncreds/index.ts
@@ -1,0 +1,1 @@
+export { WebVhAnonCredsRegistry } from './services/WebVhAnonCredsRegistry'

--- a/packages/webvh/src/anoncreds/services/WebVhAnonCredsRegistry.ts
+++ b/packages/webvh/src/anoncreds/services/WebVhAnonCredsRegistry.ts
@@ -33,7 +33,8 @@ import {
 import { canonicalize } from 'json-canonicalize'
 import { EddsaJcs2022Cryptosuite, type UnsecuredDocument } from '../../cryptosuites'
 import { WebVhDidResolver } from '../../dids'
-import { WebVhResource } from '../utils/transform'
+import { isWebVhAttestedResource, parseResourceId, WebVhAttestedResource } from '../../resources'
+import { WebVhAnonCredsResource } from '../utils/transform'
 
 type DidResourceResolutionResult = {
   error?: string
@@ -41,6 +42,128 @@ type DidResourceResolutionResult = {
   content?: Record<string, unknown> | unknown[] | string // More specific than any, but still flexible
   contentMetadata?: Record<string, unknown>
   dereferencingMetadata?: Record<string, unknown>
+}
+
+type SchemaContentShape = {
+  attrNames: string[]
+  name: string
+  version: string
+  issuerId: string
+}
+
+type CredentialDefinitionContentShape = {
+  issuerId: string
+  schemaId: string
+  type: string
+  tag: string
+  value: Record<string, unknown>
+}
+
+type RevocationRegistryDefinitionContentShape = {
+  issuerId: string
+  revocDefType: string
+  credDefId: string
+  tag: string
+  value: RevocationRegistryDefinitionValueShape
+}
+
+type RevocationRegistryDefinitionValueShape = {
+  publicKeys: {
+    accumKey: {
+      z: string
+    }
+  }
+  maxCredNum: number
+  tailsLocation: string
+  tailsHash: string
+}
+
+type RevocationStatusListShape = {
+  issuerId: string
+  revRegDefId: string
+  revocationList: number[]
+  currentAccumulator: string
+  timestamp: number
+}
+
+function isSchemaContentShape(value: unknown): value is SchemaContentShape {
+  if (!value || typeof value !== 'object') return false
+
+  const candidate = value as Record<string, unknown>
+  return (
+    Array.isArray(candidate.attrNames) &&
+    candidate.attrNames.every((item) => typeof item === 'string') &&
+    typeof candidate.name === 'string' &&
+    typeof candidate.version === 'string' &&
+    typeof candidate.issuerId === 'string'
+  )
+}
+
+function isCredentialDefinitionContentShape(
+  value: unknown
+): value is CredentialDefinitionContentShape {
+  if (!value || typeof value !== 'object') return false
+
+  const candidate = value as Record<string, unknown>
+  return (
+    typeof candidate.issuerId === 'string' &&
+    typeof candidate.schemaId === 'string' &&
+    typeof candidate.type === 'string' &&
+    typeof candidate.tag === 'string' &&
+    !!candidate.value &&
+    typeof candidate.value === 'object'
+  )
+}
+
+function isRevocationRegistryDefinitionContentShape(
+  value: unknown
+): value is RevocationRegistryDefinitionContentShape {
+  if (!value || typeof value !== 'object') return false
+
+  const candidate = value as Record<string, unknown>
+  return (
+    typeof candidate.issuerId === 'string' &&
+    typeof candidate.revocDefType === 'string' &&
+    typeof candidate.credDefId === 'string' &&
+    typeof candidate.tag === 'string' &&
+    isRevocationRegistryDefinitionValueShape(candidate.value)
+  )
+}
+
+function isRevocationRegistryDefinitionValueShape(
+  value: unknown
+): value is RevocationRegistryDefinitionValueShape {
+  if (!value || typeof value !== 'object') return false
+
+  const candidate = value as Record<string, unknown>
+  const publicKeys = candidate.publicKeys as Record<string, unknown> | undefined
+  const accumKey = publicKeys?.accumKey as Record<string, unknown> | undefined
+
+  return (
+    !!publicKeys &&
+    typeof publicKeys === 'object' &&
+    !!accumKey &&
+    typeof accumKey === 'object' &&
+    typeof accumKey.z === 'string' &&
+    typeof candidate.maxCredNum === 'number' &&
+    typeof candidate.tailsLocation === 'string' &&
+    typeof candidate.tailsHash === 'string'
+  )
+}
+
+function isRevocationStatusListShape(value: unknown): value is RevocationStatusListShape {
+  if (!value || typeof value !== 'object') return false
+
+  const candidate = value as Record<string, unknown>
+
+  return (
+    typeof candidate.issuerId === 'string' &&
+    typeof candidate.revRegDefId === 'string' &&
+    Array.isArray(candidate.revocationList) &&
+    candidate.revocationList.every((item) => typeof item === 'number') &&
+    typeof candidate.currentAccumulator === 'string' &&
+    typeof candidate.timestamp === 'number'
+  )
 }
 
 export class WebVhAnonCredsRegistry implements AnonCredsRegistry {
@@ -59,8 +182,8 @@ export class WebVhAnonCredsRegistry implements AnonCredsRegistry {
    *
    * @param agentContext The agent context.
    * @param resourceId The DID URI of the resource to resolve.
-   * @param resourceTypeString A descriptive string for the resource type (e.g., 'schema', 'credential definition') used in logs/errors.
-   * @returns The parsed and validated WebVhResource object and the original resolution result.
+  * @param resourceTypeString A descriptive string for the resource type (e.g., 'schema', 'credential definition') used in logs/errors.
+  * @returns The parsed and validated resource object and the original resolution result.
    * @throws {CredoError} If resolution, parsing, or validation fails.
    */
   private _digestMultibase(value: string) {
@@ -73,7 +196,7 @@ export class WebVhAnonCredsRegistry implements AnonCredsRegistry {
     agentContext: AgentContext,
     resourceId: string,
     resourceTypeString: string
-  ): Promise<{ resourceObject: WebVhResource; resolutionResult: DidResourceResolutionResult }> {
+  ): Promise<{ resourceObject: WebVhAttestedResource; resolutionResult: DidResourceResolutionResult }> {
     try {
       const webvhDidResolver = agentContext.dependencyManager.resolve(WebVhDidResolver)
       if (!this.supportedIdentifier.test(resourceId))
@@ -95,12 +218,12 @@ export class WebVhAnonCredsRegistry implements AnonCredsRegistry {
         )
       }
 
-      let resourceObject: WebVhResource
+      let resourceObject: WebVhAnonCredsResource
       try {
         agentContext.config.logger.trace(
           `Parsing resource data: ${JSON.stringify(resolutionResult.content).substring(0, 200)}...`
         )
-        resourceObject = JsonTransformer.fromJSON(resolutionResult.content, WebVhResource)
+        resourceObject = JsonTransformer.fromJSON(resolutionResult.content, WebVhAnonCredsResource)
       } catch (parseError) {
         agentContext.config.logger.error(`Failed to parse resource data for ${resourceId}`, {
           error: parseError instanceof Error ? parseError.message : String(parseError),
@@ -116,23 +239,8 @@ export class WebVhAnonCredsRegistry implements AnonCredsRegistry {
       // --- Attested Resource Validation steps ---
 
       // 1. Data Model Verification
-      if (!Array.isArray(resourceObject.type) || !resourceObject.type.includes('AttestedResource')) {
+      if (!isWebVhAttestedResource(resourceObject)) {
         throw new CredoError('Missing AttestedResource type.')
-      }
-      if (!resourceObject.id || typeof resourceObject.id !== 'string') {
-        throw new CredoError('Missing resource id.')
-      }
-      if (!resourceObject.content || typeof resourceObject.content !== 'object') {
-        throw new CredoError('Missing resource content.')
-      }
-      if (resourceObject.metadata && typeof resourceObject.metadata !== 'object') {
-        throw new CredoError('Expecting metadata to be an object.')
-      }
-      if (resourceObject.links && typeof resourceObject.links !== 'object') {
-        throw new CredoError('Expecting metadata to be an array.')
-      }
-      if (!resourceObject.proof || typeof resourceObject.proof !== 'object') {
-        throw new CredoError('Missing resource proof.')
       }
       agentContext.config.logger.trace(`Resource ${resourceId} attestation found.`)
 
@@ -181,25 +289,17 @@ export class WebVhAnonCredsRegistry implements AnonCredsRegistry {
       const schemaContent = resourceObject.content
 
       // Type check to ensure we have a schema content object
-      if (
-        !('attrNames' in schemaContent) ||
-        !('name' in schemaContent) ||
-        !('version' in schemaContent) ||
-        !('issuerId' in schemaContent)
-      ) {
+      if (!isSchemaContentShape(schemaContent)) {
         throw new CredoError(`Parsed resource content for ${schemaId} is not a valid schema.`)
       }
 
-      const contentIssuerId = (schemaContent as { issuerId?: string })?.issuerId // Type assertion for accessing issuerId
-      if (!contentIssuerId || typeof contentIssuerId !== 'string') {
-        throw new CredoError(`Resolved resource content for ${schemaId} is missing a valid issuerId.`)
-      }
+      const contentIssuerId = schemaContent.issuerId
 
-      const resourceDidMatch = schemaId.match(/^(did:webvh:[^/]+)/)
-      if (!resourceDidMatch || !resourceDidMatch[1]) {
+      const parsedSchemaId = parseResourceId(schemaId)
+      if (!parsedSchemaId) {
         throw new CredoError(`Could not extract DID from resource ID: ${schemaId}`)
       }
-      const expectedIssuerDid = resourceDidMatch[1]
+      const expectedIssuerDid = parsedSchemaId.did
 
       if (contentIssuerId !== expectedIssuerDid) {
         throw new CredoError(
@@ -249,26 +349,18 @@ export class WebVhAnonCredsRegistry implements AnonCredsRegistry {
       // Extract the content and make sure it's a CredDef
       const credDefContent = resourceObject.content
       // Type check for WebVhCredDefContent
-      if (
-        !('schemaId' in credDefContent) ||
-        !('type' in credDefContent) ||
-        !('tag' in credDefContent) ||
-        !('value' in credDefContent)
-      ) {
+      if (!isCredentialDefinitionContentShape(credDefContent)) {
         throw new CredoError('Resolved resource content is not a valid credential definition.')
       }
 
-      const contentIssuerId = (credDefContent as { issuerId?: string })?.issuerId
-      if (!contentIssuerId || typeof contentIssuerId !== 'string') {
-        throw new CredoError(`Resolved resource content for ${credentialDefinitionId} is missing a valid issuerId.`)
-      }
+      const contentIssuerId = credDefContent.issuerId
 
       // Extract the DID from the resourceId (part before /resources/hash)
-      const resourceDidMatch = credentialDefinitionId.match(/^(did:webvh:[^/]+)/)
-      if (!resourceDidMatch || !resourceDidMatch[1]) {
+      const parsedCredentialDefinitionId = parseResourceId(credentialDefinitionId)
+      if (!parsedCredentialDefinitionId) {
         throw new CredoError(`Could not extract DID from resource ID: ${credentialDefinitionId}`)
       }
-      const expectedIssuerDid = resourceDidMatch[1]
+      const expectedIssuerDid = parsedCredentialDefinitionId.did
 
       if (contentIssuerId !== expectedIssuerDid) {
         throw new CredoError(
@@ -324,12 +416,7 @@ export class WebVhAnonCredsRegistry implements AnonCredsRegistry {
 
       const revRegDefContent = resourceObject.content
 
-      if (
-        !('revocDefType' in revRegDefContent) ||
-        !('credDefId' in revRegDefContent) ||
-        !('tag' in revRegDefContent) ||
-        !('value' in revRegDefContent)
-      ) {
+      if (!isRevocationRegistryDefinitionContentShape(revRegDefContent)) {
         throw new CredoError(
           `Parsed resource content for ${revocationRegistryDefinitionId} is not a valid revocation registry definition.`
         )
@@ -344,7 +431,7 @@ export class WebVhAnonCredsRegistry implements AnonCredsRegistry {
           revocDefType: revRegDefContent.revocDefType as AnonCredsRevocationRegistryDefinition['revocDefType'], // TODO: Map revocDefType string to AnonCreds type
           credDefId: revRegDefContent.credDefId,
           tag: revRegDefContent.tag,
-          value: revRegDefContent.value as AnonCredsRevocationRegistryDefinitionValue, // TODO: Map value structure to AnonCreds type
+          value: revRegDefContent.value as AnonCredsRevocationRegistryDefinitionValue,
         },
         revocationRegistryDefinitionId,
         resolutionMetadata: resolutionResult.dereferencingMetadata || {},
@@ -416,6 +503,10 @@ export class WebVhAnonCredsRegistry implements AnonCredsRegistry {
 
       if (!revocationEntryResourceObject) {
         throw new CredoError('No revocation entry found for the given timestamp.')
+      }
+
+      if (!isRevocationStatusListShape(revocationEntryResourceObject.content)) {
+        throw new CredoError('Resolved revocation entry content is not a valid revocation status list.')
       }
 
       return {
@@ -601,7 +692,7 @@ export class WebVhAnonCredsRegistry implements AnonCredsRegistry {
     }
   }
 
-  public async verifyProof(agentContext: AgentContext, attestedResource: WebVhResource): Promise<boolean> {
+  public async verifyProof(agentContext: AgentContext, attestedResource: WebVhAttestedResource): Promise<boolean> {
     const cryptosuite = new EddsaJcs2022Cryptosuite(agentContext)
     try {
       const verificationResult = await cryptosuite.verifyProof(attestedResource)

--- a/packages/webvh/src/anoncreds/services/WebVhAnonCredsRegistry.ts
+++ b/packages/webvh/src/anoncreds/services/WebVhAnonCredsRegistry.ts
@@ -99,9 +99,7 @@ function isSchemaContentShape(value: unknown): value is SchemaContentShape {
   )
 }
 
-function isCredentialDefinitionContentShape(
-  value: unknown
-): value is CredentialDefinitionContentShape {
+function isCredentialDefinitionContentShape(value: unknown): value is CredentialDefinitionContentShape {
   if (!value || typeof value !== 'object') return false
 
   const candidate = value as Record<string, unknown>
@@ -115,9 +113,7 @@ function isCredentialDefinitionContentShape(
   )
 }
 
-function isRevocationRegistryDefinitionContentShape(
-  value: unknown
-): value is RevocationRegistryDefinitionContentShape {
+function isRevocationRegistryDefinitionContentShape(value: unknown): value is RevocationRegistryDefinitionContentShape {
   if (!value || typeof value !== 'object') return false
 
   const candidate = value as Record<string, unknown>
@@ -130,9 +126,7 @@ function isRevocationRegistryDefinitionContentShape(
   )
 }
 
-function isRevocationRegistryDefinitionValueShape(
-  value: unknown
-): value is RevocationRegistryDefinitionValueShape {
+function isRevocationRegistryDefinitionValueShape(value: unknown): value is RevocationRegistryDefinitionValueShape {
   if (!value || typeof value !== 'object') return false
 
   const candidate = value as Record<string, unknown>
@@ -182,8 +176,8 @@ export class WebVhAnonCredsRegistry implements AnonCredsRegistry {
    *
    * @param agentContext The agent context.
    * @param resourceId The DID URI of the resource to resolve.
-  * @param resourceTypeString A descriptive string for the resource type (e.g., 'schema', 'credential definition') used in logs/errors.
-  * @returns The parsed and validated resource object and the original resolution result.
+   * @param resourceTypeString A descriptive string for the resource type (e.g., 'schema', 'credential definition') used in logs/errors.
+   * @returns The parsed and validated resource object and the original resolution result.
    * @throws {CredoError} If resolution, parsing, or validation fails.
    */
   private _digestMultibase(value: string) {

--- a/packages/webvh/src/anoncreds/services/__tests__/WebVhTransform.test.ts
+++ b/packages/webvh/src/anoncreds/services/__tests__/WebVhTransform.test.ts
@@ -1,14 +1,14 @@
 import { JsonTransformer } from '@credo-ts/core'
 
-import { WebVhResource } from '../../utils/transform'
+import { WebVhAnonCredsResource } from '../../utils/transform'
 
 import { mockCredDefResource, mockSchemaResource } from './mock-resources'
 
 describe('WebVhTransform', () => {
   it('should correctly transform a schema resource', () => {
-    const resource = JsonTransformer.fromJSON(mockSchemaResource, WebVhResource)
+    const resource = JsonTransformer.fromJSON(mockSchemaResource, WebVhAnonCredsResource)
 
-    expect(resource).toBeInstanceOf(WebVhResource)
+    expect(resource).toBeInstanceOf(WebVhAnonCredsResource)
     expect(resource['@context']).toContain('https://opsecid.github.io/attested-resource/v1')
     expect(resource.type).toEqual(['AttestedResource'])
 
@@ -24,9 +24,9 @@ describe('WebVhTransform', () => {
   })
 
   it('should correctly transform a credential definition resource', () => {
-    const resource = JsonTransformer.fromJSON(mockCredDefResource, WebVhResource)
+    const resource = JsonTransformer.fromJSON(mockCredDefResource, WebVhAnonCredsResource)
 
-    expect(resource).toBeInstanceOf(WebVhResource)
+    expect(resource).toBeInstanceOf(WebVhAnonCredsResource)
     expect(resource['@context']).toContain('https://identity.foundation/did-attested-resources/context/v0.1')
     expect(resource.type).toEqual(['AttestedResource'])
 

--- a/packages/webvh/src/anoncreds/utils/transform.ts
+++ b/packages/webvh/src/anoncreds/utils/transform.ts
@@ -1,4 +1,4 @@
-import { IsStringOrStringArray, JsonTransformer } from '@credo-ts/core'
+import { JsonTransformer } from '@credo-ts/core'
 import { Expose, Transform, Type } from 'class-transformer'
 import {
   ArrayMinSize,
@@ -10,6 +10,7 @@ import {
   Validate,
   ValidateNested,
 } from 'class-validator'
+import { WebVhAttestedResource } from '../../resources'
 
 export class WebVhSchemaContent {
   @IsArray()
@@ -86,37 +87,7 @@ export class WebVhRevocationStatusListContent {
   public timestamp!: number
 }
 
-export class WebVhProof {
-  @IsString()
-  public type!: string
-
-  @IsString()
-  public cryptosuite!: string
-
-  @IsString()
-  public proofPurpose!: string
-
-  @IsString()
-  public proofValue!: string
-
-  @IsString()
-  public verificationMethod!: string
-}
-
-export class WebVhResource {
-  @IsArray()
-  @IsString({ each: true })
-  @Type(() => String)
-  public '@context'!: string[]
-
-  @Validate(IsStringOrStringArray)
-  @Transform(({ value }) => (Array.isArray(value) ? value : [value]))
-  @Type(() => String)
-  public type!: string[]
-
-  @IsString()
-  public id!: string
-
+export class WebVhAnonCredsResource extends WebVhAttestedResource {
   @Expose()
   @Transform(({ value }) => {
     if (value && 'attrNames' in value) {
@@ -131,33 +102,4 @@ export class WebVhResource {
     return value
   })
   public content!: WebVhSchemaContent | WebVhCredDefContent | WebVhRevRegDefContent | WebVhRevocationStatusListContent
-
-  @ValidateNested()
-  @Type(() => WebVhProof)
-  public proof!: WebVhProof
-
-  @IsOptional()
-  public metadata?: Record<string, unknown>
-
-  @IsOptional()
-  @IsArray()
-  @ValidateNested({ each: true })
-  @Type(() => WebVhLink)
-  public links?: WebVhLink[]
-}
-
-export class WebVhLink {
-  @IsString()
-  public id!: string
-
-  @IsString()
-  public type!: string
-
-  @IsOptional()
-  @IsNumber()
-  public timestamp?: number
-
-  @IsOptional()
-  @IsString()
-  public digestMultibase!: string
 }

--- a/packages/webvh/src/anoncreds/utils/transform.ts
+++ b/packages/webvh/src/anoncreds/utils/transform.ts
@@ -1,15 +1,6 @@
 import { JsonTransformer } from '@credo-ts/core'
 import { Expose, Transform, Type } from 'class-transformer'
-import {
-  ArrayMinSize,
-  IsArray,
-  IsNumber,
-  IsObject,
-  IsOptional,
-  IsString,
-  Validate,
-  ValidateNested,
-} from 'class-validator'
+import { ArrayMinSize, IsArray, IsNumber, IsObject, IsOptional, IsString } from 'class-validator'
 import { WebVhAttestedResource } from '../../resources'
 
 export class WebVhSchemaContent {

--- a/packages/webvh/src/core.ts
+++ b/packages/webvh/src/core.ts
@@ -1,0 +1,4 @@
+export { WebVhDidRegistrar, WebVhDidResolver } from './dids'
+export { WebVhApi } from './WebVhApi'
+export { WebVhModule } from './WebVhModule'
+export * from './resources'

--- a/packages/webvh/src/core.ts
+++ b/packages/webvh/src/core.ts
@@ -1,4 +1,4 @@
 export { WebVhDidRegistrar, WebVhDidResolver } from './dids'
+export * from './resources'
 export { WebVhApi } from './WebVhApi'
 export { WebVhModule } from './WebVhModule'
-export * from './resources'

--- a/packages/webvh/src/cryptosuites/eddsa-jcs-2022.ts
+++ b/packages/webvh/src/cryptosuites/eddsa-jcs-2022.ts
@@ -10,7 +10,7 @@ import {
 } from '@credo-ts/core'
 import { MultibaseEncoding, multibaseEncode } from 'didwebvh-ts'
 import { canonicalize } from 'json-canonicalize'
-import { WebVhResource } from '../anoncreds/utils/transform'
+import { WebVhAttestedResource } from '../resources'
 import type { Proof, ProofOptions, UnsecuredDocument } from './types'
 
 export class EddsaJcs2022Cryptosuite {
@@ -105,7 +105,7 @@ export class EddsaJcs2022Cryptosuite {
     return verificationResult.verified
   }
 
-  public async verifyProof(securedDocument: WebVhResource) {
+  public async verifyProof(securedDocument: WebVhAttestedResource) {
     // https://www.w3.org/TR/vc-di-eddsa/#verify-proof-eddsa-jcs-2022
     const { proof, ...unsecuredDocument } = securedDocument
     const { proofValue, ...proofOptions } = securedDocument.proof

--- a/packages/webvh/src/dids/__tests__/WebVhDidRegistrar.boundary.test.ts
+++ b/packages/webvh/src/dids/__tests__/WebVhDidRegistrar.boundary.test.ts
@@ -76,7 +76,7 @@ describe('WebVhDidRegistrar boundary contracts', () => {
       const record = await repository.findSingleByQuery(agentContext, { did })
       expect(record).toBeDefined()
 
-      const log = record!.metadata.get('log') as WebVhDidLog
+      const log = record?.metadata.get('log') as WebVhDidLog
       expect(Array.isArray(log)).toBe(true)
       expect(log).toHaveLength(1)
 
@@ -96,10 +96,10 @@ describe('WebVhDidRegistrar boundary contracts', () => {
       const result = await registrar.create(agentContext, { domain: 'id.boundary-test.app' })
       const did = result.didState.did!
       const record = await repository.findSingleByQuery(agentContext, { did })
-      const log = record!.metadata.get('log') as WebVhDidLog
+      const log = record?.metadata.get('log') as WebVhDidLog
 
       expect(Array.isArray(log[0].parameters.updateKeys)).toBe(true)
-      expect(log[0].parameters.updateKeys!.length).toBeGreaterThan(0)
+      expect(log[0].parameters.updateKeys?.length).toBeGreaterThan(0)
     })
   })
 
@@ -117,7 +117,7 @@ describe('WebVhDidRegistrar boundary contracts', () => {
       expect(updateResult.didState.state).toBe('finished')
 
       const record = await repository.findSingleByQuery(agentContext, { did })
-      const log = record!.metadata.get('log') as WebVhDidLog
+      const log = record?.metadata.get('log') as WebVhDidLog
 
       expect(log).toHaveLength(2)
     })
@@ -133,7 +133,7 @@ describe('WebVhDidRegistrar boundary contracts', () => {
       await registrar.update(agentContext, { did, didDocument })
 
       const record = await repository.findSingleByQuery(agentContext, { did })
-      const log = record!.metadata.get('log') as WebVhDidLog
+      const log = record?.metadata.get('log') as WebVhDidLog
 
       const indices = log.map((e) => parseInt(e.versionId.split('-')[0], 10))
       for (let i = 1; i < indices.length; i++) {
@@ -149,7 +149,7 @@ describe('WebVhDidRegistrar boundary contracts', () => {
       const did = result.didState.did!
 
       const record = await repository.findSingleByQuery(agentContext, { did })
-      const log = record!.metadata.get('log') as WebVhDidLog
+      const log = record?.metadata.get('log') as WebVhDidLog
 
       // Delegate directly to the upstream library — no Credo resolver involved.
       const verifier = new WebVhDidCrypto(agentContext)
@@ -173,7 +173,7 @@ describe('WebVhDidRegistrar boundary contracts', () => {
       expect(updateResult.didState.state).toBe('finished')
 
       const record = await repository.findSingleByQuery(agentContext, { did })
-      const log = record!.metadata.get('log') as WebVhDidLog
+      const log = record?.metadata.get('log') as WebVhDidLog
 
       const verifier = new WebVhDidCrypto(agentContext)
       const resolved = await resolveDIDFromLog(log, { verifier })
@@ -194,8 +194,8 @@ describe('WebVhDidRegistrar boundary contracts', () => {
       const parsed = parseResourceId(resourceId)
 
       expect(parsed).not.toBeNull()
-      expect(parsed!.did).toBe(did)
-      expect(parsed!.resourceId).toBe('zQmSomeFakeHash')
+      expect(parsed?.did).toBe(did)
+      expect(parsed?.resourceId).toBe('zQmSomeFakeHash')
     })
 
     it('parseResourceId rejects a plain DID without a resource path', async () => {

--- a/packages/webvh/src/dids/__tests__/WebVhDidRegistrar.boundary.test.ts
+++ b/packages/webvh/src/dids/__tests__/WebVhDidRegistrar.boundary.test.ts
@@ -72,7 +72,8 @@ describe('WebVhDidRegistrar boundary contracts', () => {
       const result = await registrar.create(agentContext, { domain: 'id.boundary-test.app' })
       expect(result.didState.state).toBe('finished')
 
-      const did = result.didState.did!
+      const did = result.didState.did
+      if (!did) throw new Error('create failed')
       const record = await repository.findSingleByQuery(agentContext, { did })
       expect(record).toBeDefined()
 
@@ -94,7 +95,8 @@ describe('WebVhDidRegistrar boundary contracts', () => {
 
     it('each log entry has updateKeys in parameters after create', async () => {
       const result = await registrar.create(agentContext, { domain: 'id.boundary-test.app' })
-      const did = result.didState.did!
+      const did = result.didState.did
+      if (!did) throw new Error('create failed')
       const record = await repository.findSingleByQuery(agentContext, { did })
       const log = record?.metadata.get('log') as WebVhDidLog
 
@@ -146,7 +148,8 @@ describe('WebVhDidRegistrar boundary contracts', () => {
     it('a log produced by create can be resolved by the upstream resolveDIDFromLog', async () => {
       const result = await registrar.create(agentContext, { domain: 'id.boundary-test.app' })
       expect(result.didState.state).toBe('finished')
-      const did = result.didState.did!
+      const did = result.didState.did
+      if (!did) throw new Error('create failed')
 
       const record = await repository.findSingleByQuery(agentContext, { did })
       const log = record?.metadata.get('log') as WebVhDidLog
@@ -187,7 +190,8 @@ describe('WebVhDidRegistrar boundary contracts', () => {
   describe('resource URL parsing alignment', () => {
     it('parseResourceId correctly handles URLs in the format produced by didwebvh-ts DIDs', async () => {
       const result = await registrar.create(agentContext, { domain: 'id.boundary-test.app' })
-      const did = result.didState.did!
+      const did = result.didState.did
+      if (!did) throw new Error('create failed')
 
       // Simulate a resource URL derived from a real did:webvh DID
       const resourceId = `${did}/resources/zQmSomeFakeHash`
@@ -200,7 +204,8 @@ describe('WebVhDidRegistrar boundary contracts', () => {
 
     it('parseResourceId rejects a plain DID without a resource path', async () => {
       const result = await registrar.create(agentContext, { domain: 'id.boundary-test.app' })
-      const did = result.didState.did!
+      const did = result.didState.did
+      if (!did) throw new Error('create failed')
 
       expect(parseResourceId(did)).toBeNull()
     })

--- a/packages/webvh/src/dids/__tests__/WebVhDidRegistrar.boundary.test.ts
+++ b/packages/webvh/src/dids/__tests__/WebVhDidRegistrar.boundary.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Boundary contract tests for the WebVhDidRegistrar.
+ *
+ * These tests verify that the Credo WebVH integration layer remains behaviorally
+ * aligned with the upstream `didwebvh-ts` library. Specifically:
+ *
+ * 1. The DID log produced by Credo's registrar conforms to the `DIDLogEntry`
+ *    interface defined in `didwebvh-ts` — no reimplementation drift.
+ * 2. Log state transitions (create → update) produce entries with monotonically
+ *    increasing version indices and valid timestamps.
+ * 3. A log produced by Credo's create/update operations can be resolved by the
+ *    upstream `resolveDIDFromLog` function directly, proving structural parity.
+ * 4. Resource URL parsing in the Credo resources module aligns with the URL
+ *    format that `didwebvh-ts` produces when creating DIDs.
+ */
+
+import {
+  CacheModuleConfig,
+  DidDocumentService,
+  DidRepository,
+  InjectionSymbols,
+  InMemoryLruCache,
+} from '@credo-ts/core'
+import { resolveDIDFromLog } from 'didwebvh-ts'
+import { Subject } from 'rxjs'
+import { vi } from 'vitest'
+
+import { InMemoryStorageService } from '../../../../../tests/InMemoryStorageService'
+import { agentDependencies, getAgentConfig, getAgentContext } from '../../../../core/tests/helpers'
+import type { WebVhDidLog, WebVhDidLogEntry } from '../../resources'
+import { parseResourceId } from '../../resources'
+import { WebVhDidCrypto } from '../WebVhDidCrypto'
+import { WebVhDidRegistrar } from '../WebVhDidRegistrar'
+
+// didwebvh-ts calls fetchWitnessProofs during resolve/update. In this offline unit-test
+// environment those HTTP requests fail (ENOTFOUND) and generate stderr noise even when
+// the operation succeeds. We stub global fetch to return an empty witness-proof list,
+// which preserves behavior (witness proofs are optional here) while keeping output clean.
+vi.stubGlobal(
+  'fetch',
+  vi.fn(async () => new Response(JSON.stringify([]), { status: 200, headers: { 'Content-Type': 'application/json' } }))
+)
+
+const inMemoryStorageService = new InMemoryStorageService()
+
+describe('WebVhDidRegistrar boundary contracts', () => {
+  let registrar: WebVhDidRegistrar
+  let agentContext: ReturnType<typeof getAgentContext>
+  let repository: DidRepository
+
+  beforeEach(() => {
+    registrar = new WebVhDidRegistrar()
+    const agentConfig = getAgentConfig('WebVhDidRegistrarBoundaryTest')
+    agentContext = getAgentContext({
+      agentConfig,
+      registerInstances: [
+        [InjectionSymbols.Stop$, new Subject<boolean>()],
+        [InjectionSymbols.AgentDependencies, agentDependencies],
+        [InjectionSymbols.StorageService, inMemoryStorageService],
+        [CacheModuleConfig, new CacheModuleConfig({ cache: new InMemoryLruCache({ limit: 500 }) })],
+      ],
+    })
+    repository = agentContext.dependencyManager.resolve(DidRepository)
+  })
+
+  afterEach(() => {
+    inMemoryStorageService.contextCorrelationIdToRecords = {}
+  })
+
+  describe('DID log shape conformance', () => {
+    it('stores a valid WebVhDidLog in DidRecord metadata after create', async () => {
+      const result = await registrar.create(agentContext, { domain: 'id.boundary-test.app' })
+      expect(result.didState.state).toBe('finished')
+
+      const did = result.didState.did!
+      const record = await repository.findSingleByQuery(agentContext, { did })
+      expect(record).toBeDefined()
+
+      const log = record!.metadata.get('log') as WebVhDidLog
+      expect(Array.isArray(log)).toBe(true)
+      expect(log).toHaveLength(1)
+
+      const entry: WebVhDidLogEntry = log[0]
+      expect(typeof entry.versionId).toBe('string')
+      expect(entry.versionId).toMatch(/^1-/)
+      expect(typeof entry.versionTime).toBe('string')
+      // ISO 8601 datetime
+      expect(() => new Date(entry.versionTime).toISOString()).not.toThrow()
+      expect(entry.parameters).toBeDefined()
+      expect(typeof entry.parameters).toBe('object')
+      expect(entry.state).toBeDefined()
+      expect(entry.state.id).toBe(did)
+    })
+
+    it('each log entry has updateKeys in parameters after create', async () => {
+      const result = await registrar.create(agentContext, { domain: 'id.boundary-test.app' })
+      const did = result.didState.did!
+      const record = await repository.findSingleByQuery(agentContext, { did })
+      const log = record!.metadata.get('log') as WebVhDidLog
+
+      expect(Array.isArray(log[0].parameters.updateKeys)).toBe(true)
+      expect(log[0].parameters.updateKeys!.length).toBeGreaterThan(0)
+    })
+  })
+
+  describe('DID log state transitions', () => {
+    it('log grows by one entry after update', async () => {
+      const createResult = await registrar.create(agentContext, { domain: 'id.boundary-test.app' })
+      expect(createResult.didState.state).toBe('finished')
+      const { did, didDocument } = createResult.didState
+      if (!did || !didDocument) throw new Error('create failed')
+
+      didDocument.service = [
+        new DidDocumentService({ id: '#test', type: 'TestService', serviceEndpoint: 'https://example.com' }),
+      ]
+      const updateResult = await registrar.update(agentContext, { did, didDocument })
+      expect(updateResult.didState.state).toBe('finished')
+
+      const record = await repository.findSingleByQuery(agentContext, { did })
+      const log = record!.metadata.get('log') as WebVhDidLog
+
+      expect(log).toHaveLength(2)
+    })
+
+    it('version indices are monotonically increasing across log entries', async () => {
+      const createResult = await registrar.create(agentContext, { domain: 'id.boundary-test.app' })
+      const { did, didDocument } = createResult.didState
+      if (!did || !didDocument) throw new Error('create failed')
+
+      didDocument.service = [
+        new DidDocumentService({ id: '#test', type: 'TestService', serviceEndpoint: 'https://example.com' }),
+      ]
+      await registrar.update(agentContext, { did, didDocument })
+
+      const record = await repository.findSingleByQuery(agentContext, { did })
+      const log = record!.metadata.get('log') as WebVhDidLog
+
+      const indices = log.map((e) => parseInt(e.versionId.split('-')[0], 10))
+      for (let i = 1; i < indices.length; i++) {
+        expect(indices[i]).toBeGreaterThan(indices[i - 1])
+      }
+    })
+  })
+
+  describe('upstream resolveDIDFromLog round-trip', () => {
+    it('a log produced by create can be resolved by the upstream resolveDIDFromLog', async () => {
+      const result = await registrar.create(agentContext, { domain: 'id.boundary-test.app' })
+      expect(result.didState.state).toBe('finished')
+      const did = result.didState.did!
+
+      const record = await repository.findSingleByQuery(agentContext, { did })
+      const log = record!.metadata.get('log') as WebVhDidLog
+
+      // Delegate directly to the upstream library — no Credo resolver involved.
+      const verifier = new WebVhDidCrypto(agentContext)
+      const resolved = await resolveDIDFromLog(log, { verifier })
+
+      expect(resolved.did).toBe(did)
+      expect(resolved.meta.error).toBeUndefined()
+      expect(resolved.doc).toBeDefined()
+      expect(resolved.doc.id).toBe(did)
+    })
+
+    it('a log produced by create+update can be resolved by the upstream resolveDIDFromLog', async () => {
+      const createResult = await registrar.create(agentContext, { domain: 'id.boundary-test.app' })
+      const { did, didDocument } = createResult.didState
+      if (!did || !didDocument) throw new Error('create failed')
+
+      didDocument.service = [
+        new DidDocumentService({ id: '#test', type: 'TestService', serviceEndpoint: 'https://example.com' }),
+      ]
+      const updateResult = await registrar.update(agentContext, { did, didDocument })
+      expect(updateResult.didState.state).toBe('finished')
+
+      const record = await repository.findSingleByQuery(agentContext, { did })
+      const log = record!.metadata.get('log') as WebVhDidLog
+
+      const verifier = new WebVhDidCrypto(agentContext)
+      const resolved = await resolveDIDFromLog(log, { verifier })
+
+      expect(resolved.did).toBe(did)
+      expect(resolved.meta.error).toBeUndefined()
+      expect(resolved.doc.service).toBeDefined()
+    })
+  })
+
+  describe('resource URL parsing alignment', () => {
+    it('parseResourceId correctly handles URLs in the format produced by didwebvh-ts DIDs', async () => {
+      const result = await registrar.create(agentContext, { domain: 'id.boundary-test.app' })
+      const did = result.didState.did!
+
+      // Simulate a resource URL derived from a real did:webvh DID
+      const resourceId = `${did}/resources/zQmSomeFakeHash`
+      const parsed = parseResourceId(resourceId)
+
+      expect(parsed).not.toBeNull()
+      expect(parsed!.did).toBe(did)
+      expect(parsed!.resourceId).toBe('zQmSomeFakeHash')
+    })
+
+    it('parseResourceId rejects a plain DID without a resource path', async () => {
+      const result = await registrar.create(agentContext, { domain: 'id.boundary-test.app' })
+      const did = result.didState.did!
+
+      expect(parseResourceId(did)).toBeNull()
+    })
+  })
+})

--- a/packages/webvh/src/index.ts
+++ b/packages/webvh/src/index.ts
@@ -1,2 +1,3 @@
 export * from './anoncreds'
 export * from './core'
+export * from './resources'

--- a/packages/webvh/src/index.ts
+++ b/packages/webvh/src/index.ts
@@ -1,4 +1,2 @@
-export { WebVhAnonCredsRegistry } from './anoncreds/services/WebVhAnonCredsRegistry'
-export { WebVhDidRegistrar, WebVhDidResolver } from './dids'
-export { WebVhApi } from './WebVhApi'
-export { WebVhModule } from './WebVhModule'
+export * from './core'
+export * from './anoncreds'

--- a/packages/webvh/src/index.ts
+++ b/packages/webvh/src/index.ts
@@ -1,2 +1,2 @@
-export * from './core'
 export * from './anoncreds'
+export * from './core'

--- a/packages/webvh/src/resources/__tests__/attestedResource.test.ts
+++ b/packages/webvh/src/resources/__tests__/attestedResource.test.ts
@@ -1,3 +1,4 @@
+import type { WebVhDidLog, WebVhDidLogEntry } from '../attestedResource'
 import { getResourceType, isWebVhAttestedResource, parseResourceId } from '../attestedResource'
 
 describe('attestedResource helpers', () => {
@@ -52,5 +53,39 @@ describe('attestedResource helpers', () => {
 
     expect(isWebVhAttestedResource(invalid)).toBe(false)
     expect(getResourceType(invalid as never)).toBeUndefined()
+  })
+})
+
+describe('WebVhDidLog types', () => {
+  it('WebVhDidLogEntry is assignable from a valid log entry shape', () => {
+    const entry: WebVhDidLogEntry = {
+      versionId: '1-zQmHash',
+      versionTime: '2026-01-01T00:00:00Z',
+      parameters: {
+        method: 'did:webvh:0.5',
+        updateKeys: ['zKey1'],
+      },
+      state: {
+        id: 'did:webvh:example.com:01',
+        '@context': ['https://www.w3.org/ns/did/v1'],
+      },
+    }
+
+    expect(entry.versionId).toBe('1-zQmHash')
+    expect(entry.parameters.updateKeys).toEqual(['zKey1'])
+  })
+
+  it('WebVhDidLog is assignable from an array of log entries', () => {
+    const log: WebVhDidLog = [
+      {
+        versionId: '1-zQmHash',
+        versionTime: '2026-01-01T00:00:00Z',
+        parameters: { method: 'did:webvh:0.5' },
+        state: { id: 'did:webvh:example.com:01', '@context': ['https://www.w3.org/ns/did/v1'] },
+      },
+    ]
+
+    expect(log).toHaveLength(1)
+    expect(log[0].versionId).toBe('1-zQmHash')
   })
 })

--- a/packages/webvh/src/resources/__tests__/attestedResource.test.ts
+++ b/packages/webvh/src/resources/__tests__/attestedResource.test.ts
@@ -104,10 +104,14 @@ describe('requireResourceType', () => {
   })
 
   it('throws when resourceType is an empty string', () => {
-    expect(() => requireResourceType({ metadata: { resourceType: '' } })).toThrow('missing required metadata.resourceType')
+    expect(() => requireResourceType({ metadata: { resourceType: '' } })).toThrow(
+      'missing required metadata.resourceType'
+    )
   })
 
   it('throws when resourceType is not a string', () => {
-    expect(() => requireResourceType({ metadata: { resourceType: 42 } })).toThrow('missing required metadata.resourceType')
+    expect(() => requireResourceType({ metadata: { resourceType: 42 } })).toThrow(
+      'missing required metadata.resourceType'
+    )
   })
 })

--- a/packages/webvh/src/resources/__tests__/attestedResource.test.ts
+++ b/packages/webvh/src/resources/__tests__/attestedResource.test.ts
@@ -1,5 +1,5 @@
 import type { WebVhDidLog, WebVhDidLogEntry } from '../attestedResource'
-import { getResourceType, isWebVhAttestedResource, parseResourceId } from '../attestedResource'
+import { getResourceType, isWebVhAttestedResource, parseResourceId, requireResourceType } from '../attestedResource'
 
 describe('attestedResource helpers', () => {
   it('parses a did:webvh resource id', () => {
@@ -87,5 +87,27 @@ describe('WebVhDidLog types', () => {
 
     expect(log).toHaveLength(1)
     expect(log[0].versionId).toBe('1-zQmHash')
+  })
+})
+
+describe('requireResourceType', () => {
+  it('returns resourceType when present and non-empty', () => {
+    expect(requireResourceType({ metadata: { resourceType: 'anonCredsSchema' } })).toBe('anonCredsSchema')
+  })
+
+  it('throws when metadata is absent', () => {
+    expect(() => requireResourceType({})).toThrow('missing required metadata.resourceType')
+  })
+
+  it('throws when resourceType is absent from metadata', () => {
+    expect(() => requireResourceType({ metadata: {} })).toThrow('missing required metadata.resourceType')
+  })
+
+  it('throws when resourceType is an empty string', () => {
+    expect(() => requireResourceType({ metadata: { resourceType: '' } })).toThrow('missing required metadata.resourceType')
+  })
+
+  it('throws when resourceType is not a string', () => {
+    expect(() => requireResourceType({ metadata: { resourceType: 42 } })).toThrow('missing required metadata.resourceType')
   })
 })

--- a/packages/webvh/src/resources/__tests__/attestedResource.test.ts
+++ b/packages/webvh/src/resources/__tests__/attestedResource.test.ts
@@ -1,0 +1,56 @@
+import { getResourceType, isWebVhAttestedResource, parseResourceId } from '../attestedResource'
+
+describe('attestedResource helpers', () => {
+  it('parses a did:webvh resource id', () => {
+    const parsed = parseResourceId('did:webvh:example.com:tenant:01/resources/zQmHash')
+
+    expect(parsed).toEqual({
+      did: 'did:webvh:example.com:tenant:01',
+      resourceId: 'zQmHash',
+    })
+  })
+
+  it('returns null for non-resource ids', () => {
+    expect(parseResourceId('did:webvh:example.com:tenant:01')).toBeNull()
+  })
+
+  it('detects valid attested resource payloads', () => {
+    const valid = {
+      '@context': ['https://identity.foundation/did-attested-resources/context/v0.1'],
+      id: 'did:webvh:example.com:tenant:01/resources/zQmHash',
+      type: ['AttestedResource'],
+      content: { name: 'resource' },
+      proof: {
+        type: 'DataIntegrityProof',
+        cryptosuite: 'eddsa-jcs-2022',
+        proofPurpose: 'assertionMethod',
+        proofValue: 'zProof',
+        verificationMethod: 'did:webvh:example.com:tenant:01#key-1',
+      },
+      metadata: {
+        resourceType: 'anonCredsSchema',
+      },
+    }
+
+    expect(isWebVhAttestedResource(valid)).toBe(true)
+    expect(getResourceType(valid)).toBe('anonCredsSchema')
+  })
+
+  it('rejects missing attested resource type', () => {
+    const invalid = {
+      id: 'did:webvh:example.com:tenant:01/resources/zQmHash',
+      type: ['OtherType'],
+      content: { name: 'resource' },
+      proof: {
+        type: 'DataIntegrityProof',
+        cryptosuite: 'eddsa-jcs-2022',
+        proofPurpose: 'assertionMethod',
+        proofValue: 'zProof',
+        verificationMethod: 'did:webvh:example.com:tenant:01#key-1',
+      },
+    }
+
+    expect(isWebVhAttestedResource(invalid)).toBe(false)
+    expect(getResourceType(invalid as never)).toBeUndefined()
+  })
+})

--- a/packages/webvh/src/resources/attestedResource.ts
+++ b/packages/webvh/src/resources/attestedResource.ts
@@ -132,3 +132,16 @@ export function getResourceType(resource: Pick<WebVhAttestedResource, 'metadata'
   const resourceType = resource.metadata?.resourceType
   return typeof resourceType === 'string' ? resourceType : undefined
 }
+
+/**
+ * Returns the `metadata.resourceType` string from a webvh attested resource.
+ * Throws if the field is absent or empty, ensuring callers receive a non-optional
+ * string suitable for deterministic indexing, policy routing, or typed dispatch.
+ */
+export function requireResourceType(resource: Pick<WebVhAttestedResource, 'metadata'>): string {
+  const resourceType = resource.metadata?.resourceType
+  if (typeof resourceType !== 'string' || resourceType.length === 0) {
+    throw new Error('WebVh attested resource is missing required metadata.resourceType')
+  }
+  return resourceType
+}

--- a/packages/webvh/src/resources/attestedResource.ts
+++ b/packages/webvh/src/resources/attestedResource.ts
@@ -1,6 +1,22 @@
 import { IsStringOrStringArray } from '@credo-ts/core'
 import { Transform, Type } from 'class-transformer'
 import { IsArray, IsNumber, IsObject, IsOptional, IsString, Validate, ValidateNested } from 'class-validator'
+import type { DIDLog, DIDLogEntry } from 'didwebvh-ts'
+
+/**
+ * A single entry in a did:webvh DID log.
+ * Structurally identical to `DIDLogEntry` from `didwebvh-ts`; re-exported here
+ * as a stable Credo-level contract so consumers do not need to import directly
+ * from the upstream library.
+ */
+export type WebVhDidLogEntry = DIDLogEntry
+
+/**
+ * An ordered array of `WebVhDidLogEntry` items representing the full history of
+ * a did:webvh DID document.
+ * Structurally identical to `DIDLog` from `didwebvh-ts`.
+ */
+export type WebVhDidLog = DIDLog
 
 export type WebVhResourceIdParts = {
   did: string

--- a/packages/webvh/src/resources/attestedResource.ts
+++ b/packages/webvh/src/resources/attestedResource.ts
@@ -1,0 +1,118 @@
+import { IsStringOrStringArray } from '@credo-ts/core'
+import { Transform, Type } from 'class-transformer'
+import { IsArray, IsNumber, IsObject, IsOptional, IsString, Validate, ValidateNested } from 'class-validator'
+
+export type WebVhResourceIdParts = {
+  did: string
+  resourceId: string
+}
+
+export class WebVhAttestedResourceProof {
+  @IsString()
+  public type!: string
+
+  @IsString()
+  public cryptosuite!: string
+
+  @IsString()
+  public proofPurpose!: string
+
+  @IsString()
+  public proofValue!: string
+
+  @IsString()
+  public verificationMethod!: string
+}
+
+export class WebVhAttestedResourceLink {
+  @IsString()
+  public id!: string
+
+  @IsString()
+  public type!: string
+
+  @IsOptional()
+  @IsNumber()
+  public timestamp?: number
+
+  @IsOptional()
+  @IsString()
+  public digestMultibase?: string
+}
+
+export class WebVhAttestedResource {
+  @IsArray()
+  @IsString({ each: true })
+  @Type(() => String)
+  public '@context'!: string[]
+
+  @Validate(IsStringOrStringArray)
+  @Transform(({ value }) => (Array.isArray(value) ? value : [value]))
+  @Type(() => String)
+  public type!: string[]
+
+  @IsString()
+  public id!: string
+
+  @IsObject()
+  public content!: unknown
+
+  @ValidateNested()
+  @Type(() => WebVhAttestedResourceProof)
+  public proof!: WebVhAttestedResourceProof
+
+  @IsOptional()
+  @IsObject()
+  public metadata?: Record<string, unknown>
+
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => WebVhAttestedResourceLink)
+  public links?: WebVhAttestedResourceLink[]
+}
+
+export interface WebVhResourcePublisher<TResource = unknown, TOptions = unknown> {
+  publish(options: TOptions): Promise<TResource>
+}
+
+export interface WebVhResourceResolver<TResource = unknown> {
+  resolve(resourceId: string): Promise<TResource>
+}
+
+export function isWebVhAttestedResource(value: unknown): value is WebVhAttestedResource {
+  if (!value || typeof value !== 'object') return false
+
+  const candidate = value as {
+    type?: unknown
+    id?: unknown
+    content?: unknown
+    proof?: unknown
+    metadata?: unknown
+    links?: unknown
+  }
+
+  if (!Array.isArray(candidate.type) || !candidate.type.includes('AttestedResource')) return false
+  if (typeof candidate.id !== 'string') return false
+  if (!candidate.content || typeof candidate.content !== 'object') return false
+  if (!candidate.proof || typeof candidate.proof !== 'object') return false
+  if (candidate.metadata !== undefined && typeof candidate.metadata !== 'object') return false
+  if (candidate.links !== undefined && !Array.isArray(candidate.links)) return false
+
+  return true
+}
+
+export function parseResourceId(resourceId: string): WebVhResourceIdParts | null {
+  const match = resourceId.match(/^(did:webvh:[^/]+)\/resources\/([^/]+)$/)
+  if (!match) return null
+
+  return {
+    did: match[1],
+    resourceId: match[2],
+  }
+}
+
+export function getResourceType(resource: Pick<WebVhAttestedResource, 'metadata'>): string | undefined {
+  const resourceType = resource.metadata?.resourceType
+  return typeof resourceType === 'string' ? resourceType : undefined
+}

--- a/packages/webvh/src/resources/index.ts
+++ b/packages/webvh/src/resources/index.ts
@@ -1,0 +1,1 @@
+export * from './attestedResource'


### PR DESCRIPTION
`webvh` currently couples generic `did:webvh` capabilities with the AnonCreds adapter (resource model, parsing, and resource URL handling). This makes core `webvh` reuse less clear to application logic.

Changes:

This PR decouples the `webvh` subsystem while preserving the delegation of method-specific semantics to `didwebvh-ts` to improve the user/dev experience.

The shared `AttestedResource` contracts are refactored into `webvh` core resources:
* `WebVhAttestedResource`
* `WebVhAttestedResourceProof`
* `WebVhAttestedResourceLink`
* `WebVhResourceIdParts`

alongside helpers:
* `isWebVhAttestedResource`
* `getResourceType` (permissive, returns `string` or `undefined`)
* `requireResourceType` (strictly returns `string`, throws on missing/invalid `metadata.resourceType`)
* `parseResourceId`

The refactor also exposes core log contract aliases from `didwebvh-ts` for downstream consumers:
* `WebVhDidLogEntry`
* `WebVhDidLog`

All of these are exported through explicit surfaces for `core`, `anoncreds`, and `resources`.

The AnonCreds registry/transform path has been updated to consume the shared core resource contracts/helpers instead of duplicating local shape logic.

Added boundary contract tests to verify compatibility with `didwebvh-ts` for log shape/state transitions, upstream round-trip resolution, and resource URL parsing alignment.

Result:

* `did:webvh` types and methods can be consumed independent of AnonCreds.
* AnonCreds remains a consumer adapter over generic `webvh` core behavior.

