### PR TITLE
fix(webvh): revocation status list shape validation

### DIFF
--- a/packages/webvh/src/anoncreds/services/WebVhAnonCredsRegistry.ts
+++ b/packages/webvh/src/anoncreds/services/WebVhAnonCredsRegistry.ts
@@ -499,12 +499,19 @@ export class WebVhAnonCredsRegistry implements AnonCredsRegistry {
         throw new CredoError('No revocation entry found for the given timestamp.')
       }
 
-      if (!isRevocationStatusListShape(revocationEntryResourceObject.content)) {
+      // The signed attested resource does not embed the timestamp, so we inject it before validating the shape
+      const selectedEntry = revocationEntries.find((entry) => entry.id === revocationEntryId)
+      const revocationStatusListContent = {
+        ...(revocationEntryResourceObject.content as object),
+        timestamp: selectedEntry?.timestamp,
+      }
+
+      if (!isRevocationStatusListShape(revocationStatusListContent)) {
         throw new CredoError('Resolved revocation entry content is not a valid revocation status list.')
       }
 
       return {
-        revocationStatusList: revocationEntryResourceObject.content as AnonCredsRevocationStatusList,
+        revocationStatusList: revocationStatusListContent as AnonCredsRevocationStatusList,
         resolutionMetadata: revocationEntryResolutionResult.dereferencingMetadata || {},
         revocationStatusListMetadata: revocationEntryResourceObject.metadata || {},
       }


### PR DESCRIPTION
After I've noticed an error when resolving a revocation status list, and it was because it was expecting the timestamp on the shape of it. So a simple way here is to inject the given timestamp so the validation is properly done (and the returned object is a complete revocation status list object).

cc @rmlearney-digicatapult 