### PR TITLE
fix(openid4vc): include auth-code scope in credential offer

### DIFF
--- a/.changeset/heavy-needles-kneel.md
+++ b/.changeset/heavy-needles-kneel.md
@@ -1,0 +1,5 @@
+---
+"@credo-ts/openid4vc": patch
+---
+
+fix(openid4vc): include auth-code scope in credential offer

--- a/packages/openid4vc/src/openid4vc-issuer/OpenId4VcIssuerService.ts
+++ b/packages/openid4vc/src/openid4vc-issuer/OpenId4VcIssuerService.ts
@@ -1480,7 +1480,7 @@ export class OpenId4VcIssuerService {
         authorization_server: config.issuerMetadata.credentialIssuer.authorization_servers
           ? authorizationServerUrl
           : undefined,
-        scope: scope,
+        scope,
       }
     }
 

--- a/packages/openid4vc/src/openid4vc-issuer/OpenId4VcIssuerService.ts
+++ b/packages/openid4vc/src/openid4vc-issuer/OpenId4VcIssuerService.ts
@@ -1453,6 +1453,7 @@ export class OpenId4VcIssuerService {
     if (authorizationCodeFlowConfig) {
       const { requirePresentationDuringIssuance } = authorizationCodeFlowConfig
       let authorizationServerUrl = authorizationCodeFlowConfig.authorizationServerUrl
+      const scope = authorizationCodeFlowConfig.scope
 
       if (requirePresentationDuringIssuance) {
         if (authorizationServerUrl && authorizationServerUrl !== issuerMetadata.credentialIssuer.credential_issuer) {
@@ -1479,6 +1480,7 @@ export class OpenId4VcIssuerService {
         authorization_server: config.issuerMetadata.credentialIssuer.authorization_servers
           ? authorizationServerUrl
           : undefined,
+        scope: scope,
       }
     }
 

--- a/packages/openid4vc/src/openid4vc-issuer/OpenId4VcIssuerServiceOptions.ts
+++ b/packages/openid4vc/src/openid4vc-issuer/OpenId4VcIssuerServiceOptions.ts
@@ -96,6 +96,14 @@ export interface OpenId4VciAuthorizationCodeFlowConfig {
    * @default false
    */
   requirePresentationDuringIssuance?: boolean
+  /**
+   * Optional OAuth 2.0 scope value(s) for authorization code flow.
+   *
+   * This can be used to align with HAIP requirement that the issuer includes a scope
+   * value so the wallet can identify the desired credential type and use it in the
+   * authorization request `scope` parameter.
+   */
+  scope?: string
 }
 
 interface OpenId4VciCreateCredentialOfferOptionsBase {

--- a/packages/openid4vc/src/openid4vc-issuer/OpenId4VcIssuerServiceOptions.ts
+++ b/packages/openid4vc/src/openid4vc-issuer/OpenId4VcIssuerServiceOptions.ts
@@ -96,6 +96,7 @@ export interface OpenId4VciAuthorizationCodeFlowConfig {
    * @default false
    */
   requirePresentationDuringIssuance?: boolean
+
   /**
    * Optional OAuth 2.0 scope value(s) for authorization code flow.
    *


### PR DESCRIPTION
We are trying to align our OID4VCI issuer flow with [HAIP 1.0-05 section 4.2](https://openid.net/specs/openid4vc-high-assurance-interoperability-profile-1_0-05.html#section-4.2), which states that for **authorization_code** the issuer **MUST** include a **scope** value so the wallet can identify the credential type, and the wallet MUST use it in the authorization request.
#### Interoperability question:

- **Scope validation gap**: In this draft we currently do not validate that the **scope** used in **authorization_code**. Should we enforce this mapping for [HAIP 4.3 compliance](https://openid.net/specs/openid4vc-high-assurance-interoperability-profile-1_0-05.html#section-4.3) _(scope MUST map to specific Credential Type)_, and if multiple credentials are offered, then what should be the validation approach?

But as section 4.3 also mentions _scope value may be pre-agreed_ , I think we can give flexibility to the users to set their scope.
