### PR TITLE
fix(webvh): store update key kms ids on create

### DIFF
--- a/packages/webvh/src/dids/WebVhDidRegistrar.ts
+++ b/packages/webvh/src/dids/WebVhDidRegistrar.ts
@@ -108,6 +108,7 @@ export class WebVhDidRegistrar implements DidRegistrar {
         keys,
       })
       didRecord.metadata.set(WebVhDidRecordMetadataKeys.DidLog, log)
+      didRecord.metadata.set(WebVhDidRecordMetadataKeys.UpdateKeyKmsKeyIds, { [publicKeyMultibase]: keyId })
       didRecord.setTags({ domain: domainKey })
       await didRepository.save(agentContext, didRecord)
 


### PR DESCRIPTION
Adds the missing `UpdateKeyKmsKeyIds` metadata assignment to the DID creation flow, ensuring update key references are stored consistently during record initialization.