### PR TITLE
fix(webvh): fragment handling

### DIFF
--- a/packages/webvh/src/cryptosuites/eddsa-jcs-2022.ts
+++ b/packages/webvh/src/cryptosuites/eddsa-jcs-2022.ts
@@ -44,8 +44,8 @@ export class EddsaJcs2022Cryptosuite {
     const verificationMethod = didDocument.dereferenceVerificationMethod(verificationMethodId)
     const publicJwk = getPublicJwkFromVerificationMethod(verificationMethod)
     return (
-      didRecord.keys?.find(
-        ({ didDocumentRelativeKeyId }) => didDocumentRelativeKeyId === `#${verificationMethod.publicKeyMultibase}`
+      didRecord.keys?.find(({ didDocumentRelativeKeyId }) =>
+        verificationMethod.id.endsWith(didDocumentRelativeKeyId)
       )?.kmsKeyId ?? publicJwk.legacyKeyId
     )
   }

--- a/packages/webvh/src/cryptosuites/eddsa-jcs-2022.ts
+++ b/packages/webvh/src/cryptosuites/eddsa-jcs-2022.ts
@@ -44,9 +44,8 @@ export class EddsaJcs2022Cryptosuite {
     const verificationMethod = didDocument.dereferenceVerificationMethod(verificationMethodId)
     const publicJwk = getPublicJwkFromVerificationMethod(verificationMethod)
     return (
-      didRecord.keys?.find(({ didDocumentRelativeKeyId }) =>
-        verificationMethod.id.endsWith(didDocumentRelativeKeyId)
-      )?.kmsKeyId ?? publicJwk.legacyKeyId
+      didRecord.keys?.find(({ didDocumentRelativeKeyId }) => verificationMethod.id.endsWith(didDocumentRelativeKeyId))
+        ?.kmsKeyId ?? publicJwk.legacyKeyId
     )
   }
 

--- a/packages/webvh/src/dids/WebVhDidRegistrar.ts
+++ b/packages/webvh/src/dids/WebVhDidRegistrar.ts
@@ -63,7 +63,7 @@ export class WebVhDidRegistrar implements DidRegistrar {
       const { publicKeyMultibase, keyId } = await this.generatePublicKey(agentContext)
       const signer = new WebVhDidCryptoSigner(agentContext, publicKeyMultibase, keyId)
       const verifier = new WebVhDidCrypto(agentContext)
-      const baseDid = `did:webvh:{SCID}:${domain}`
+      const baseDid = `did:webvh:{SCID}:${encodeURIComponent(domain)}`
 
       // Create DID
       const { did, doc, log } = await createDID({

--- a/packages/webvh/src/dids/WebVhDidRegistrar.ts
+++ b/packages/webvh/src/dids/WebVhDidRegistrar.ts
@@ -83,9 +83,14 @@ export class WebVhDidRegistrar implements DidRegistrar {
 
       const didDocument = JsonTransformer.fromJSON(doc, DidDocument)
 
+      // Derive the fragment from the actual DID document verificationMethod. didwebvh-ts
+      // is responsible for incorporating and signing over fragments in the log
+      // so we read back what the library produced
+      const matchedVm = didDocument.verificationMethod?.find((vm) => vm.publicKeyMultibase === publicKeyMultibase)
+      const vmIdFragment = matchedVm?.id.split('#')[1]
       keys.push({
         kmsKeyId: keyId,
-        didDocumentRelativeKeyId: `#${publicKeyMultibase}`,
+        didDocumentRelativeKeyId: `#${vmIdFragment}`,
       })
       const didRecord = new DidRecord({
         did,

--- a/packages/webvh/src/dids/__tests__/WebVhDidRegistrar.boundary.test.ts
+++ b/packages/webvh/src/dids/__tests__/WebVhDidRegistrar.boundary.test.ts
@@ -187,8 +187,44 @@ describe('WebVhDidRegistrar boundary contracts', () => {
     })
   })
 
-  describe('resource URL parsing alignment', () => {
-    it('parseResourceId correctly handles URLs in the format produced by didwebvh-ts DIDs', async () => {
+  describe('key fragment conformance', () => {
+    it('stored didDocumentRelativeKeyId matches the actual fragment in the DID document verificationMethod', async () => {
+      const result = await registrar.create(agentContext, { domain: 'id.boundary-test.app' })
+      expect(result.didState.state).toBe('finished')
+      const did = result.didState.did
+      if (!did) throw new Error('create failed')
+
+      const record = await repository.findSingleByQuery(agentContext, { did })
+      expect(record?.keys).toBeDefined()
+      expect(record!.keys!.length).toBeGreaterThan(0)
+
+      const storedFragment = record!.keys![0].didDocumentRelativeKeyId
+
+      // The stored fragment must start with '#' and must match the actual VM id
+      // in the resolved DID document
+      expect(storedFragment).toMatch(/^#/)
+
+      const vmId = record!.didDocument?.verificationMethod?.[0]?.id
+      expect(vmId).toBeDefined()
+      expect(vmId!.endsWith(storedFragment)).toBe(true)
+    })
+
+    it('didDocumentRelativeKeyId matches via endsWith semantics as used in Credo core', async () => {
+      const result = await registrar.create(agentContext, { domain: 'id.boundary-test.app' })
+      const did = result.didState.did
+      if (!did) throw new Error('create failed')
+
+      const record = await repository.findSingleByQuery(agentContext, { did })
+      const storedFragment = record!.keys![0].didDocumentRelativeKeyId
+      const vmId = record!.didDocument?.verificationMethod?.[0]?.id
+
+      // This mirrors the lookup logic used by Credo core (DidsApi line ~208) and the
+      // corrected cryptosuite: verificationMethod.id.endsWith(didDocumentRelativeKeyId)
+      expect(vmId!.endsWith(storedFragment)).toBe(true)
+    })
+  })
+
+  describe('resource URL parsing alignment', () => {    it('parseResourceId correctly handles URLs in the format produced by didwebvh-ts DIDs', async () => {
       const result = await registrar.create(agentContext, { domain: 'id.boundary-test.app' })
       const did = result.didState.did
       if (!did) throw new Error('create failed')

--- a/packages/webvh/src/dids/__tests__/WebVhDidRegistrar.boundary.test.ts
+++ b/packages/webvh/src/dids/__tests__/WebVhDidRegistrar.boundary.test.ts
@@ -196,17 +196,18 @@ describe('WebVhDidRegistrar boundary contracts', () => {
 
       const record = await repository.findSingleByQuery(agentContext, { did })
       expect(record?.keys).toBeDefined()
-      expect(record!.keys!.length).toBeGreaterThan(0)
+      expect(record?.keys?.length).toBeGreaterThan(0)
 
-      const storedFragment = record!.keys![0].didDocumentRelativeKeyId
+      const storedFragment = record?.keys?.[0].didDocumentRelativeKeyId
+      if (!storedFragment) throw new Error('Missing didDocumentRelativeKeyId')
 
       // The stored fragment must start with '#' and must match the actual VM id
       // in the resolved DID document
       expect(storedFragment).toMatch(/^#/)
 
-      const vmId = record!.didDocument?.verificationMethod?.[0]?.id
-      expect(vmId).toBeDefined()
-      expect(vmId!.endsWith(storedFragment)).toBe(true)
+      const vmId = record?.didDocument?.verificationMethod?.[0]?.id
+      if (!vmId) throw new Error('Missing verificationMethod id')
+      expect(vmId.endsWith(storedFragment)).toBe(true)
     })
 
     it('didDocumentRelativeKeyId matches via endsWith semantics as used in Credo core', async () => {
@@ -215,16 +216,19 @@ describe('WebVhDidRegistrar boundary contracts', () => {
       if (!did) throw new Error('create failed')
 
       const record = await repository.findSingleByQuery(agentContext, { did })
-      const storedFragment = record!.keys![0].didDocumentRelativeKeyId
-      const vmId = record!.didDocument?.verificationMethod?.[0]?.id
+      const storedFragment = record?.keys?.[0].didDocumentRelativeKeyId
+      if (!storedFragment) throw new Error('Missing didDocumentRelativeKeyId')
+      const vmId = record?.didDocument?.verificationMethod?.[0]?.id
+      if (!vmId) throw new Error('Missing verificationMethod id')
 
       // This mirrors the lookup logic used by Credo core (DidsApi line ~208) and the
       // corrected cryptosuite: verificationMethod.id.endsWith(didDocumentRelativeKeyId)
-      expect(vmId!.endsWith(storedFragment)).toBe(true)
+      expect(vmId.endsWith(storedFragment)).toBe(true)
     })
   })
 
-  describe('resource URL parsing alignment', () => {    it('parseResourceId correctly handles URLs in the format produced by didwebvh-ts DIDs', async () => {
+  describe('resource URL parsing alignment', () => {
+    it('parseResourceId correctly handles URLs in the format produced by didwebvh-ts DIDs', async () => {
       const result = await registrar.create(agentContext, { domain: 'id.boundary-test.app' })
       const did = result.didState.did
       if (!did) throw new Error('create failed')

--- a/packages/webvh/src/dids/__tests__/WebVhDidRegistrar.test.ts
+++ b/packages/webvh/src/dids/__tests__/WebVhDidRegistrar.test.ts
@@ -69,13 +69,19 @@ describe('WebVhDidRegistrar Integration Tests', () => {
       ])
       expect(result.didState.didDocument?.id).toMatch(/^did:webvh:.+/)
       expect(result.didState.didDocument?.controller).toMatch(/^did:webvh:.+/)
-      expect(result.didState.didDocument?.authentication?.[0]).toMatch(/^did:webvh:.+/)
-
       const authentication = result.didState.didDocument?.authentication?.[0]
       const verification = result.didState.didDocument?.verificationMethod?.[0]
       expect(verification?.id).toMatch(/^did:webvh:.+/)
       expect(verification?.controller).toMatch(/^did:webvh:.+/)
       expect(authentication).toEqual(verification?.id)
+    })
+
+    it('should percent-encode host:port in resulting did id', async () => {
+      const result = await registrar.create(agentContext, { domain: 'alice:8443' })
+      expect(result.didState.state).toBe('finished')
+      expect(result.didState.did).toContain('alice%3A8443')
+      expect(result.didState.didDocument?.id).toContain('alice%3A8443')
+      expect(result.didState.didDocument?.controller).toContain('alice%3A8443')
     })
 
     it('should correctly create two dids, each one with differents path and port', async () => {
@@ -109,7 +115,6 @@ describe('WebVhDidRegistrar Integration Tests', () => {
       ])
       expect(result.didState.didDocument?.id).toMatch(/%3A80:credo:01$/)
       expect(result.didState.didDocument?.controller).toMatch(/%3A80:credo:01$/)
-
       const authentication = result.didState.didDocument?.authentication?.[0]
       const verification = result.didState.didDocument?.verificationMethod?.[0]
       expect(authentication).toEqual(verification?.id)


### PR DESCRIPTION
`didwebvh-ts` generates default key fragments (`didDocumentRelativeKeyId`) as the last 8 characters of the `publicKeyMultibase` when `vm.id` is not supplied by the user

Credo `webvh` does not (currently) have an interface for supplying user-defined `vm.id`

However, the way the `webvh` module currently extracts and uses key fragments causes failed KMS lookups

**WebVhDidRegistrar.ts**

`didwebvh-ts` returns the full did with the truncated fragment, but credo was storing the full `publicKeyMultibase` as the reference:

* didwebvh-ts generates: `did:webvh:QmABC...123:example.com#nWb8z5ZJ`
* Credo stores: `#z6MkrJVnaZkeFzdQyMZu1cgjg7k1pZZ6pvBQ7XJPt4swbTQ5`
* DID document contains: `#nWb8z5ZJ`

Fix:

Because the did log is signed over the entire did, we now extract the actual VM id fragment from the document returned from `didwebvh-ts` and store this as the `didDocumentRelativeKeyId`

**eddsa-jcs-2022.ts**

The `_publicKeyIdFromId` method was using the wrong comparison operand with strict equality instead of `.endsWith()`

Because the lookup always fails, this fell through to `publicJwk.legacyKeyId` which may work in some configurations but masked the real lookup failure and would silently break when `legacyKeyId` is absent or stale

Fix:

Modelled on the `.endsWith()` lookup by `didDocumentKey.ts` and `W3cJwtCredentialService.ts`. Legacy fallback preserved
