### PR TITLE
fix(webvh): domain URI encoding

### DIFF
--- a/packages/webvh/src/dids/WebVhDidRegistrar.ts
+++ b/packages/webvh/src/dids/WebVhDidRegistrar.ts
@@ -63,7 +63,7 @@ export class WebVhDidRegistrar implements DidRegistrar {
       const { publicKeyMultibase, keyId } = await this.generatePublicKey(agentContext)
       const signer = new WebVhDidCryptoSigner(agentContext, publicKeyMultibase, keyId)
       const verifier = new WebVhDidCrypto(agentContext)
-      const baseDid = `did:webvh:{SCID}:${domain}`
+      const baseDid = `did:webvh:{SCID}:${encodeURIComponent(domain)}`
 
       // Create DID
       const { did, doc, log } = await createDID({

--- a/packages/webvh/src/dids/__tests__/WebVhDidRegistrar.test.ts
+++ b/packages/webvh/src/dids/__tests__/WebVhDidRegistrar.test.ts
@@ -69,13 +69,19 @@ describe('WebVhDidRegistrar Integration Tests', () => {
       ])
       expect(result.didState.didDocument?.id).toMatch(/^did:webvh:.+/)
       expect(result.didState.didDocument?.controller).toMatch(/^did:webvh:.+/)
-      expect(result.didState.didDocument?.authentication?.[0]).toMatch(/^did:webvh:.+/)
-
       const authentication = result.didState.didDocument?.authentication?.[0]
       const verification = result.didState.didDocument?.verificationMethod?.[0]
       expect(verification?.id).toMatch(/^did:webvh:.+/)
       expect(verification?.controller).toMatch(/^did:webvh:.+/)
       expect(authentication).toEqual(verification?.id)
+    })
+
+    it('should percent-encode host:port in resulting did id', async () => {
+      const result = await registrar.create(agentContext, { domain: 'alice:8443' })
+      expect(result.didState.state).toBe('finished')
+      expect(result.didState.did).toContain('alice%3A8443')
+      expect(result.didState.didDocument?.id).toContain('alice%3A8443')
+      expect(result.didState.didDocument?.controller).toContain('alice%3A8443')
     })
 
     it('should correctly create two dids, each one with differents path and port', async () => {
@@ -109,7 +115,6 @@ describe('WebVhDidRegistrar Integration Tests', () => {
       ])
       expect(result.didState.didDocument?.id).toMatch(/%3A80:credo:01$/)
       expect(result.didState.didDocument?.controller).toMatch(/%3A80:credo:01$/)
-
       const authentication = result.didState.didDocument?.authentication?.[0]
       const verification = result.didState.didDocument?.verificationMethod?.[0]
       expect(authentication).toEqual(verification?.id)


### PR DESCRIPTION
Critical error which only appeared when testing the latest changes against implicit invitation flows for `did:webvh`

Credo builds `baseDid` from the caller input, while `didwebvh-ts` builds DID identifiers from `encodeURIComponent(domain)`. Calls from `credo-ts` to `didwebvh-ts` must be normalised at this boundary:

```ts
// existing credo-ts WebVhDidRegistrar.ts
const baseDid = `did:webvh:{SCID}:${domain}`

const { did, doc, log } = await createDID({
   domain,
   verificationMethods: [
      {
         controller: baseDid,
         type: 'Multikey',
         publicKeyMultibase,
      },
   ],
   // ...
})
```

```ts
// didwebvh-ts
const encodedDomain = encodeURIComponent(options.domain)
const computedController = `did:webvh:{SCID}:${encodedDomain}`

const didDocumentInput = {
   ...options,
   controller: computedController,
   verificationMethods: normalizedVerificationMethods,
}
```

*Credo:* `domain` is `alice:8443` -> `baseDid` `did:webvh:{SCID}:alice:8443` in `controller:`
*didWebVh-ts:* encodes and constructs `did:webvh:{SCID}:alice%3A8443`

This creates a mismatch in the verifier which expects both of these DIDs to be percent encoded and point to the same canonical DID

If `domain` is passed as `alice%3A8443`, credo keeps the percent-encoded `baseDid` but this is then double-encoded by `didwebvh-ts` into `alice%253A8443`

Fix:

Build `baseDid` with `encodeURIComponent(domain)` at the boundary and pass the original raw `domain` string into `createDID` to ensure exact match between `credo` and `didwebvh-ts` encodings

Added unit test to ensure correct encoding



