### PR TITLE
feat(didcomm): make DidCommOutOfBandInvitationV2 sendable through a connection

### DIFF
--- a/packages/core/src/storage/migration/__tests__/__snapshots__/0.1.test.ts.snap
+++ b/packages/core/src/storage/migration/__tests__/__snapshots__/0.1.test.ts.snap
@@ -1284,6 +1284,7 @@ exports[`UpdateAssistant | v0.1 - v0.2 > should correctly update the connection 
     "tags": {
       "connectionTypes": [],
       "did": "did:peer:1zQmVxHfU6ZgzxZfwAm6W5t4HKeupKctxpF6FaHgBmnvhEho",
+      "didcommVersion": undefined,
       "invitationDid": "did:peer:2.SeyJzIjoicnhqczphbGljZSIsInQiOiJkaWQtY29tbXVuaWNhdGlvbiIsInByaW9yaXR5IjowLCJyZWNpcGllbnRLZXlzIjpbImRpZDprZXk6ejZNa2ZpUE1QeENRZVNEWkdNa0N2bTFZMnJCb1BzbXc0WkhNdjcxalh0Y1dSUmlNI3o2TWtmaVBNUHhDUWVTRFpHTWtDdm0xWTJyQm9Qc213NFpITXY3MWpYdGNXUlJpTSJdLCJyIjpbXX0",
       "invitationKey": "2G8JohwyJtj69ruWFC3hBkdoaJW5eg31E66ohceVWCvy",
       "mediatorId": undefined,
@@ -1322,6 +1323,7 @@ exports[`UpdateAssistant | v0.1 - v0.2 > should correctly update the connection 
     "tags": {
       "connectionTypes": [],
       "did": "did:peer:1zQmdBUroNDMEZX7An4NZWpuPXsmvYoFm6KkNUr6T2FvoKf2",
+      "didcommVersion": undefined,
       "invitationDid": "did:peer:2.SeyJzIjoicnhqczpmYWJlciIsInQiOiJkaWQtY29tbXVuaWNhdGlvbiIsInByaW9yaXR5IjowLCJyZWNpcGllbnRLZXlzIjpbImRpZDprZXk6ejZNa2ZpUE1QeENRZVNEWkdNa0N2bTFZMnJCb1BzbXc0WkhNdjcxalh0Y1dSUmlNI3o2TWtmaVBNUHhDUWVTRFpHTWtDdm0xWTJyQm9Qc213NFpITXY3MWpYdGNXUlJpTSJdLCJyIjpbXX0",
       "invitationKey": "2G8JohwyJtj69ruWFC3hBkdoaJW5eg31E66ohceVWCvy",
       "mediatorId": undefined,
@@ -1360,6 +1362,7 @@ exports[`UpdateAssistant | v0.1 - v0.2 > should correctly update the connection 
     "tags": {
       "connectionTypes": [],
       "did": "did:peer:1zQmSL5aqVsh36Ei4r8NkohfkMiaPLjtu3jqzRr9pSqnfTkE",
+      "didcommVersion": undefined,
       "invitationDid": "did:peer:2.SeyJzIjoicnhqczphbGljZSIsInQiOiJkaWQtY29tbXVuaWNhdGlvbiIsInByaW9yaXR5IjowLCJyZWNpcGllbnRLZXlzIjpbImRpZDprZXk6ejZNa3RDWkFRTkd2V2I0V0hBandCcVB0WGhaZERZb3JiU0prR1c5dmoxdWh3MUhEI3o2TWt0Q1pBUU5HdldiNFdIQWp3QnFQdFhoWmREWW9yYlNKa0dXOXZqMXVodzFIRCJdLCJyIjpbXX0",
       "invitationKey": "EkJ7p82VB3a3AfuEWGS3gc1dPyY1BZ4PaVEztjwh1nVq",
       "mediatorId": undefined,
@@ -1409,6 +1412,7 @@ exports[`UpdateAssistant | v0.1 - v0.2 > should correctly update the connection 
     "tags": {
       "connectionTypes": [],
       "did": "did:peer:1zQmctp3J5DumzD4DDtirW6LvbEPPLUih2UacpX25wjqvC8e",
+      "didcommVersion": undefined,
       "invitationDid": "did:peer:2.SeyJzIjoicnhqczphbGljZSIsInQiOiJkaWQtY29tbXVuaWNhdGlvbiIsInByaW9yaXR5IjowLCJyZWNpcGllbnRLZXlzIjpbImRpZDprZXk6ejZNa3VXVEVtSDFtVW82Vzk2elNXeUg2MTJoRkhvd1J6TkVzY1BZQkwyQ0NNeUMyI3o2TWt1V1RFbUgxbVVvNlc5NnpTV3lINjEyaEZIb3dSek5Fc2NQWUJMMkNDTXlDMiJdLCJyIjpbXX0",
       "invitationKey": "G4CCB2mL9Fc32c9jqQKF9w9FUEfaaUzWvNdFVkEBSkQe",
       "mediatorId": undefined,
@@ -1443,6 +1447,7 @@ exports[`UpdateAssistant | v0.1 - v0.2 > should correctly update the connection 
     "tags": {
       "connectionTypes": [],
       "did": "did:peer:1zQmfCM4v4QbeYNWSv48dhxxnB6TmAydwj1G4mcS1TrmhBjT",
+      "didcommVersion": undefined,
       "invitationDid": "did:peer:2.SeyJzIjoicnhqczphbGljZSIsInQiOiJkaWQtY29tbXVuaWNhdGlvbiIsInByaW9yaXR5IjowLCJyZWNpcGllbnRLZXlzIjpbImRpZDprZXk6ejZNa28zMURORTNncU1SWmoxSk5odjJCSGIxY2FRc2hjZDluamdLa0VRWHNnRlJwI3o2TWtvMzFETkUzZ3FNUlpqMUpOaHYyQkhiMWNhUXNoY2Q5bmpnS2tFUVhzZ0ZScCJdLCJyIjpbXX0",
       "invitationKey": "9akAmyoFVow6cWTg2M4LSVTckqbrCjuS3fQpQ8Zrm2eS",
       "mediatorId": undefined,
@@ -2404,6 +2409,7 @@ exports[`UpdateAssistant | v0.1 - v0.2 > should correctly update the connection 
     "tags": {
       "connectionTypes": [],
       "did": "did:peer:1zQmfLL2K1xoNdBEcjLCuGH7sq5hUF4zgeWH9WhmZwwucqfa",
+      "didcommVersion": undefined,
       "invitationDid": "did:peer:2.SeyJzIjoicnhqczpmYWJlciIsInQiOiJkaWQtY29tbXVuaWNhdGlvbiIsInByaW9yaXR5IjowLCJyZWNpcGllbnRLZXlzIjpbImRpZDprZXk6ejZNa2pESkw0WDdZR29INmdqYW1oWlIyTnpvd1BacXRKZlg1a1B1TnVXaVZkak1yI3o2TWtqREpMNFg3WUdvSDZnamFtaFpSMk56b3dQWnF0SmZYNWtQdU51V2lWZGpNciJdLCJyIjpbXX0",
       "invitationKey": "5m3HUGs6wFndaEk51zTBXuFwZza2tnGj4NzT5EkUiWaU",
       "mediatorId": undefined,
@@ -2442,6 +2448,7 @@ exports[`UpdateAssistant | v0.1 - v0.2 > should correctly update the connection 
     "tags": {
       "connectionTypes": [],
       "did": "did:peer:1zQmYfrkcLycyPxZZSrSw3LEMYZNLJLD3HjQ1VpSV692bcZx",
+      "didcommVersion": undefined,
       "invitationDid": "did:peer:2.SeyJzIjoicnhqczpmYWJlciIsInQiOiJkaWQtY29tbXVuaWNhdGlvbiIsInByaW9yaXR5IjowLCJyZWNpcGllbnRLZXlzIjpbImRpZDprZXk6ejZNa21vZDh2cDJuVVJWa3RWQzVjZVFleXIyVlV6MjZpdTJaQU5MTlZnOXBNYXdhI3o2TWttb2Q4dnAyblVSVmt0VkM1Y2VRZXlyMlZVejI2aXUyWkFOTE5WZzlwTWF3YSJdLCJyIjpbXX0",
       "invitationKey": "8MN6LZnM8t1HmzMNw5Sp8kUVfQkFK1nCUMRSfQBoSNAC",
       "mediatorId": undefined,

--- a/packages/didcomm/src/modules/connections/__tests__/did-rotate.test.ts
+++ b/packages/didcomm/src/modules/connections/__tests__/did-rotate.test.ts
@@ -691,10 +691,8 @@ describe('DIDComm V2 multi-use OOB inviter-side rotation', () => {
 
     // biome-ignore lint/style/noNonNullAssertion: no explanation
     const firstAccepterDid = (await accepter.didcomm.connections.findById(firstAccepterConnection?.id!))?.did
-    console.log(await accepter.didcomm.connections.findById(firstAccepterConnection?.id!))
     // biome-ignore lint/style/noNonNullAssertion: no explanation
     const secondAccepterDid = (await accepterTwo.didcomm.connections.findById(secondAccepterConnection?.id!))?.did
-    console.log(await accepterTwo.didcomm.connections.findById(secondAccepterConnection?.id!))
     const inviterToFirst = inviterConnections.find((c) => c.theirDid === firstAccepterDid)
     const inviterToSecond = inviterConnections.find((c) => c.theirDid === secondAccepterDid)
     expect(inviterToFirst).toBeDefined()

--- a/packages/didcomm/src/modules/connections/services/DidCommDidRotateV2Service.ts
+++ b/packages/didcomm/src/modules/connections/services/DidCommDidRotateV2Service.ts
@@ -80,7 +80,9 @@ export class DidCommDidRotateV2Service {
       throw new CredoError(`Cannot rotate connection '${connection.id}': no current did`)
     }
     if (connection.didcommVersion !== 'v2') {
-      throw new CredoError(`rotateOurDid only supports v2 connections; '${connection.id}' is ${connection.didcommVersion ?? 'v1'}`)
+      throw new CredoError(
+        `rotateOurDid only supports v2 connections; '${connection.id}' is ${connection.didcommVersion ?? 'v1'}`
+      )
     }
 
     const priorDid = connection.did
@@ -123,7 +125,8 @@ export class DidCommDidRotateV2Service {
     const pending = connection.metadata.get(DidCommConnectionMetadataKeys.DidRotateV2)
     if (!pending) return
     if (!inboundTo?.length || !connection.did) return
-    if (!inboundTo.includes(connection.did) && inboundTo.every((to) => !this.didsEqual(to, connection.did as string))) return
+    if (!inboundTo.includes(connection.did) && inboundTo.every((to) => !this.didsEqual(to, connection.did as string)))
+      return
 
     connection.metadata.delete(DidCommConnectionMetadataKeys.DidRotateV2)
     await agentContext.dependencyManager.resolve(DidCommConnectionService).update(agentContext, connection)
@@ -471,10 +474,7 @@ export class DidCommDidRotateV2Service {
       type: DidCommConnectionEventTypes.DidCommConnectionDidRotated,
       payload: {
         connectionRecord: connectionRecord.clone(),
-        ourDid:
-          previousOurDid && connectionRecord.did
-            ? { from: previousOurDid, to: connectionRecord.did }
-            : undefined,
+        ourDid: previousOurDid && connectionRecord.did ? { from: previousOurDid, to: connectionRecord.did } : undefined,
         theirDid:
           previousTheirDid && connectionRecord.theirDid
             ? { from: previousTheirDid, to: connectionRecord.theirDid }

--- a/packages/didcomm/src/modules/oob/__tests__/OutOfBandInvitationV2.test.ts
+++ b/packages/didcomm/src/modules/oob/__tests__/OutOfBandInvitationV2.test.ts
@@ -1,0 +1,253 @@
+import { JsonTransformer, MessageValidator } from '../../../../../core/src/utils'
+import { buildV2PlaintextFromMessage } from '../../../v2/plaintextBuilder'
+import { DidCommOutOfBandInvitationV2 } from '../messages/DidCommOutOfBandInvitationV2'
+
+describe('DidCommOutOfBandInvitationV2', () => {
+  const FROM = 'did:webvh:Q:host.example'
+  const TYPE_URI = 'https://didcomm.org/out-of-band/2.0/invitation'
+  const buildBody = () => ({ goal: 'g', goalCode: 'gc', accept: ['didcomm/v2'] })
+  const v2Attachment = { id: 'att-1', media_type: 'application/json', data: { json: { foo: 'bar' } } }
+
+  describe('constructor', () => {
+    it('sets id (generated), from, and body fields', () => {
+      const inv = new DidCommOutOfBandInvitationV2({ from: FROM, body: buildBody() })
+      expect(inv.id).toBeDefined()
+      expect(inv.from).toBe(FROM)
+      expect(inv.goal).toBe('g')
+      expect(inv.goalCode).toBe('gc')
+      expect(inv.accept).toEqual(['didcomm/v2'])
+    })
+
+    it('respects custom id', () => {
+      const inv = new DidCommOutOfBandInvitationV2({ id: 'custom-id', from: FROM })
+      expect(inv.id).toBe('custom-id')
+    })
+
+    it('declares supportedDidCommVersions = ["v2"]', () => {
+      const inv = new DidCommOutOfBandInvitationV2({ from: FROM })
+      expect(inv.supportedDidCommVersions).toEqual(['v2'])
+    })
+
+    it('exposes static type as ParsedMessageType', () => {
+      expect(DidCommOutOfBandInvitationV2.type.messageTypeUri).toBe(TYPE_URI)
+    })
+
+    it('stores v2 attachments via the base class ~attach mixin', () => {
+      const inv = new DidCommOutOfBandInvitationV2({ from: FROM, attachments: [v2Attachment] })
+      expect(inv.appendedAttachments).toHaveLength(1)
+      expect(inv.appendedAttachments?.[0].id).toBe('att-1')
+    })
+  })
+
+  describe('attachments getter', () => {
+    it('returns v2-shape array reflecting appendedAttachments', () => {
+      const inv = new DidCommOutOfBandInvitationV2({ from: FROM, attachments: [v2Attachment] })
+      expect(inv.attachments).toHaveLength(1)
+      expect(inv.attachments?.[0]).toMatchObject({
+        id: 'att-1',
+        media_type: 'application/json',
+        data: { json: { foo: 'bar' } },
+      })
+    })
+
+    it('returns undefined when there are no attachments', () => {
+      const inv = new DidCommOutOfBandInvitationV2({ from: FROM })
+      expect(inv.attachments).toBeUndefined()
+    })
+  })
+
+  describe('body getter', () => {
+    it('returns reconstructed body when any field is set', () => {
+      const inv = new DidCommOutOfBandInvitationV2({ from: FROM, body: buildBody() })
+      expect(inv.body).toEqual({ goal: 'g', goalCode: 'gc', accept: ['didcomm/v2'] })
+    })
+
+    it('returns undefined when no body field is set', () => {
+      const inv = new DidCommOutOfBandInvitationV2({ from: FROM })
+      expect(inv.body).toBeUndefined()
+    })
+  })
+
+  describe('toJSON', () => {
+    it('returns v2 wire shape (type/id/from, not @type/@id)', () => {
+      const inv = new DidCommOutOfBandInvitationV2({ from: FROM, body: buildBody() })
+      const json = inv.toJSON() as unknown as Record<string, unknown>
+
+      expect(json.type).toBe(TYPE_URI)
+      expect(json.id).toBe(inv.id)
+      expect(json.from).toBe(FROM)
+      expect(json['@type']).toBeUndefined()
+      expect(json['@id']).toBeUndefined()
+
+      const body = json.body as Record<string, unknown>
+      expect(body.goal_code).toBe('gc')
+      expect(body.goal).toBe('g')
+      expect(body.accept).toEqual(['didcomm/v2'])
+    })
+
+    it('serializes attachments in v2 wire shape', () => {
+      const inv = new DidCommOutOfBandInvitationV2({ from: FROM, attachments: [v2Attachment] })
+      const json = inv.toJSON() as unknown as Record<string, unknown>
+      const attachments = json.attachments as Array<Record<string, unknown>>
+      expect(attachments).toHaveLength(1)
+      expect(attachments[0]).toMatchObject({ id: 'att-1', media_type: 'application/json' })
+    })
+
+    it('omits attachments when there are none', () => {
+      const inv = new DidCommOutOfBandInvitationV2({ from: FROM })
+      const json = inv.toJSON() as unknown as Record<string, unknown>
+      expect(json.attachments).toBeUndefined()
+    })
+  })
+
+  describe('toV2Plaintext', () => {
+    it('returns v2 plaintext with snake_case goal_code', () => {
+      const inv = new DidCommOutOfBandInvitationV2({ from: FROM, body: buildBody() })
+      const v2 = inv.toV2Plaintext()
+      expect(v2.id).toBe(inv.id)
+      expect(v2.type).toBe(TYPE_URI)
+      expect(v2.from).toBe(FROM)
+      expect(v2.body).toEqual({ goal: 'g', goal_code: 'gc', accept: ['didcomm/v2'] })
+    })
+
+    it('includes v2-shape attachments derived from appendedAttachments', () => {
+      const inv = new DidCommOutOfBandInvitationV2({ from: FROM, attachments: [v2Attachment] })
+      const v2 = inv.toV2Plaintext()
+      expect(v2.attachments).toHaveLength(1)
+      expect(v2.attachments?.[0].id).toBe('att-1')
+      expect(v2.attachments?.[0].media_type).toBe('application/json')
+    })
+  })
+
+  describe('buildV2PlaintextFromMessage hook', () => {
+    it('uses toV2Plaintext (avoids the v1 fallback mapping)', () => {
+      const inv = new DidCommOutOfBandInvitationV2({ from: FROM, body: buildBody() })
+      const v2 = buildV2PlaintextFromMessage(inv)
+      expect(v2.type).toBe(TYPE_URI)
+      expect(v2.from).toBe(FROM)
+      expect(v2.body).toMatchObject({ goal_code: 'gc' })
+    })
+  })
+
+  describe('inbound URL/QR path: fromJson', () => {
+    it('hydrates a valid instance from v2 wire JSON', () => {
+      const json = {
+        type: TYPE_URI,
+        id: 'inv-url-12345678',
+        from: FROM,
+        body: { goal: 'g', goal_code: 'gc', accept: ['didcomm/v2'] },
+      }
+      const inv = DidCommOutOfBandInvitationV2.fromJson(json)
+      expect(inv).toBeInstanceOf(DidCommOutOfBandInvitationV2)
+      expect(inv.id).toBe('inv-url-12345678')
+      expect(inv.from).toBe(FROM)
+      expect(inv.goal).toBe('g')
+      expect(inv.goalCode).toBe('gc')
+      expect(() => MessageValidator.validateSync(inv)).not.toThrow()
+    })
+
+    it('preserves v2 attachments through fromJson (PR #2777 contract)', () => {
+      const json = {
+        type: TYPE_URI,
+        id: 'inv-url-attach-1',
+        from: FROM,
+        attachments: [v2Attachment],
+      }
+      const inv = DidCommOutOfBandInvitationV2.fromJson(json)
+      expect(inv.attachments).toHaveLength(1)
+      expect(inv.attachments?.[0]).toMatchObject({ id: 'att-1', media_type: 'application/json' })
+    })
+
+    it('throws on wrong type (JsonTransformer.fromJSON validates by default)', () => {
+      expect(() =>
+        DidCommOutOfBandInvitationV2.fromJson({
+          type: 'https://didcomm.org/wrong/1.0/x',
+          id: 'inv-bad-type-1',
+          from: FROM,
+        })
+      ).toThrow(/type does not match/)
+    })
+
+    it('throws on missing from (JsonTransformer.fromJSON validates by default)', () => {
+      expect(() => DidCommOutOfBandInvitationV2.fromJson({ type: TYPE_URI, id: 'inv-no-from-1' })).toThrow(
+        /from must be a string/
+      )
+    })
+  })
+
+  describe('inbound v2 envelope path: class-transform from post-normalize JSON', () => {
+    it('hydrates a valid instance with all fields populated', () => {
+      // Simulates the post-`normalizeV2PlaintextToV1` JSON that the v2 envelope dispatcher feeds
+      // to class-transformer when an OOB v2 message arrives in-band.
+      const normalized = {
+        '@type': TYPE_URI,
+        '@id': 'inv-envelope-12345',
+        from: FROM,
+        goal: 'g',
+        goal_code: 'gc',
+        accept: ['didcomm/v2'],
+      }
+      const inv = JsonTransformer.fromJSON(normalized, DidCommOutOfBandInvitationV2)
+      expect(inv).toBeInstanceOf(DidCommOutOfBandInvitationV2)
+      expect(inv.id).toBe('inv-envelope-12345')
+      expect(inv.from).toBe(FROM)
+      expect(inv.goal).toBe('g')
+      expect(inv.goalCode).toBe('gc')
+      expect(inv.accept).toEqual(['didcomm/v2'])
+      expect(() => MessageValidator.validateSync(inv)).not.toThrow()
+    })
+
+    it('exposes envelope-borne ~attach as v2-shape attachments via the getter', () => {
+      // Post-normalize JSON: attachments arrive as v1-shaped `~attach`, base class mixin
+      // populates `appendedAttachments`, getter surfaces them in v2 shape.
+      const normalized = {
+        '@type': TYPE_URI,
+        '@id': 'inv-envelope-attach',
+        from: FROM,
+        '~attach': [{ '@id': 'att-env-1', 'mime-type': 'application/json', data: { json: { hi: 1 } } }],
+      }
+      const inv = JsonTransformer.fromJSON(normalized, DidCommOutOfBandInvitationV2)
+      expect(inv.appendedAttachments).toHaveLength(1)
+      expect(inv.attachments).toHaveLength(1)
+      expect(inv.attachments?.[0]).toMatchObject({
+        id: 'att-env-1',
+        media_type: 'application/json',
+        data: { json: { hi: 1 } },
+      })
+    })
+  })
+
+  describe('toUrl / fromUrl roundtrip', () => {
+    it('encodes the v2 shape under _oob and parses back losslessly', () => {
+      const original = new DidCommOutOfBandInvitationV2({ from: FROM, body: buildBody() })
+      const url = original.toUrl({ domain: 'https://example.com' })
+
+      expect(url).toMatch(/^https:\/\/example\.com\?_oob=/)
+
+      const parsed = DidCommOutOfBandInvitationV2.fromUrl(url)
+      expect(parsed.id).toBe(original.id)
+      expect(parsed.from).toBe(original.from)
+      expect(parsed.body?.goal).toBe('g')
+      expect(parsed.body?.goalCode).toBe('gc')
+      expect(parsed.body?.accept).toEqual(['didcomm/v2'])
+    })
+
+    it('preserves attachments through toUrl → fromUrl', () => {
+      const original = new DidCommOutOfBandInvitationV2({
+        from: FROM,
+        body: buildBody(),
+        attachments: [v2Attachment],
+      })
+      const parsed = DidCommOutOfBandInvitationV2.fromUrl(original.toUrl({ domain: 'https://example.com' }))
+      expect(parsed.attachments).toHaveLength(1)
+      expect(parsed.attachments?.[0]).toMatchObject({ id: 'att-1', media_type: 'application/json' })
+    })
+  })
+
+  describe('validation', () => {
+    it('passes MessageValidator on a well-formed instance', () => {
+      const inv = new DidCommOutOfBandInvitationV2({ from: FROM, body: buildBody() })
+      expect(() => MessageValidator.validateSync(inv)).not.toThrow()
+    })
+  })
+})

--- a/packages/didcomm/src/modules/oob/messages/DidCommOutOfBandInvitationV2.ts
+++ b/packages/didcomm/src/modules/oob/messages/DidCommOutOfBandInvitationV2.ts
@@ -1,12 +1,15 @@
-import { CredoError, JsonEncoder } from '@credo-ts/core'
+import { CredoError, JsonEncoder, JsonTransformer } from '@credo-ts/core'
 import { Expose } from 'class-transformer'
 import { IsOptional, IsString } from 'class-validator'
 import queryString from 'query-string'
 
 import { DidCommMessage } from '../../../DidCommMessage'
+import { DidCommAttachment } from '../../../decorators/attachment/DidCommAttachment'
 import type { DidCommPlaintextMessage } from '../../../types'
 import type { DidCommVersion } from '../../../util/didcommVersion'
 import { IsValidMessageType, parseMessageType } from '../../../util/messageType'
+import { normalizeV2PlaintextToV1 } from '../../../v2/normalize'
+import { mapV1AttachmentToV2, mapV2AttachmentToV1 } from '../../../v2/plaintextBuilder'
 import type { DidCommV2Attachment, DidCommV2PlaintextMessage } from '../../../v2/types'
 
 const LINK_PARAM = '_oob'
@@ -40,7 +43,11 @@ export class DidCommOutOfBandInvitationV2 extends DidCommMessage {
       this.goal = options.body?.goal
       this.goalCode = options.body?.goalCode
       this.accept = options.body?.accept
-      this.attachments = options.attachments
+      if (options.attachments) {
+        for (const v2Att of options.attachments) {
+          this.addAppendedAttachment(JsonTransformer.fromJSON(mapV2AttachmentToV1(v2Att), DidCommAttachment))
+        }
+      }
     }
   }
 
@@ -48,6 +55,7 @@ export class DidCommOutOfBandInvitationV2 extends DidCommMessage {
   public readonly type = DidCommOutOfBandInvitationV2.type.messageTypeUri
   public static readonly type = parseMessageType('https://didcomm.org/out-of-band/2.0/invitation')
 
+  @IsString()
   public declare from: string
 
   @Expose({ name: 'goal' })
@@ -65,16 +73,20 @@ export class DidCommOutOfBandInvitationV2 extends DidCommMessage {
   @IsOptional()
   public accept?: string[]
 
-  @Expose({ name: 'attachments' })
-  @IsOptional()
-  public attachments?: DidCommV2Attachment[]
-
   public get body(): DidCommOutOfBandInvitationV2Body | undefined {
     if (this.goal === undefined && this.goalCode === undefined && this.accept === undefined) return undefined
     return { goal: this.goal, goalCode: this.goalCode, accept: this.accept }
   }
 
+  public get attachments(): DidCommV2Attachment[] | undefined {
+    if (!this.appendedAttachments?.length) return undefined
+    return this.appendedAttachments.map((att) =>
+      mapV1AttachmentToV2(JsonTransformer.toJSON(att) as Record<string, unknown>)
+    )
+  }
+
   public toJSON(): DidCommPlaintextMessage {
+    const attachments = this.attachments
     const wire = {
       type: DidCommOutOfBandInvitationV2.type.messageTypeUri,
       id: this.id,
@@ -86,7 +98,7 @@ export class DidCommOutOfBandInvitationV2 extends DidCommMessage {
             accept: this.accept,
           }
         : undefined,
-      attachments: this.attachments && this.attachments.length > 0 ? this.attachments : undefined,
+      attachments,
     }
     return wire as unknown as DidCommPlaintextMessage
   }
@@ -102,7 +114,8 @@ export class DidCommOutOfBandInvitationV2 extends DidCommMessage {
       from: this.from,
       body,
     }
-    if (this.attachments && this.attachments.length > 0) plaintext.attachments = this.attachments
+    const attachments = this.attachments
+    if (attachments) plaintext.attachments = attachments
     return plaintext
   }
 
@@ -112,27 +125,10 @@ export class DidCommOutOfBandInvitationV2 extends DidCommMessage {
   }
 
   public static fromJson(json: Record<string, unknown>): DidCommOutOfBandInvitationV2 {
-    const type = json.type as string
-    if (type !== DidCommOutOfBandInvitationV2.type.messageTypeUri) {
-      throw new CredoError(
-        `Invalid v2 OOB invitation type: expected ${DidCommOutOfBandInvitationV2.type.messageTypeUri}, got ${type}`
-      )
-    }
-    const id = json.id as string
-    const from = json.from as string
-    if (!from) {
-      throw new CredoError('Invalid v2 OOB invitation: missing from')
-    }
-    const bodyJson = json.body as Record<string, unknown> | undefined
-    const body = bodyJson
-      ? {
-          goalCode: bodyJson.goal_code as string | undefined,
-          goal: bodyJson.goal as string | undefined,
-          accept: bodyJson.accept as string[] | undefined,
-        }
-      : undefined
-    const attachments = Array.isArray(json.attachments) ? (json.attachments as DidCommV2Attachment[]) : undefined
-    return new DidCommOutOfBandInvitationV2({ id, from, body, attachments })
+    return JsonTransformer.fromJSON(
+      normalizeV2PlaintextToV1(json as DidCommV2PlaintextMessage),
+      DidCommOutOfBandInvitationV2
+    )
   }
 
   public static fromUrl(invitationUrl: string): DidCommOutOfBandInvitationV2 {

--- a/packages/didcomm/src/modules/oob/messages/DidCommOutOfBandInvitationV2.ts
+++ b/packages/didcomm/src/modules/oob/messages/DidCommOutOfBandInvitationV2.ts
@@ -1,6 +1,13 @@
-import { CredoError, JsonEncoder, utils } from '@credo-ts/core'
+import { CredoError, JsonEncoder } from '@credo-ts/core'
+import { Expose } from 'class-transformer'
+import { IsOptional, IsString } from 'class-validator'
 import queryString from 'query-string'
-import type { DidCommV2Attachment } from '../../../v2/types'
+
+import { DidCommMessage } from '../../../DidCommMessage'
+import type { DidCommPlaintextMessage } from '../../../types'
+import type { DidCommVersion } from '../../../util/didcommVersion'
+import { IsValidMessageType, parseMessageType } from '../../../util/messageType'
+import type { DidCommV2Attachment, DidCommV2PlaintextMessage } from '../../../v2/types'
 
 const LINK_PARAM = '_oob'
 
@@ -19,51 +26,97 @@ export interface DidCommOutOfBandInvitationV2Options {
 
 /**
  * DIDComm v2 Out-of-Band Invitation (https://didcomm.org/out-of-band/2.0/invitation).
- * Structure: { type, id, from, body: { goal_code, goal, accept }, attachments? }.
+ * Wire structure: { type, id, from, body: { goal_code, goal, accept }, attachments? }.
  */
-export class DidCommOutOfBandInvitationV2 {
-  public static readonly type = 'https://didcomm.org/out-of-band/2.0/invitation'
-
-  public id!: string
-  public from!: string
-  public body?: DidCommOutOfBandInvitationV2Body
-  public attachments?: DidCommV2Attachment[]
+export class DidCommOutOfBandInvitationV2 extends DidCommMessage {
+  public readonly allowDidSovPrefix = false
+  public readonly supportedDidCommVersions: DidCommVersion[] = ['v2']
 
   public constructor(options?: DidCommOutOfBandInvitationV2Options) {
+    super()
     if (options) {
-      this.id = options.id ?? utils.uuid()
+      this.id = options.id ?? this.generateId()
       this.from = options.from
-      this.body = options.body
+      this.goal = options.body?.goal
+      this.goalCode = options.body?.goalCode
+      this.accept = options.body?.accept
       this.attachments = options.attachments
     }
   }
 
-  public toJSON(): Record<string, unknown> {
-    return {
-      type: DidCommOutOfBandInvitationV2.type,
+  @IsValidMessageType(DidCommOutOfBandInvitationV2.type)
+  public readonly type = DidCommOutOfBandInvitationV2.type.messageTypeUri
+  public static readonly type = parseMessageType('https://didcomm.org/out-of-band/2.0/invitation')
+
+  public declare from: string
+
+  @Expose({ name: 'goal' })
+  @IsString()
+  @IsOptional()
+  public goal?: string
+
+  @Expose({ name: 'goal_code' })
+  @IsString()
+  @IsOptional()
+  public goalCode?: string
+
+  @Expose({ name: 'accept' })
+  @IsString({ each: true })
+  @IsOptional()
+  public accept?: string[]
+
+  @Expose({ name: 'attachments' })
+  @IsOptional()
+  public attachments?: DidCommV2Attachment[]
+
+  public get body(): DidCommOutOfBandInvitationV2Body | undefined {
+    if (this.goal === undefined && this.goalCode === undefined && this.accept === undefined) return undefined
+    return { goal: this.goal, goalCode: this.goalCode, accept: this.accept }
+  }
+
+  public toJSON(): DidCommPlaintextMessage {
+    const wire = {
+      type: DidCommOutOfBandInvitationV2.type.messageTypeUri,
       id: this.id,
       from: this.from,
       body: this.body
         ? {
-            goal_code: this.body.goalCode,
-            goal: this.body.goal,
-            accept: this.body.accept,
+            goal_code: this.goalCode,
+            goal: this.goal,
+            accept: this.accept,
           }
         : undefined,
       attachments: this.attachments && this.attachments.length > 0 ? this.attachments : undefined,
     }
+    return wire as unknown as DidCommPlaintextMessage
+  }
+
+  public toV2Plaintext(): DidCommV2PlaintextMessage {
+    const body: Record<string, unknown> = {}
+    if (this.goal !== undefined) body.goal = this.goal
+    if (this.goalCode !== undefined) body.goal_code = this.goalCode
+    if (this.accept !== undefined) body.accept = this.accept
+    const plaintext: DidCommV2PlaintextMessage = {
+      id: this.id,
+      type: DidCommOutOfBandInvitationV2.type.messageTypeUri,
+      from: this.from,
+      body,
+    }
+    if (this.attachments && this.attachments.length > 0) plaintext.attachments = this.attachments
+    return plaintext
   }
 
   public toUrl({ domain }: { domain: string }): string {
-    const invitationJson = this.toJSON()
-    const encodedInvitation = JsonEncoder.toBase64Url(invitationJson)
+    const encodedInvitation = JsonEncoder.toBase64Url(this.toJSON())
     return `${domain}?${LINK_PARAM}=${encodedInvitation}`
   }
 
   public static fromJson(json: Record<string, unknown>): DidCommOutOfBandInvitationV2 {
     const type = json.type as string
-    if (type !== DidCommOutOfBandInvitationV2.type) {
-      throw new CredoError(`Invalid v2 OOB invitation type: expected ${DidCommOutOfBandInvitationV2.type}, got ${type}`)
+    if (type !== DidCommOutOfBandInvitationV2.type.messageTypeUri) {
+      throw new CredoError(
+        `Invalid v2 OOB invitation type: expected ${DidCommOutOfBandInvitationV2.type.messageTypeUri}, got ${type}`
+      )
     }
     const id = json.id as string
     const from = json.from as string
@@ -86,7 +139,7 @@ export class DidCommOutOfBandInvitationV2 {
     const parsedUrl = queryString.parseUrl(invitationUrl).query
     const encodedInvitation = parsedUrl[LINK_PARAM]
     if (typeof encodedInvitation === 'string') {
-      const invitationJson = JsonEncoder.fromBase64(encodedInvitation) as Record<string, unknown>
+      const invitationJson = JsonEncoder.fromBase64Url(encodedInvitation) as Record<string, unknown>
       return DidCommOutOfBandInvitationV2.fromJson(invitationJson)
     }
     throw new CredoError(

--- a/packages/didcomm/src/util/parseInvitation.ts
+++ b/packages/didcomm/src/util/parseInvitation.ts
@@ -40,7 +40,7 @@ const fetchShortUrl = async (invitationUrl: string, dependencies: AgentDependenc
 export const parseInvitationJson = (invitationJson: Record<string, unknown>): DidCommOutOfBandInvitation => {
   // DIDComm v2 OOB uses "type" not "@type"
   const v2Type = invitationJson.type as string
-  if (v2Type === DidCommOutOfBandInvitationV2.type) {
+  if (v2Type === DidCommOutOfBandInvitationV2.type.messageTypeUri) {
     const v2Invitation = DidCommOutOfBandInvitationV2.fromJson(invitationJson)
     return convertV2InvitationToOutOfBandInvitation(v2Invitation)
   }

--- a/packages/didcomm/src/util/parseInvitation.ts
+++ b/packages/didcomm/src/util/parseInvitation.ts
@@ -42,6 +42,7 @@ export const parseInvitationJson = (invitationJson: Record<string, unknown>): Di
   const v2Type = invitationJson.type as string
   if (v2Type === DidCommOutOfBandInvitationV2.type.messageTypeUri) {
     const v2Invitation = DidCommOutOfBandInvitationV2.fromJson(invitationJson)
+    MessageValidator.validateSync(v2Invitation)
     return convertV2InvitationToOutOfBandInvitation(v2Invitation)
   }
 


### PR DESCRIPTION
`DidCommOutOfBandInvitationV2` was a plain class, so v2 OOB invitations couldn't be passed to `messageSender.sendMessage()`. To send a v2 OOB through an existing v2 connection consumers had to wrap it via `convertV2InvitationToOutOfBandInvitation` and send the v1 wrapper, producing `out-of-band/1.1/invitation` on the wire even for v2 to v2 flows.

This change makes it a `DidCommMessage` subclass mirroring `DidCommBasicMessageV2`.


Some additional types + style fixes are present too