### PR TITLE
feat(connections): emit state change on v2 OOB accept

### DIFF
--- a/packages/didcomm/src/modules/connections/DidCommConnectionsApi.ts
+++ b/packages/didcomm/src/modules/connections/DidCommConnectionsApi.ts
@@ -116,36 +116,44 @@ export class DidCommConnectionsApi {
     } else if (protocol === DidCommHandshakeProtocol.None) {
       // V2 OOB: create connection without handshake (no ConnectionRequest/Response sent)
       if (ourDid) {
-        const connectionRecord = await this.connectionService.createConnection(this.agentContext, {
-          protocol: DidCommHandshakeProtocol.None,
-          role: DidCommDidExchangeRole.Responder,
-          state: DidCommDidExchangeState.Completed,
-          theirDid: outOfBandRecord.outOfBandInvitation.v2Invitation?.from,
-          did: ourDid,
-          outOfBandId: outOfBandRecord.id,
-          invitationDid: outOfBandRecord.outOfBandInvitation.v2Invitation?.from,
-          alias: config.alias,
-          theirLabel: outOfBandRecord.outOfBandInvitation.v2Invitation?.body?.goal,
-          didcommVersion: 'v2',
-        })
+        const connectionRecord = await this.connectionService.createConnection(
+          this.agentContext,
+          {
+            protocol: DidCommHandshakeProtocol.None,
+            role: DidCommDidExchangeRole.Responder,
+            state: DidCommDidExchangeState.Completed,
+            theirDid: outOfBandRecord.outOfBandInvitation.v2Invitation?.from,
+            did: ourDid,
+            outOfBandId: outOfBandRecord.id,
+            invitationDid: outOfBandRecord.outOfBandInvitation.v2Invitation?.from,
+            alias: config.alias,
+            theirLabel: outOfBandRecord.outOfBandInvitation.v2Invitation?.body?.goal,
+            didcommVersion: 'v2',
+          },
+          true
+        )
         return connectionRecord
       }
       if (!routing) {
         throw new CredoError('Routing is required for v2 OOB accept to create did:peer:2')
       }
       const { did } = await createPeerDidForV2OOB(this.agentContext, routing)
-      const connectionRecord = await this.connectionService.createConnection(this.agentContext, {
-        protocol: DidCommHandshakeProtocol.None,
-        role: DidCommDidExchangeRole.Responder,
-        state: DidCommDidExchangeState.Completed,
-        theirDid: outOfBandRecord.outOfBandInvitation.v2Invitation?.from,
-        did,
-        outOfBandId: outOfBandRecord.id,
-        invitationDid: outOfBandRecord.outOfBandInvitation.v2Invitation?.from,
-        alias: config.alias,
-        theirLabel: outOfBandRecord.outOfBandInvitation.v2Invitation?.body?.goal,
-        didcommVersion: 'v2',
-      })
+      const connectionRecord = await this.connectionService.createConnection(
+        this.agentContext,
+        {
+          protocol: DidCommHandshakeProtocol.None,
+          role: DidCommDidExchangeRole.Responder,
+          state: DidCommDidExchangeState.Completed,
+          theirDid: outOfBandRecord.outOfBandInvitation.v2Invitation?.from,
+          did,
+          outOfBandId: outOfBandRecord.id,
+          invitationDid: outOfBandRecord.outOfBandInvitation.v2Invitation?.from,
+          alias: config.alias,
+          theirLabel: outOfBandRecord.outOfBandInvitation.v2Invitation?.body?.goal,
+          didcommVersion: 'v2',
+        },
+        true
+      )
       return connectionRecord
     } else {
       throw new CredoError(`Unsupported handshake protocol ${protocol}.`)


### PR DESCRIPTION
Emit `DidCommConnectionStateChanged` on v2 OOB accept so invitee-side listeners fire in line with v1 and the inviter-side auto-create.