### PR TITLE
fix(didcomm): respect message-level from/to/from_prior in buildV2PlaintextFromMessage

### DIFF
--- a/packages/didcomm/src/v2/plaintextBuilder.ts
+++ b/packages/didcomm/src/v2/plaintextBuilder.ts
@@ -65,9 +65,13 @@ export function buildV2PlaintextFromMessage(
   const v2Native = message as unknown as { toV2Plaintext?: () => DidCommV2PlaintextMessage }
   if (typeof v2Native.toV2Plaintext === 'function') {
     const plaintext = v2Native.toV2Plaintext()
-    if (config?.from !== undefined) plaintext.from = config.from
-    if (config?.to !== undefined) plaintext.to = Array.isArray(config.to) ? config.to : [config.to]
-    if (config?.fromPrior !== undefined) plaintext.from_prior = config.fromPrior
+    if (plaintext.from === undefined && config?.from !== undefined) plaintext.from = config.from
+    if (plaintext.to === undefined && config?.to !== undefined) {
+      plaintext.to = Array.isArray(config.to) ? config.to : [config.to]
+    }
+    if (plaintext.from_prior === undefined && config?.fromPrior !== undefined) {
+      plaintext.from_prior = config.fromPrior
+    }
     return plaintext
   }
 


### PR DESCRIPTION
When a v2 DIDComm message that sets its own from is sent through an existing connection, credo's plaintextBuilder silently overwrites the message's from with the sending connection's DID.