### PR TITLE
fix(didcomm): align v2 connection-less OOB key handling with v1 envelope service

### DIFF
--- a/packages/didcomm/src/DidCommMessageSender.ts
+++ b/packages/didcomm/src/DidCommMessageSender.ts
@@ -694,10 +694,11 @@ export class DidCommMessageSender {
       service: { ...service, recipientKeys: 'omitted...', routingKeys: 'omitted...' },
     })
 
-    // For connectionless v2: use did:key as kid so recipient can resolve via tryParseKidAsPublicJwk
+    // v2 spec: kid must be a DID URL into a keyAgreement vm. Preserve any attached keyId; only fall back to did:key for raw base58 from v1 ~service.
     const recipientKeys =
       !connection && this.didCommModuleConfig.sendsV2
         ? service.recipientKeys.map((k) => {
+            if (k.hasKeyId) return k
             const copy = Kms.PublicJwk.fromPublicJwk(k.toJson())
             copy.keyId = new DidKey(k).did
             return copy

--- a/packages/didcomm/src/getDidCommOutboundMessageContext.ts
+++ b/packages/didcomm/src/getDidCommOutboundMessageContext.ts
@@ -1,6 +1,7 @@
 import type { AgentContext, BaseRecordAny, ResolvedDidCommService } from '@credo-ts/core'
 import { CredoError, DidKey, Kms, utils } from '@credo-ts/core'
 import type { DidCommMessage } from './DidCommMessage'
+import { DidCommModuleConfig } from './DidCommModuleConfig'
 import { ServiceDecorator } from './decorators/service/ServiceDecorator'
 import type { DidCommRouting } from './models'
 import { DidCommOutboundMessageContext } from './models'
@@ -177,19 +178,25 @@ async function getServicesForMessage(
     outOfBandRecord?: DidCommOutOfBandRecord
   }
 ) {
+  // Key off sendsV2 config; invitationType is @Exclude()-decorated and lost after the OOB record's storage round-trip.
+  const preferDidcommV2 = agentContext.dependencyManager.resolve(DidCommModuleConfig).sendsV2
+
+  // v1 ~service holds raw base58 keys with no DID URL keyId; for v2 OOB Receiver, re-resolve via the OOB record to get a keyAgreement vm.
+  const skipLastReceivedServiceForV2 = preferDidcommV2 && outOfBandRecord?.role === DidCommOutOfBandRole.Receiver
+
   let ourService = lastSentMessage?.service?.resolvedDidCommService
-  let recipientService = lastReceivedMessage.service?.resolvedDidCommService
+  let recipientService = skipLastReceivedServiceForV2 ? undefined : lastReceivedMessage.service?.resolvedDidCommService
 
   const outOfBandService = agentContext.dependencyManager.resolve(DidCommOutOfBandService)
 
-  // Check if valid
   if (outOfBandRecord?.role === DidCommOutOfBandRole.Sender) {
     // Extract ourService from the oob record if not on a previous message
     if (!ourService) {
       ourService = await outOfBandService.getResolvedServiceForOutOfBandServices(
         agentContext,
         outOfBandRecord.outOfBandInvitation.getServices(),
-        outOfBandRecord.invitationInlineServiceKeys
+        outOfBandRecord.invitationInlineServiceKeys,
+        preferDidcommV2
       )
     }
 
@@ -208,7 +215,9 @@ async function getServicesForMessage(
     if (!recipientService) {
       recipientService = await outOfBandService.getResolvedServiceForOutOfBandServices(
         agentContext,
-        outOfBandRecord.outOfBandInvitation.getServices()
+        outOfBandRecord.outOfBandInvitation.getServices(),
+        undefined,
+        preferDidcommV2
       )
     }
 

--- a/packages/didcomm/src/modules/oob/DidCommOutOfBandService.ts
+++ b/packages/didcomm/src/modules/oob/DidCommOutOfBandService.ts
@@ -1,5 +1,5 @@
-import type { AgentContext, Kms, Query, QueryOptions } from '@credo-ts/core'
-import { CredoError, DidsApi, EventEmitter, injectable, parseDid } from '@credo-ts/core'
+import type { AgentContext, Query, QueryOptions } from '@credo-ts/core'
+import { CredoError, DidsApi, EventEmitter, injectable, Kms, parseDid } from '@credo-ts/core'
 import type { DidCommInboundMessageContext } from '../../models'
 import { DidCommDocumentService } from '../../services'
 import type { DidCommConnectionRecord, DidCommHandshakeProtocol } from '../connections'
@@ -283,21 +283,21 @@ export class DidCommOutOfBandService {
   }
 
   /**
-   * Extract a resolved didcomm service from an out of band invitation.
-   *
-   * Currently the first service that can be resolved is returned.
+   * Extract a resolved didcomm service from an out of band invitation. The first resolvable service is returned;
+   * when `preferDidcommV2` is set, X25519-keyAgreement services are preferred so v2 packing emits a spec-compliant kid.
    */
   public async getResolvedServiceForOutOfBandServices(
     agentContext: AgentContext,
     services: Array<string | OutOfBandDidCommService>,
-    /**
-     * Optional keys for the inline services
-     */
-    inlineServiceKeys?: DidCommOutOfBandInlineServiceKey[]
+    inlineServiceKeys?: DidCommOutOfBandInlineServiceKey[],
+    preferDidcommV2?: boolean
   ) {
     for (const service of services) {
       if (typeof service === 'string') {
-        const [didService] = await this.didCommDocumentService.resolveServicesFromDid(agentContext, service)
+        const allServices = await this.didCommDocumentService.resolveServicesFromDid(agentContext, service)
+        const didService = preferDidcommV2
+          ? (allServices.find((s) => s.recipientKeys.some((k) => k.is(Kms.X25519PublicJwk))) ?? allServices[0])
+          : allServices[0]
 
         if (didService) return didService
       } else {

--- a/packages/didcomm/src/v2/resolveV2Keys.ts
+++ b/packages/didcomm/src/v2/resolveV2Keys.ts
@@ -8,8 +8,14 @@ import {
   JsonEncoder,
   Kms,
   parseDid,
+  RecordNotFoundError,
 } from '@credo-ts/core'
+import { getResolvedDidcommServiceWithSigningKeyId } from '../modules/connections/services/helpers'
+import { DidCommOutOfBandRole } from '../modules/oob/domain/DidCommOutOfBandRole'
+import { DidCommOutOfBandRepository } from '../modules/oob/repository/DidCommOutOfBandRepository'
+import { DidCommOutOfBandRecordMetadataKeys } from '../modules/oob/repository/outOfBandRecordMetadataTypes'
 import { DidCommMediatorRoutingRepository } from '../modules/routing/repository'
+import { DidCommDocumentService } from '../services/DidCommDocumentService'
 import type { DidCommV2EncryptedMessage } from './types'
 
 @injectable()
@@ -88,18 +94,13 @@ export class DidCommV2KeyResolver {
           // for did:key kids (v2 Forward to mediator routing key).
         }
 
-        // Path 3: mediator routing record lookup for did:key kids.
-        // When a v2 Forward arrives addressed to the mediator's routing key, the kid
-        // is `did:key:z6...` which is NOT a Created DID in the DID store. We fall back
-        // to the mediator routing repository (same fallback pattern as v1's
-        // DidCommEnvelopeService.extractOurRecipientKeyWithKeyId).
-        //
-        // The kid may be Ed25519 (z6Mk) or X25519 (z6LS). The routing record stores
-        // Ed25519 keys, so we look up by Ed25519 fingerprint directly, and for X25519
-        // kids we derive the Ed25519=>X25519 mapping and compare.
-        if (kid.startsWith('did:key:')) {
+        const kidPublicJwk = kid.startsWith('did:key:') ? DidKey.fromDid(kid).publicJwk : null
+
+        // Path 2: did:key kid for a mediator routing key (v2 Forward
+        // arrives addressed to a key our mediator manages). Routing keys aren't
+        // Created DIDs, so we look them up in the mediator routing repository.
+        if (kidPublicJwk) {
           try {
-            const kidPublicJwk = DidKey.fromDid(kid).publicJwk
             const mediatorRoutingRepository = agentContext.dependencyManager.resolve(DidCommMediatorRoutingRepository)
 
             // Ed25519 kid: direct fingerprint lookup
@@ -149,14 +150,122 @@ export class DidCommV2KeyResolver {
               }
             }
           } catch {
-            // Ignore failures in Path 3 and continue to next recipient
+            // Ignore failures and try the next path.
+          }
+        }
+
+        // Path 3: did:key kid whose underlying public key is actually
+        // a verification method on one of our Created DIDs (e.g. the master Ed25519
+        // of did:webvh, referenced as `did:key:z6Mk...`). Path 1 missed it
+        // because the did:key form itself isn't registered. We reverse-lookup by
+        // public key and pull the kmsKeyId from the parent DID record.
+        if (kidPublicJwk) {
+          try {
+            const documentService = agentContext.dependencyManager.resolve(DidCommDocumentService)
+            const { didDocument, keys } = await documentService.resolveCreatedDidDocumentWithKeysByRecipientKey(
+              agentContext,
+              kidPublicJwk
+            )
+
+            for (const vm of didDocument.verificationMethod ?? []) {
+              let vmJwk: Kms.PublicJwk
+              try {
+                vmJwk = getPublicJwkFromVerificationMethod(vm)
+              } catch {
+                continue
+              }
+              const directMatch = vmJwk.fingerprint === kidPublicJwk.fingerprint
+              const derivedMatch =
+                vmJwk.is(Kms.Ed25519PublicJwk) &&
+                (vmJwk as Kms.PublicJwk<Kms.Ed25519PublicJwk>).convertTo(Kms.X25519PublicJwk).fingerprint ===
+                  kidPublicJwk.fingerprint
+              if (!directMatch && !derivedMatch) continue
+
+              const x25519 = vmJwk.is(Kms.X25519PublicJwk)
+                ? (vmJwk as Kms.PublicJwk<Kms.X25519PublicJwk>)
+                : (vmJwk as Kms.PublicJwk<Kms.Ed25519PublicJwk>).convertTo(Kms.X25519PublicJwk)
+              const kmsKeyId = keys?.find(({ didDocumentRelativeKeyId }) =>
+                vm.id.endsWith(didDocumentRelativeKeyId)
+              )?.kmsKeyId
+              x25519.keyId = kmsKeyId ?? (vmJwk.hasKeyId ? vmJwk.keyId : vmJwk.legacyKeyId)
+              return {
+                recipientKey: x25519 as Kms.PublicJwk<Kms.X25519PublicJwk> & { keyId: string },
+                matchedKid: kid,
+              }
+            }
+          } catch (error) {
+            if (!(error instanceof RecordNotFoundError)) throw error
+          }
+        }
+
+        // Path 4: did:key kid for an ephemeral routing key from a
+        // connection-less OOB exchange. The wallet generates a fresh routing key
+        // per exchange and stores its kmsKeyId only on the OOB record's metadata.
+        // Look up the OOB record by fingerprint and pull the kmsKeyId from there.
+        // Sender role: the kid matches one of our invitation's inline service keys.
+        // Receiver role: the kid matches our recipientRouting key for that exchange.
+        if (kidPublicJwk) {
+          const fingerprint = kidPublicJwk.fingerprint
+          const outOfBandRepository = agentContext.dependencyManager.resolve(DidCommOutOfBandRepository)
+
+          const outOfBandRecord = await outOfBandRepository.findSingleByQuery(agentContext, {
+            $or: [
+              {
+                role: DidCommOutOfBandRole.Sender,
+                recipientKeyFingerprints: [fingerprint],
+              },
+              {
+                role: DidCommOutOfBandRole.Receiver,
+                recipientRoutingKeyFingerprint: fingerprint,
+              },
+            ],
+          })
+
+          if (outOfBandRecord?.role === DidCommOutOfBandRole.Sender) {
+            agentContext.config.logger.debug(
+              `Found out of band record with id '${outOfBandRecord.id}' and role '${outOfBandRecord.role}' for recipient key '${fingerprint}' for incoming didcomm v2 message`
+            )
+
+            for (const service of outOfBandRecord.outOfBandInvitation.getInlineServices()) {
+              const resolvedService = getResolvedDidcommServiceWithSigningKeyId(
+                service,
+                outOfBandRecord.invitationInlineServiceKeys
+              )
+              const recipientKey = resolvedService.recipientKeys.find((rk) => rk.fingerprint === fingerprint)
+              if (!recipientKey) continue
+              const matchedKeyId = recipientKey.hasKeyId ? recipientKey.keyId : recipientKey.legacyKeyId
+              const x25519 = recipientKey.is(Kms.X25519PublicJwk)
+                ? (recipientKey as Kms.PublicJwk<Kms.X25519PublicJwk>)
+                : (recipientKey as Kms.PublicJwk<Kms.Ed25519PublicJwk>).convertTo(Kms.X25519PublicJwk)
+              x25519.keyId = matchedKeyId
+              return {
+                recipientKey: x25519 as Kms.PublicJwk<Kms.X25519PublicJwk> & { keyId: string },
+                matchedKid: kid,
+              }
+            }
+          } else if (outOfBandRecord?.role === DidCommOutOfBandRole.Receiver) {
+            agentContext.config.logger.debug(
+              `Found out of band record with id '${outOfBandRecord.id}' and role '${outOfBandRecord.role}' for recipient key '${fingerprint}' for incoming didcomm v2 message`
+            )
+
+            const recipientRouting = outOfBandRecord.metadata.get(DidCommOutOfBandRecordMetadataKeys.RecipientRouting)
+            if (recipientRouting?.recipientKeyFingerprint === fingerprint) {
+              const x25519 = kidPublicJwk.is(Kms.X25519PublicJwk)
+                ? (kidPublicJwk as Kms.PublicJwk<Kms.X25519PublicJwk>)
+                : (kidPublicJwk as Kms.PublicJwk<Kms.Ed25519PublicJwk>).convertTo(Kms.X25519PublicJwk)
+              x25519.keyId = recipientRouting.recipientKeyId ?? x25519.legacyKeyId
+              return {
+                recipientKey: x25519 as Kms.PublicJwk<Kms.X25519PublicJwk> & { keyId: string },
+                matchedKid: kid,
+              }
+            }
           }
         }
 
         continue
       }
 
-      // Path 2: kid stored directly in KMS (e.g. internal key id)
+      // Path 5: kid stored directly in KMS (e.g. internal key id)
       const kmsPublic = await kms.getPublicKey({ keyId: kid }).catch((err) => {
         if (err instanceof Kms.KeyManagementKeyNotFoundError) return null
         throw err


### PR DESCRIPTION
V2 OOB connection-less return-route flows didn't decrypt because the resolver couldn't dereference `did:key:` kids that aren't Created DIDs.

Two new paths in `resolveV2Keys`, mirroring `DidCommEnvelopeService.extractOurRecipientKeyWithKeyId`:
- Reverse lookup: kid's public key matches a VM on one of our Created DIDs.
- OOB record fallback: kid is an ephemeral OOB routing key; kmsKeyId lives in `metadata.RecipientRouting`.

Sender-side fixes so v2 packing emits spec-compliant kids:
- `DidCommMessageSender`: preserve any keyId already attached by `resolveServicesFromDid`; only fall back to `did:key:` for raw v1 ~service keys.
- `getDidCommOutboundMessageContext`: for v2 OOB Receiver outbound, skip the v1 ~service decorator and re-resolve via the OOB record.
- `DidCommOutOfBandService.getResolvedServiceForOutOfBandServices`: prefer X25519 services when the caller is v2-capable.

## Test

End-to-end V2 OOB credential offer + proof request between an issuer and a wallet. V1 flows unchanged.