### PR TITLE
feat(didcomm-v2): add A256CBC-HS512 content encryption and apu/apv headers

### DIFF
--- a/packages/askar/src/kms/AskarKeyManagementService.ts
+++ b/packages/askar/src/kms/AskarKeyManagementService.ts
@@ -467,11 +467,22 @@ export class AskarKeyManagementService implements Kms.KeyManagementService {
           keysToFree.push(privateKey)
         }
 
+        let ephemeralKey: Key | undefined
+        if (
+          key.keyAgreement.algorithm === 'ECDH-1PU+A256KW' &&
+          'ephemeralKeyId' in key.keyAgreement &&
+          key.keyAgreement.ephemeralKeyId
+        ) {
+          ephemeralKey = (await this.getKeyAsserted(agentContext, key.keyAgreement.ephemeralKeyId)).key
+          keysToFree.push(ephemeralKey)
+        }
+
         const { contentEncryptionKey, encryptedContentEncryptionKey } = deriveEncryptionKey({
           encryption,
           keyAgreement: key.keyAgreement,
           recipientKey,
           senderKey: privateKey,
+          ephemeralKey,
         })
 
         encryptionKey = contentEncryptionKey

--- a/packages/askar/src/kms/AskarKeyManagementService.ts
+++ b/packages/askar/src/kms/AskarKeyManagementService.ts
@@ -13,7 +13,12 @@ import {
 import { AskarStoreManager } from '../AskarStoreManager'
 import { AskarErrorCode, isAskarError, jwkCrvToAskarAlg, jwkEncToAskarAlg } from '../utils'
 import { aeadDecrypt } from './crypto/decrypt'
-import { askarSupportedKeyAgreementAlgorithms, deriveDecryptionKey, deriveEncryptionKey } from './crypto/deriveKey'
+import {
+  askarSupportedKeyAgreementAlgorithms,
+  deriveDecryptionKey,
+  deriveEncryptionKey,
+  encryptEcdh1Pu,
+} from './crypto/deriveKey'
 import { type AskarSupportedEncryptionOptions, aeadEncrypt } from './crypto/encrypt'
 import { randomBytes } from './crypto/randomBytes'
 
@@ -467,14 +472,24 @@ export class AskarKeyManagementService implements Kms.KeyManagementService {
           keysToFree.push(privateKey)
         }
 
-        let ephemeralKey: Key | undefined
-        if (
-          key.keyAgreement.algorithm === 'ECDH-1PU+A256KW' &&
-          'ephemeralKeyId' in key.keyAgreement &&
-          key.keyAgreement.ephemeralKeyId
-        ) {
-          ephemeralKey = (await this.getKeyAsserted(agentContext, key.keyAgreement.ephemeralKeyId)).key
-          keysToFree.push(ephemeralKey)
+        // ECDH-1PU+A256KW binds the JWE Authentication Tag into the KDF per draft-madden, so
+        // content encryption has to happen before key derivation. encryptEcdh1Pu does the full
+        // atomic flow (CEK gen, content encrypt, KEK derive with tag, CEK wrap) and short-circuits
+        // the rest of this method.
+        if (key.keyAgreement.algorithm === 'ECDH-1PU+A256KW') {
+          let ephemeralKey: Key | undefined
+          if ('ephemeralKeyId' in key.keyAgreement && key.keyAgreement.ephemeralKeyId) {
+            ephemeralKey = (await this.getKeyAsserted(agentContext, key.keyAgreement.ephemeralKeyId)).key
+            keysToFree.push(ephemeralKey)
+          }
+          return encryptEcdh1Pu({
+            keyAgreement: key.keyAgreement,
+            encryption: encryption as AskarSupportedEncryptionOptions,
+            senderKey: privateKey,
+            recipientKey,
+            data,
+            ephemeralKey,
+          })
         }
 
         const { contentEncryptionKey, encryptedContentEncryptionKey } = deriveEncryptionKey({
@@ -482,7 +497,6 @@ export class AskarKeyManagementService implements Kms.KeyManagementService {
           keyAgreement: key.keyAgreement,
           recipientKey,
           senderKey: privateKey,
-          ephemeralKey,
         })
 
         encryptionKey = contentEncryptionKey

--- a/packages/askar/src/kms/crypto/deriveKey.ts
+++ b/packages/askar/src/kms/crypto/deriveKey.ts
@@ -1,6 +1,7 @@
 import { Kms, TypedArrayEncoder } from '@credo-ts/core'
 import { askar, Key, KeyAlgorithm } from '@openwallet-foundation/askar-shared'
 import { jwkEncToAskarAlg } from '../../utils'
+import { type AskarSupportedEncryptionOptions, aeadEncrypt } from './encrypt'
 
 export const askarSupportedKeyAgreementAlgorithms = [
   'ECDH-ES',
@@ -18,14 +19,21 @@ type AskarSupportedKeyAgreementDecryptOptions = Kms.KmsKeyAgreementDecryptOption
   algorithm: (typeof askarSupportedKeyAgreementAlgorithms)[number]
 }
 
-function deriveEncryptionKeyEcdh1Pu(options: {
+/**
+ * Full ECDH-1PU+A256KW encrypt flow per draft-madden-jose-ecdh-1pu-04 §2.3:
+ * encrypt content with a fresh CEK first, then derive the KEK with the resulting JWE
+ * Authentication Tag bound into SuppPubInfo, then wrap the CEK with that KEK. The KEK
+ * cannot be derived before content encryption because it depends on the tag.
+ */
+export function encryptEcdh1Pu(options: {
   keyAgreement: AskarSupportedKeyAgreementEncryptOptions & { algorithm: 'ECDH-1PU+A256KW' }
-  encryption: Kms.KmsEncryptDataEncryption
+  encryption: AskarSupportedEncryptionOptions
   senderKey: Key
   recipientKey: Key
+  data: Uint8Array
   ephemeralKey?: Key
 }) {
-  const { keyAgreement, encryption, senderKey, recipientKey, ephemeralKey: providedEphemeralKey } = options
+  const { keyAgreement, encryption, senderKey, recipientKey, data, ephemeralKey: providedEphemeralKey } = options
 
   if (senderKey.algorithm !== KeyAlgorithm.X25519 || recipientKey.algorithm !== KeyAlgorithm.X25519) {
     throw new Kms.KeyManagementAlgorithmNotSupportedError(
@@ -50,46 +58,46 @@ function deriveEncryptionKeyEcdh1Pu(options: {
   const apv = keyAgreement.apv ? new Uint8Array(keyAgreement.apv) : new Uint8Array([])
   const algId = TypedArrayEncoder.fromUtf8String('ECDH-1PU+A256KW')
 
-  const derivedKey = new Key(
-    askar.keyDeriveEcdh1pu({
-      algorithm: KeyAlgorithm.AesA256Kw,
-      ephemeralKey,
-      senderKey,
-      recipientKey,
-      algId,
-      apu,
-      apv,
-      receive: false,
-    })
-  )
-
-  let contentEncryptionKey: Key | undefined
-  let encryptedContentEncryptionKey: Kms.KmsEncryptedKey | undefined
+  const contentEncryptionKey = Key.generate(askarEncryptionAlgorithm)
+  let derivedKey: Key | undefined
   try {
-    contentEncryptionKey = Key.generate(askarEncryptionAlgorithm)
-    const wrappedKey = derivedKey.wrapKey({
-      other: contentEncryptionKey,
-    })
-    const epkBytes = ephemeralKey.publicBytes
+    const aeadResult = aeadEncrypt({ key: contentEncryptionKey, data, encryption })
+
+    derivedKey = new Key(
+      askar.keyDeriveEcdh1pu({
+        algorithm: KeyAlgorithm.AesA256Kw,
+        ephemeralKey,
+        senderKey,
+        recipientKey,
+        algId,
+        apu,
+        apv,
+        ccTag: aeadResult.tag,
+        receive: false,
+      })
+    )
+    const wrappedKey = derivedKey.wrapKey({ other: contentEncryptionKey })
     const ephemeralPublicKey = {
       kty: 'OKP',
       crv: 'X25519',
-      x: TypedArrayEncoder.toBase64Url(epkBytes),
+      x: TypedArrayEncoder.toBase64Url(ephemeralKey.publicBytes),
     } as const
-    encryptedContentEncryptionKey = {
-      encrypted: new Uint8Array(wrappedKey.ciphertext),
-      iv: wrappedKey.nonce ? new Uint8Array(wrappedKey.nonce) : undefined,
-      tag: wrappedKey.tag ? new Uint8Array(wrappedKey.tag) : undefined,
-      ephemeralPublicKey,
-    }
+
     return {
-      contentEncryptionKey,
-      encryptedContentEncryptionKey,
+      encrypted: aeadResult.encrypted,
+      iv: aeadResult.iv,
+      tag: aeadResult.tag,
+      encryptedKey: {
+        encrypted: new Uint8Array(wrappedKey.ciphertext),
+        iv: wrappedKey.nonce ? new Uint8Array(wrappedKey.nonce) : undefined,
+        tag: wrappedKey.tag ? new Uint8Array(wrappedKey.tag) : undefined,
+        ephemeralPublicKey,
+      } satisfies Kms.KmsEncryptedKey,
     }
   } finally {
     if (ownsEphemeralKey) ephemeralKey.handle.free()
-    derivedKey.handle.free()
-    // contentEncryptionKey is returned to caller; they free it.
+    derivedKey?.handle.free()
+    contentEncryptionKey.handle.free()
   }
 }
 
@@ -98,9 +106,8 @@ export function deriveEncryptionKey(options: {
   senderKey: Key
   recipientKey: Key
   encryption: Kms.KmsEncryptDataEncryption
-  ephemeralKey?: Key
 }) {
-  const { keyAgreement, encryption, senderKey, recipientKey, ephemeralKey } = options
+  const { keyAgreement, encryption, senderKey, recipientKey } = options
 
   const askarEncryptionAlgorithm = jwkEncToAskarAlg[encryption.algorithm as keyof typeof jwkEncToAskarAlg]
   if (!askarEncryptionAlgorithm) {
@@ -118,15 +125,11 @@ export function deriveEncryptionKey(options: {
     )
   }
 
-  // ECDH-1PU+A256KW: derive KEK via askar.keyDeriveEcdh1pu (using caller's ephemeral if supplied), wrap CEK
+  // ECDH-1PU+A256KW requires the JWE Authentication Tag in the KDF, so it goes through encryptEcdh1Pu
+  // which performs content encryption + key wrapping atomically. Callers that reach this dispatcher
+  // with 1PU are programming errors.
   if (keyAgreement.algorithm === 'ECDH-1PU+A256KW') {
-    return deriveEncryptionKeyEcdh1Pu({
-      keyAgreement,
-      encryption,
-      senderKey,
-      recipientKey,
-      ephemeralKey,
-    })
+    throw new Kms.KeyManagementError('Use encryptEcdh1Pu for ECDH-1PU+A256KW; deriveEncryptionKey only handles ECDH-ES')
   }
 
   const askarKeyWrappingAlgorithm =
@@ -300,6 +303,10 @@ function deriveDecryptionKeyEcdh1Pu(options: {
   const apu = keyAgreement.apu ? new Uint8Array(keyAgreement.apu) : new Uint8Array([])
   const apv = keyAgreement.apv ? new Uint8Array(keyAgreement.apv) : new Uint8Array([])
   const algId = TypedArrayEncoder.fromUtf8String('ECDH-1PU+A256KW')
+  // draft-madden-jose-ecdh-1pu-04 binds the JWE Authentication Tag into the KDF SuppPubInfo
+  // for the Key Wrapping variants of ECDH-1PU.
+  const decryptionTag = 'tag' in decryption ? decryption.tag : undefined
+  const ccTag = decryptionTag ? new Uint8Array(decryptionTag) : undefined
 
   const derivedKey = new Key(
     askar.keyDeriveEcdh1pu({
@@ -310,6 +317,7 @@ function deriveDecryptionKeyEcdh1Pu(options: {
       algId,
       apu,
       apv,
+      ccTag,
       receive: true,
     })
   )

--- a/packages/askar/src/kms/crypto/deriveKey.ts
+++ b/packages/askar/src/kms/crypto/deriveKey.ts
@@ -23,14 +23,18 @@ function deriveEncryptionKeyEcdh1Pu(options: {
   encryption: Kms.KmsEncryptDataEncryption
   senderKey: Key
   recipientKey: Key
+  ephemeralKey?: Key
 }) {
-  const { keyAgreement, encryption, senderKey, recipientKey } = options
+  const { keyAgreement, encryption, senderKey, recipientKey, ephemeralKey: providedEphemeralKey } = options
 
   if (senderKey.algorithm !== KeyAlgorithm.X25519 || recipientKey.algorithm !== KeyAlgorithm.X25519) {
     throw new Kms.KeyManagementAlgorithmNotSupportedError(
       'ECDH-1PU+A256KW requires X25519 sender and recipient keys',
       'askar'
     )
+  }
+  if (providedEphemeralKey && providedEphemeralKey.algorithm !== KeyAlgorithm.X25519) {
+    throw new Kms.KeyManagementAlgorithmNotSupportedError('ECDH-1PU+A256KW requires an X25519 ephemeral key', 'askar')
   }
   const askarEncryptionAlgorithm = jwkEncToAskarAlg[encryption.algorithm as keyof typeof jwkEncToAskarAlg]
   if (!askarEncryptionAlgorithm) {
@@ -40,7 +44,8 @@ function deriveEncryptionKeyEcdh1Pu(options: {
     )
   }
 
-  const ephemeralKey = Key.generate(KeyAlgorithm.X25519)
+  const ephemeralKey = providedEphemeralKey ?? Key.generate(KeyAlgorithm.X25519)
+  const ownsEphemeralKey = !providedEphemeralKey
   const apu = keyAgreement.apu ? new Uint8Array(keyAgreement.apu) : new Uint8Array([])
   const apv = keyAgreement.apv ? new Uint8Array(keyAgreement.apv) : new Uint8Array([])
   const algId = TypedArrayEncoder.fromUtf8String('ECDH-1PU+A256KW')
@@ -82,7 +87,7 @@ function deriveEncryptionKeyEcdh1Pu(options: {
       encryptedContentEncryptionKey,
     }
   } finally {
-    ephemeralKey.handle.free()
+    if (ownsEphemeralKey) ephemeralKey.handle.free()
     derivedKey.handle.free()
     // contentEncryptionKey is returned to caller; they free it.
   }
@@ -93,8 +98,9 @@ export function deriveEncryptionKey(options: {
   senderKey: Key
   recipientKey: Key
   encryption: Kms.KmsEncryptDataEncryption
+  ephemeralKey?: Key
 }) {
-  const { keyAgreement, encryption, senderKey, recipientKey } = options
+  const { keyAgreement, encryption, senderKey, recipientKey, ephemeralKey } = options
 
   const askarEncryptionAlgorithm = jwkEncToAskarAlg[encryption.algorithm as keyof typeof jwkEncToAskarAlg]
   if (!askarEncryptionAlgorithm) {
@@ -112,13 +118,14 @@ export function deriveEncryptionKey(options: {
     )
   }
 
-  // ECDH-1PU+A256KW: generate ephemeral key, derive KEK via askar.keyDeriveEcdh1pu, wrap CEK
+  // ECDH-1PU+A256KW: derive KEK via askar.keyDeriveEcdh1pu (using caller's ephemeral if supplied), wrap CEK
   if (keyAgreement.algorithm === 'ECDH-1PU+A256KW') {
     return deriveEncryptionKeyEcdh1Pu({
       keyAgreement,
       encryption,
       senderKey,
       recipientKey,
+      ephemeralKey,
     })
   }
 

--- a/packages/core/src/modules/kms/options/KmsKeyAgreementEncryptOptions.ts
+++ b/packages/core/src/modules/kms/options/KmsKeyAgreementEncryptOptions.ts
@@ -68,6 +68,13 @@ const zKmsKeyAgreementEncryptEcdh1Pu = z.object({
   algorithm: z.literal('ECDH-1PU+A256KW'),
   externalPublicJwk: zKmsJwkPublicOkp.extend({ crv: zKmsJwkPublicOkp.shape.crv.extract(['X25519']) }),
 
+  /**
+   * Optional id of a caller-provided ephemeral key. When set, the KMS uses this key for the
+   * ECDH-1PU agreement instead of generating one internally; the caller can then read its
+   * public component to embed in the JWE protected header before computing AAD.
+   */
+  ephemeralKeyId: zKmsKeyId.optional(),
+
   apu: z.optional(zAnyUint8Array),
   apv: z.optional(zAnyUint8Array),
 })

--- a/packages/didcomm/package.json
+++ b/packages/didcomm/package.json
@@ -39,6 +39,8 @@
   },
   "devDependencies": {
     "@animo-id/pex": "catalog:",
+    "@openwallet-foundation/askar-nodejs": "catalog:",
+    "@openwallet-foundation/askar-shared": "catalog:",
     "@sphereon/pex-models": "catalog:",
     "@types/luxon": "^3.7.1",
     "reflect-metadata": "catalog:",

--- a/packages/didcomm/package.json
+++ b/packages/didcomm/package.json
@@ -40,7 +40,6 @@
   "devDependencies": {
     "@animo-id/pex": "catalog:",
     "@openwallet-foundation/askar-nodejs": "catalog:",
-    "@openwallet-foundation/askar-shared": "catalog:",
     "@sphereon/pex-models": "catalog:",
     "@types/luxon": "^3.7.1",
     "reflect-metadata": "catalog:",

--- a/packages/didcomm/src/__tests__/DidCommMessageReceiver.test.ts
+++ b/packages/didcomm/src/__tests__/DidCommMessageReceiver.test.ts
@@ -19,11 +19,11 @@ describe('DidCommMessageReceiver', () => {
         alg: 'ECDH-1PU+A256KW',
         enc: 'A256GCM',
         skid: 'key-id',
-        recipients: [{ header: { kid: 'recipient-kid' }, encrypted_key: 'enc' }],
       })
 
       const v2Message = {
         protected: v2Protected,
+        recipients: [{ header: { kid: 'recipient-kid' }, encrypted_key: 'enc' }],
         iv: 'dGVzdC1pdi0xMg',
         ciphertext: 'dGVzdC1jaXBoZXJ0ZXh0',
         tag: 'dGVzdC10YWc',

--- a/packages/didcomm/src/util/__tests__/didcommVersion.test.ts
+++ b/packages/didcomm/src/util/__tests__/didcommVersion.test.ts
@@ -20,14 +20,12 @@ describe('didcommVersion', () => {
     alg: 'ECDH-1PU+A256KW',
     enc: 'A256GCM',
     skid: 'key-id',
-    recipients: [],
   })
 
   const v2AnoncryptProtected = JsonEncoder.toBase64Url({
     typ: 'application/didcomm-encrypted+json',
     alg: 'ECDH-ES+A256KW',
     enc: 'A256GCM',
-    recipients: [],
   })
 
   describe('isDidCommV2EncryptedMessage', () => {
@@ -40,6 +38,7 @@ describe('didcommVersion', () => {
     it('returns true for v2 encrypted message', () => {
       const message = {
         protected: v2AuthcryptProtected,
+        recipients: [],
         iv: 'base64iv',
         ciphertext: 'base64ciphertext',
         tag: 'base64tag',
@@ -50,6 +49,7 @@ describe('didcommVersion', () => {
     it('returns true for v2 anoncrypt message', () => {
       const message = {
         protected: v2AnoncryptProtected,
+        recipients: [],
         iv: 'base64iv',
         ciphertext: 'base64ciphertext',
         tag: 'base64tag',
@@ -60,6 +60,16 @@ describe('didcommVersion', () => {
     it('returns false for v1 encrypted message', () => {
       const message = {
         protected: v1Protected,
+        iv: 'base64iv',
+        ciphertext: 'base64ciphertext',
+        tag: 'base64tag',
+      }
+      expect(isDidCommV2EncryptedMessage(message)).toBe(false)
+    })
+
+    it('returns false when top-level recipients is missing', () => {
+      const message = {
+        protected: v2AuthcryptProtected,
         iv: 'base64iv',
         ciphertext: 'base64ciphertext',
         tag: 'base64tag',
@@ -86,6 +96,7 @@ describe('didcommVersion', () => {
     it('returns false for v2 encrypted message', () => {
       const message = {
         protected: v2AuthcryptProtected,
+        recipients: [],
         iv: 'base64iv',
         ciphertext: 'base64ciphertext',
         tag: 'base64tag',
@@ -98,6 +109,7 @@ describe('didcommVersion', () => {
     it('returns true for v2 authcrypt message', () => {
       const message = {
         protected: v2AuthcryptProtected,
+        recipients: [],
         iv: 'base64iv',
         ciphertext: 'base64ciphertext',
         tag: 'base64tag',
@@ -108,6 +120,7 @@ describe('didcommVersion', () => {
     it('returns false for v2 anoncrypt message', () => {
       const message = {
         protected: v2AnoncryptProtected,
+        recipients: [],
         iv: 'base64iv',
         ciphertext: 'base64ciphertext',
         tag: 'base64tag',

--- a/packages/didcomm/src/util/didcommVersion.ts
+++ b/packages/didcomm/src/util/didcommVersion.ts
@@ -1,5 +1,6 @@
 import { CredoError, JsonEncoder } from '@credo-ts/core'
 import type { DidCommConnectionRecord } from '../modules/connections/repository'
+import type { DidCommV2EncryptedMessage } from '../v2/types'
 import { isValidJweStructure } from './JWE'
 
 const DIDCOMM_V2_TYP = 'application/didcomm-encrypted+json'
@@ -18,13 +19,17 @@ export type DidCommVersion = 'v1' | 'v2'
 
 /**
  * Detect whether an encrypted message is DIDComm v2 format.
- * v2 uses typ: 'application/didcomm-encrypted+json' in the JWE protected header.
+ * v2 uses typ: 'application/didcomm-encrypted+json' in the JWE protected header,
+ * and JWE General JSON Serialization with a top-level recipients array.
  *
- * @param message - The message to check (typically a JWE object with protected, iv, ciphertext, tag)
+ * @param message - The message to check (typically a JWE object with protected, recipients, iv, ciphertext, tag)
  * @returns true if the message is DIDComm v2 encrypted format
  */
-export function isDidCommV2EncryptedMessage(message: unknown): boolean {
+export function isDidCommV2EncryptedMessage(message: unknown): message is DidCommV2EncryptedMessage {
   if (!isValidJweStructure(message)) {
+    return false
+  }
+  if (!Array.isArray((message as { recipients?: unknown }).recipients)) {
     return false
   }
   try {
@@ -44,6 +49,9 @@ export function isDidCommV2EncryptedMessage(message: unknown): boolean {
  */
 export function isDidCommV2AuthcryptMessage(message: unknown): boolean {
   if (!isValidJweStructure(message)) {
+    return false
+  }
+  if (!Array.isArray((message as { recipients?: unknown }).recipients)) {
     return false
   }
   try {

--- a/packages/didcomm/src/v2/DidCommV2EnvelopeService.ts
+++ b/packages/didcomm/src/v2/DidCommV2EnvelopeService.ts
@@ -9,18 +9,23 @@ import {
   type Logger,
   TypedArrayEncoder,
 } from '@credo-ts/core'
-import type { DidCommV2EncryptedMessage, DidCommV2PlaintextMessage } from './types'
+import { computeApu, computeApv } from './apuApv'
+import type { DidCommV2ContentEncryptionAlgorithm, DidCommV2EncryptedMessage, DidCommV2PlaintextMessage } from './types'
 
 export interface DidCommV2EnvelopeKeys {
   recipientKey: Kms.PublicJwk<Kms.X25519PublicJwk>
   senderKey: Kms.PublicJwk<Kms.X25519PublicJwk>
   /** DID URL of the sender key; used as skid in JWE so recipient can resolve it. Falls back to senderKey.keyId if absent. */
   senderKeySkid?: string
+  /** Content encryption algorithm. Defaults to A256CBC-HS512 (mandatory authcrypt enc per DIDComm v2.1). */
+  contentEncryptionAlgorithm?: DidCommV2ContentEncryptionAlgorithm
 }
 
 /** Keys for anoncrypt: only recipient key; no sender (anonymous). */
 export interface DidCommV2AnoncryptKeys {
   recipientKey: Kms.PublicJwk<Kms.X25519PublicJwk>
+  /** Content encryption algorithm. Defaults to A256GCM (legacy default; A256CBC-HS512 and XC20P are also valid). */
+  contentEncryptionAlgorithm?: DidCommV2ContentEncryptionAlgorithm
 }
 
 @injectable()
@@ -52,47 +57,66 @@ export class DidCommV2EnvelopeService {
       throw new CredoError('DIDComm v2 authcrypt requires X25519 recipient key')
     }
 
-    const { encrypted, iv, tag, encryptedKey } = await kms.encrypt({
-      key: {
-        keyAgreement: {
-          algorithm: 'ECDH-1PU+A256KW',
-          keyId: keys.senderKey.keyId,
-          externalPublicJwk: recipientX25519.toJson(),
-        },
-      },
-      encryption: { algorithm: 'A256GCM' },
-      data: plaintextBytes,
-    })
-
-    if (!iv || !tag) {
-      throw new CredoError('Expected iv and tag from KMS encrypt')
-    }
-
-    const epk = encryptedKey?.ephemeralPublicKey
-    if (!epk) {
-      throw new CredoError('ECDH-1PU must return ephemeral public key')
-    }
-
+    const enc: DidCommV2ContentEncryptionAlgorithm = keys.contentEncryptionAlgorithm ?? 'A256CBC-HS512'
     const skid = keys.senderKeySkid ?? keys.senderKey.keyId
-    const protectedHeader = JsonEncoder.toBase64Url({
-      typ: 'application/didcomm-encrypted+json',
-      alg: 'ECDH-1PU+A256KW',
-      enc: 'A256GCM',
-      skid,
-      epk: { kty: epk.kty, crv: epk.crv, x: epk.x },
-    })
+    const recipientKid = keys.recipientKey.keyId
+    const apu = computeApu(skid)
+    const apv = computeApv([recipientKid])
 
-    return {
-      protected: protectedHeader,
-      recipients: [
-        {
-          header: { kid: keys.recipientKey.keyId },
-          encrypted_key: TypedArrayEncoder.toBase64Url(encryptedKey.encrypted),
+    const ephemeralKey = await kms.createKey({ type: { kty: 'OKP', crv: 'X25519' } })
+    try {
+      const epk = ephemeralKey.publicJwk
+      if (!epk || (epk as { kty?: string }).kty !== 'OKP' || (epk as { crv?: string }).crv !== 'X25519') {
+        throw new CredoError('Expected X25519 ephemeral public key')
+      }
+      const epkJwk = epk as { kty: 'OKP'; crv: 'X25519'; x: string }
+
+      const protectedHeader = JsonEncoder.toBase64Url({
+        typ: 'application/didcomm-encrypted+json',
+        alg: 'ECDH-1PU+A256KW',
+        enc,
+        skid,
+        apu: TypedArrayEncoder.toBase64Url(apu),
+        apv: TypedArrayEncoder.toBase64Url(apv),
+        epk: { kty: epkJwk.kty, crv: epkJwk.crv, x: epkJwk.x },
+      })
+
+      const { encrypted, iv, tag, encryptedKey } = await kms.encrypt({
+        key: {
+          keyAgreement: {
+            algorithm: 'ECDH-1PU+A256KW',
+            keyId: keys.senderKey.keyId,
+            ephemeralKeyId: ephemeralKey.keyId,
+            externalPublicJwk: recipientX25519.toJson(),
+            apu,
+            apv,
+          },
         },
-      ],
-      iv: TypedArrayEncoder.toBase64Url(iv),
-      ciphertext: TypedArrayEncoder.toBase64Url(encrypted),
-      tag: TypedArrayEncoder.toBase64Url(tag),
+        encryption: { algorithm: enc, aad: TypedArrayEncoder.fromUtf8String(protectedHeader) },
+        data: plaintextBytes,
+      })
+
+      if (!iv || !tag) {
+        throw new CredoError('Expected iv and tag from KMS encrypt')
+      }
+      if (!encryptedKey?.encrypted) {
+        throw new CredoError('Expected encrypted key from KMS for ECDH-1PU+A256KW')
+      }
+
+      return {
+        protected: protectedHeader,
+        recipients: [
+          {
+            header: { kid: recipientKid },
+            encrypted_key: TypedArrayEncoder.toBase64Url(encryptedKey.encrypted),
+          },
+        ],
+        iv: TypedArrayEncoder.toBase64Url(iv),
+        ciphertext: TypedArrayEncoder.toBase64Url(encrypted),
+        tag: TypedArrayEncoder.toBase64Url(tag),
+      }
+    } finally {
+      await kms.deleteKey({ keyId: ephemeralKey.keyId })
     }
   }
 
@@ -118,20 +142,37 @@ export class DidCommV2EnvelopeService {
       throw new CredoError('DIDComm v2 anoncrypt requires X25519 recipient key')
     }
 
-    const ephemeralKey = await kms.createKey({
-      type: { kty: 'OKP', crv: 'X25519' },
-    })
+    const enc: DidCommV2ContentEncryptionAlgorithm = keys.contentEncryptionAlgorithm ?? 'A256GCM'
+    const recipientKid = keys.recipientKey.keyId
+    const apv = computeApv([recipientKid])
+
+    const ephemeralKey = await kms.createKey({ type: { kty: 'OKP', crv: 'X25519' } })
 
     try {
+      const epk = ephemeralKey.publicJwk
+      if (!epk || (epk as { kty?: string }).kty !== 'OKP' || (epk as { crv?: string }).crv !== 'X25519') {
+        throw new CredoError('Expected X25519 ephemeral public key')
+      }
+      const epkJwk = epk as { kty: 'OKP'; crv: 'X25519'; x: string }
+
+      const protectedHeader = JsonEncoder.toBase64Url({
+        typ: 'application/didcomm-encrypted+json',
+        alg: 'ECDH-ES+A256KW',
+        enc,
+        apv: TypedArrayEncoder.toBase64Url(apv),
+        epk: { kty: epkJwk.kty, crv: epkJwk.crv, x: epkJwk.x },
+      })
+
       const { encrypted, iv, tag, encryptedKey } = await kms.encrypt({
         key: {
           keyAgreement: {
             algorithm: 'ECDH-ES+A256KW',
             keyId: ephemeralKey.keyId,
             externalPublicJwk: recipientX25519.toJson(),
+            apv,
           },
         },
-        encryption: { algorithm: 'A256GCM' },
+        encryption: { algorithm: enc, aad: TypedArrayEncoder.fromUtf8String(protectedHeader) },
         data: plaintextBytes,
       })
 
@@ -142,24 +183,11 @@ export class DidCommV2EnvelopeService {
         throw new CredoError('Expected encrypted key from KMS for ECDH-ES+A256KW')
       }
 
-      const epk = ephemeralKey.publicJwk
-      if (!epk || (epk as { kty?: string }).kty !== 'OKP' || (epk as { crv?: string }).crv !== 'X25519') {
-        throw new CredoError('Expected X25519 ephemeral public key')
-      }
-      const epkJwk = epk as { kty: 'OKP'; crv: 'X25519'; x: string }
-
-      const protectedHeader = JsonEncoder.toBase64Url({
-        typ: 'application/didcomm-encrypted+json',
-        alg: 'ECDH-ES+A256KW',
-        enc: 'A256GCM',
-        epk: { kty: epkJwk.kty, crv: epkJwk.crv, x: epkJwk.x },
-      })
-
       return {
         protected: protectedHeader,
         recipients: [
           {
-            header: { kid: keys.recipientKey.keyId },
+            header: { kid: recipientKid },
             encrypted_key: TypedArrayEncoder.toBase64Url(encryptedKey.encrypted),
           },
         ],

--- a/packages/didcomm/src/v2/DidCommV2EnvelopeService.ts
+++ b/packages/didcomm/src/v2/DidCommV2EnvelopeService.ts
@@ -227,8 +227,10 @@ export class DidCommV2EnvelopeService {
     if (protectedJson.typ !== 'application/didcomm-encrypted+json') {
       throw new CredoError(`Invalid DIDComm v2 envelope typ: ${protectedJson.typ}`)
     }
-    if (protectedJson.enc !== 'A256GCM') {
-      throw new CredoError(`Unsupported enc: ${protectedJson.enc}`)
+
+    const enc = protectedJson.enc
+    if (enc !== 'A256GCM' && enc !== 'A256CBC-HS512') {
+      throw new CredoError(`Unsupported enc: ${enc}`)
     }
 
     const recipient = encrypted.recipients?.find((r) => r.header?.kid === keys.matchedKid)
@@ -241,8 +243,11 @@ export class DidCommV2EnvelopeService {
       throw new CredoError('Invalid ephemeral public key in protected header')
     }
 
+    const aad = TypedArrayEncoder.fromUtf8String(encrypted.protected)
+    const apv = this.parseAndValidateApv(protectedJson, encrypted.recipients)
+
     if (protectedJson.alg === 'ECDH-ES+A256KW') {
-      return this.unpackAnoncrypt(agentContext, encrypted, keys, recipient, epk.x)
+      return this.unpackAnoncrypt(agentContext, encrypted, keys, recipient, epk.x, enc, aad, apv)
     }
 
     if (protectedJson.alg !== 'ECDH-1PU+A256KW') {
@@ -253,6 +258,7 @@ export class DidCommV2EnvelopeService {
     if (!skid) {
       throw new CredoError('Authcrypt requires skid in protected header')
     }
+    const apu = this.parseAndValidateApu(protectedJson, skid)
     const senderKey = await keys.resolveSenderKey(skid)
     if (!senderKey) {
       throw new CredoError('Could not resolve sender key for skid')
@@ -271,12 +277,15 @@ export class DidCommV2EnvelopeService {
           },
           ephemeralPublicJwk: { kty: 'OKP', crv: 'X25519', x: epk.x },
           senderPublicJwk: senderX25519.toJson(),
+          apu,
+          apv,
         },
       },
       decryption: {
-        algorithm: 'A256GCM',
+        algorithm: enc,
         iv: TypedArrayEncoder.fromBase64Url(encrypted.iv),
         tag: TypedArrayEncoder.fromBase64Url(encrypted.tag),
+        aad,
       },
       encrypted: TypedArrayEncoder.fromBase64Url(encrypted.ciphertext),
     })
@@ -295,7 +304,10 @@ export class DidCommV2EnvelopeService {
       matchedKid: string
     },
     recipient: { header: { kid: string }; encrypted_key: string },
-    epkX: string
+    epkX: string,
+    enc: DidCommV2ContentEncryptionAlgorithm,
+    aad: Uint8Array,
+    apv: Uint8Array
   ): Promise<{
     plaintext: DidCommV2PlaintextMessage
     senderKey: Kms.PublicJwk<Kms.X25519PublicJwk> | null
@@ -311,12 +323,14 @@ export class DidCommV2EnvelopeService {
           encryptedKey: {
             encrypted: TypedArrayEncoder.fromBase64Url(recipient.encrypted_key),
           },
+          apv,
         },
       },
       decryption: {
-        algorithm: 'A256GCM',
+        algorithm: enc,
         iv: TypedArrayEncoder.fromBase64Url(encrypted.iv),
         tag: TypedArrayEncoder.fromBase64Url(encrypted.tag),
+        aad,
       },
       encrypted: TypedArrayEncoder.fromBase64Url(encrypted.ciphertext),
     })
@@ -326,4 +340,40 @@ export class DidCommV2EnvelopeService {
 
     return { plaintext, senderKey: null }
   }
+
+  private parseAndValidateApu(protectedJson: Record<string, unknown>, skid: string): Uint8Array {
+    const expected = computeApu(skid)
+    const apuField = protectedJson.apu
+    if (typeof apuField !== 'string') {
+      throw new CredoError('Authcrypt requires apu in protected header')
+    }
+    const received = TypedArrayEncoder.fromBase64Url(apuField)
+    if (!constantTimeEqual(received, expected)) {
+      throw new CredoError('apu in protected header does not match skid')
+    }
+    return received
+  }
+
+  private parseAndValidateApv(
+    protectedJson: Record<string, unknown>,
+    recipients: DidCommV2EncryptedMessage['recipients']
+  ): Uint8Array {
+    const apvField = protectedJson.apv
+    if (typeof apvField !== 'string') {
+      throw new CredoError('Missing apv in protected header')
+    }
+    const received = TypedArrayEncoder.fromBase64Url(apvField)
+    const expected = computeApv(recipients.map((r) => r.header.kid))
+    if (!constantTimeEqual(received, expected)) {
+      throw new CredoError('apv in protected header does not match recipient kids')
+    }
+    return received
+  }
+}
+
+function constantTimeEqual(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) return false
+  let diff = 0
+  for (let i = 0; i < a.length; i++) diff |= a[i] ^ b[i]
+  return diff === 0
 }

--- a/packages/didcomm/src/v2/DidCommV2EnvelopeService.ts
+++ b/packages/didcomm/src/v2/DidCommV2EnvelopeService.ts
@@ -79,19 +79,17 @@ export class DidCommV2EnvelopeService {
       alg: 'ECDH-1PU+A256KW',
       enc: 'A256GCM',
       skid,
-      recipients: [
-        {
-          header: {
-            kid: keys.recipientKey.keyId,
-            epk: { kty: epk.kty, crv: epk.crv, x: epk.x },
-          },
-          encrypted_key: TypedArrayEncoder.toBase64Url(encryptedKey.encrypted),
-        },
-      ],
+      epk: { kty: epk.kty, crv: epk.crv, x: epk.x },
     })
 
     return {
       protected: protectedHeader,
+      recipients: [
+        {
+          header: { kid: keys.recipientKey.keyId },
+          encrypted_key: TypedArrayEncoder.toBase64Url(encryptedKey.encrypted),
+        },
+      ],
       iv: TypedArrayEncoder.toBase64Url(iv),
       ciphertext: TypedArrayEncoder.toBase64Url(encrypted),
       tag: TypedArrayEncoder.toBase64Url(tag),
@@ -154,19 +152,17 @@ export class DidCommV2EnvelopeService {
         typ: 'application/didcomm-encrypted+json',
         alg: 'ECDH-ES+A256KW',
         enc: 'A256GCM',
-        recipients: [
-          {
-            header: {
-              kid: keys.recipientKey.keyId,
-              epk: { kty: epkJwk.kty, crv: epkJwk.crv, x: epkJwk.x },
-            },
-            encrypted_key: TypedArrayEncoder.toBase64Url(encryptedKey.encrypted),
-          },
-        ],
+        epk: { kty: epkJwk.kty, crv: epkJwk.crv, x: epkJwk.x },
       })
 
       return {
         protected: protectedHeader,
+        recipients: [
+          {
+            header: { kid: keys.recipientKey.keyId },
+            encrypted_key: TypedArrayEncoder.toBase64Url(encryptedKey.encrypted),
+          },
+        ],
         iv: TypedArrayEncoder.toBase64Url(iv),
         ciphertext: TypedArrayEncoder.toBase64Url(encrypted),
         tag: TypedArrayEncoder.toBase64Url(tag),
@@ -207,22 +203,18 @@ export class DidCommV2EnvelopeService {
       throw new CredoError(`Unsupported enc: ${protectedJson.enc}`)
     }
 
-    const recipients = protectedJson.recipients as Array<{
-      header: { kid: string; epk: { kty: string; crv: string; x: string } }
-      encrypted_key: string
-    }>
-    const recipient = recipients?.find((r) => r.header?.kid === keys.matchedKid)
+    const recipient = encrypted.recipients?.find((r) => r.header?.kid === keys.matchedKid)
     if (!recipient) {
       throw new CredoError('No matching recipient in envelope')
     }
 
-    const epk = recipient.header.epk
-    if (!epk || epk.kty !== 'OKP' || epk.crv !== 'X25519') {
-      throw new CredoError('Invalid ephemeral public key in recipient header')
+    const epk = protectedJson.epk as { kty?: string; crv?: string; x?: string } | undefined
+    if (!epk || epk.kty !== 'OKP' || epk.crv !== 'X25519' || !epk.x) {
+      throw new CredoError('Invalid ephemeral public key in protected header')
     }
 
     if (protectedJson.alg === 'ECDH-ES+A256KW') {
-      return this.unpackAnoncrypt(agentContext, encrypted, keys, recipient, protectedJson)
+      return this.unpackAnoncrypt(agentContext, encrypted, keys, recipient, epk.x)
     }
 
     if (protectedJson.alg !== 'ECDH-1PU+A256KW') {
@@ -274,8 +266,8 @@ export class DidCommV2EnvelopeService {
       recipientKey: Kms.PublicJwk<Kms.X25519PublicJwk> & { keyId: string }
       matchedKid: string
     },
-    recipient: { header: { kid: string; epk: { kty: string; crv: string; x: string } }; encrypted_key: string },
-    _protectedJson: Record<string, unknown>
+    recipient: { header: { kid: string }; encrypted_key: string },
+    epkX: string
   ): Promise<{
     plaintext: DidCommV2PlaintextMessage
     senderKey: Kms.PublicJwk<Kms.X25519PublicJwk> | null
@@ -287,7 +279,7 @@ export class DidCommV2EnvelopeService {
         keyAgreement: {
           algorithm: 'ECDH-ES+A256KW',
           keyId: keys.recipientKey.keyId,
-          externalPublicJwk: { kty: 'OKP', crv: 'X25519', x: recipient.header.epk.x },
+          externalPublicJwk: { kty: 'OKP', crv: 'X25519', x: epkX },
           encryptedKey: {
             encrypted: TypedArrayEncoder.fromBase64Url(recipient.encrypted_key),
           },

--- a/packages/didcomm/src/v2/DidCommV2EnvelopeService.ts
+++ b/packages/didcomm/src/v2/DidCommV2EnvelopeService.ts
@@ -24,7 +24,7 @@ export interface DidCommV2EnvelopeKeys {
 /** Keys for anoncrypt: only recipient key; no sender (anonymous). */
 export interface DidCommV2AnoncryptKeys {
   recipientKey: Kms.PublicJwk<Kms.X25519PublicJwk>
-  /** Content encryption algorithm. Defaults to A256GCM (legacy default; A256CBC-HS512 and XC20P are also valid). */
+  /** Content encryption algorithm. Defaults to A256CBC-HS512; A256GCM is also accepted. */
   contentEncryptionAlgorithm?: DidCommV2ContentEncryptionAlgorithm
 }
 
@@ -142,7 +142,7 @@ export class DidCommV2EnvelopeService {
       throw new CredoError('DIDComm v2 anoncrypt requires X25519 recipient key')
     }
 
-    const enc: DidCommV2ContentEncryptionAlgorithm = keys.contentEncryptionAlgorithm ?? 'A256GCM'
+    const enc: DidCommV2ContentEncryptionAlgorithm = keys.contentEncryptionAlgorithm ?? 'A256CBC-HS512'
     const recipientKid = keys.recipientKey.keyId
     const apv = computeApv([recipientKid])
 

--- a/packages/didcomm/src/v2/__tests__/DidCommV2EnvelopeService.askar.test.ts
+++ b/packages/didcomm/src/v2/__tests__/DidCommV2EnvelopeService.askar.test.ts
@@ -1,0 +1,142 @@
+import { InjectionSymbols, JsonEncoder, Kms, TypedArrayEncoder } from '@credo-ts/core'
+import { askar } from '@openwallet-foundation/askar-nodejs'
+
+import { AskarModuleConfig, AskarMultiWalletDatabaseScheme } from '../../../../askar/src/AskarModuleConfig'
+import { AskarKeyManagementService } from '../../../../askar/src/kms/AskarKeyManagementService'
+import { getAgentConfig, getAgentContext } from '../../../../core/tests/helpers'
+import testLogger from '../../../../core/tests/logger'
+import { NodeFileSystem } from '../../../../node/src/NodeFileSystem'
+
+import { computeApu, computeApv } from '../apuApv'
+import { DidCommV2EnvelopeService } from '../DidCommV2EnvelopeService'
+import type { DidCommV2ContentEncryptionAlgorithm, DidCommV2PlaintextMessage } from '../types'
+
+describe('DidCommV2EnvelopeService (Askar round-trip)', () => {
+  const agentContext = getAgentContext({
+    contextCorrelationId: 'v2-envelope-askar-roundtrip',
+    agentConfig: getAgentConfig('V2EnvelopeAskarRoundTrip'),
+    kmsBackends: [new AskarKeyManagementService()],
+    registerInstances: [
+      [InjectionSymbols.Logger, testLogger],
+      [InjectionSymbols.FileSystem, new NodeFileSystem()],
+      [
+        AskarModuleConfig,
+        new AskarModuleConfig({
+          multiWalletDatabaseScheme: AskarMultiWalletDatabaseScheme.ProfilePerWallet,
+          askar,
+          store: {
+            id: 'v2-envelope-askar-roundtrip',
+            key: 'CwNJroKHTSSj3XvE7ZAnuKiTn2C4QkFvxEqfm5rzhNrb',
+            keyDerivationMethod: 'raw',
+            database: { type: 'sqlite', config: { inMemory: true } },
+          },
+        }),
+      ],
+    ],
+  })
+
+  let envelopeService: DidCommV2EnvelopeService
+  let senderKey: Kms.PublicJwk<Kms.X25519PublicJwk>
+  let recipientKey: Kms.PublicJwk<Kms.X25519PublicJwk>
+
+  beforeAll(async () => {
+    agentContext.dependencyManager.registerSingleton(DidCommV2EnvelopeService)
+    envelopeService = agentContext.dependencyManager.resolve(DidCommV2EnvelopeService)
+
+    const kms = agentContext.dependencyManager.resolve(Kms.KeyManagementApi)
+    const sender = await kms.createKey({ type: { kty: 'OKP', crv: 'X25519' } })
+    const recipient = await kms.createKey({ type: { kty: 'OKP', crv: 'X25519' } })
+
+    senderKey = Kms.PublicJwk.fromPublicJwk(sender.publicJwk) as Kms.PublicJwk<Kms.X25519PublicJwk>
+    senderKey.keyId = sender.keyId
+    recipientKey = Kms.PublicJwk.fromPublicJwk(recipient.publicJwk) as Kms.PublicJwk<Kms.X25519PublicJwk>
+    recipientKey.keyId = recipient.keyId
+  })
+
+  const plaintext: DidCommV2PlaintextMessage = {
+    id: 'roundtrip-1',
+    type: 'https://didcomm.org/trust-ping/1.0/ping',
+    from: 'did:example:alice',
+    to: ['did:example:bob'],
+    body: { response_requested: true },
+  }
+
+  describe('authcrypt', () => {
+    it.each<DidCommV2ContentEncryptionAlgorithm>([
+      'A256CBC-HS512',
+      'A256GCM',
+    ])('round-trips with %s content encryption', async (enc) => {
+      const encrypted = await envelopeService.pack(agentContext, plaintext, {
+        senderKey,
+        recipientKey,
+        contentEncryptionAlgorithm: enc,
+      })
+
+      expect(encrypted.recipients).toHaveLength(1)
+      expect(encrypted.recipients[0].header.kid).toBe(recipientKey.keyId)
+
+      const protectedJson = JsonEncoder.fromBase64Url(encrypted.protected)
+      expect(protectedJson).toMatchObject({
+        typ: 'application/didcomm-encrypted+json',
+        alg: 'ECDH-1PU+A256KW',
+        enc,
+        skid: senderKey.keyId,
+        epk: { kty: 'OKP', crv: 'X25519', x: expect.any(String) },
+      })
+      expect(protectedJson.apu).toBe(TypedArrayEncoder.toBase64Url(computeApu(senderKey.keyId)))
+      expect(protectedJson.apv).toBe(TypedArrayEncoder.toBase64Url(computeApv([recipientKey.keyId])))
+
+      const { plaintext: decrypted, senderKey: resolvedSender } = await envelopeService.unpack(
+        agentContext,
+        encrypted,
+        {
+          recipientKey: recipientKey as Kms.PublicJwk<Kms.X25519PublicJwk> & { keyId: string },
+          matchedKid: recipientKey.keyId,
+          resolveSenderKey: async (skid) => (skid === senderKey.keyId ? senderKey : null),
+        }
+      )
+
+      expect(decrypted).toEqual(plaintext)
+      expect(resolvedSender).not.toBeNull()
+    })
+  })
+
+  describe('anoncrypt', () => {
+    it.each<DidCommV2ContentEncryptionAlgorithm>([
+      'A256CBC-HS512',
+      'A256GCM',
+    ])('round-trips with %s content encryption', async (enc) => {
+      const encrypted = await envelopeService.packAnoncrypt(agentContext, plaintext, {
+        recipientKey,
+        contentEncryptionAlgorithm: enc,
+      })
+
+      expect(encrypted.recipients).toHaveLength(1)
+      expect(encrypted.recipients[0].header.kid).toBe(recipientKey.keyId)
+
+      const protectedJson = JsonEncoder.fromBase64Url(encrypted.protected)
+      expect(protectedJson).toMatchObject({
+        typ: 'application/didcomm-encrypted+json',
+        alg: 'ECDH-ES+A256KW',
+        enc,
+        epk: { kty: 'OKP', crv: 'X25519', x: expect.any(String) },
+      })
+      expect(protectedJson.skid).toBeUndefined()
+      expect(protectedJson.apu).toBeUndefined()
+      expect(protectedJson.apv).toBe(TypedArrayEncoder.toBase64Url(computeApv([recipientKey.keyId])))
+
+      const { plaintext: decrypted, senderKey: resolvedSender } = await envelopeService.unpack(
+        agentContext,
+        encrypted,
+        {
+          recipientKey: recipientKey as Kms.PublicJwk<Kms.X25519PublicJwk> & { keyId: string },
+          matchedKid: recipientKey.keyId,
+          resolveSenderKey: async () => null,
+        }
+      )
+
+      expect(decrypted).toEqual(plaintext)
+      expect(resolvedSender).toBeNull()
+    })
+  })
+})

--- a/packages/didcomm/src/v2/__tests__/DidCommV2EnvelopeService.test.ts
+++ b/packages/didcomm/src/v2/__tests__/DidCommV2EnvelopeService.test.ts
@@ -197,6 +197,7 @@ describe('DidCommV2EnvelopeService', () => {
 
     const encrypted = await envelopeService.packAnoncrypt(agentContext, plaintext, {
       recipientKey,
+      contentEncryptionAlgorithm: 'A256GCM',
     })
 
     expect(encrypted).toMatchObject({

--- a/packages/didcomm/src/v2/__tests__/DidCommV2EnvelopeService.test.ts
+++ b/packages/didcomm/src/v2/__tests__/DidCommV2EnvelopeService.test.ts
@@ -165,6 +165,7 @@ describe('DidCommV2EnvelopeService', () => {
     const encrypted = await envelopeService.pack(agentContext, plaintext, {
       senderKey,
       recipientKey,
+      contentEncryptionAlgorithm: 'A256GCM',
     })
 
     expect(encrypted).toMatchObject({

--- a/packages/didcomm/src/v2/__tests__/DidCommV2EnvelopeService.test.ts
+++ b/packages/didcomm/src/v2/__tests__/DidCommV2EnvelopeService.test.ts
@@ -169,15 +169,13 @@ describe('DidCommV2EnvelopeService', () => {
 
     expect(encrypted).toMatchObject({
       protected: expect.any(String),
+      recipients: expect.any(Array),
       iv: expect.any(String),
       ciphertext: expect.any(String),
       tag: expect.any(String),
     })
 
-    const protectedJson = JsonEncoder.fromBase64Url(encrypted.protected) as {
-      recipients?: Array<{ header?: { kid?: string } }>
-    }
-    const matchedKid = protectedJson.recipients?.[0]?.header?.kid ?? recipientKey.keyId
+    const matchedKid = encrypted.recipients[0]?.header?.kid ?? recipientKey.keyId
     const { plaintext: decrypted } = await envelopeService.unpack(agentContext, encrypted, {
       recipientKey,
       matchedKid,
@@ -202,18 +200,16 @@ describe('DidCommV2EnvelopeService', () => {
 
     expect(encrypted).toMatchObject({
       protected: expect.any(String),
+      recipients: expect.any(Array),
       iv: expect.any(String),
       ciphertext: expect.any(String),
       tag: expect.any(String),
     })
 
-    const protectedJson = JsonEncoder.fromBase64Url(encrypted.protected) as {
-      alg?: string
-      recipients?: Array<{ header?: { kid?: string } }>
-    }
+    const protectedJson = JsonEncoder.fromBase64Url(encrypted.protected) as { alg?: string }
     expect(protectedJson.alg).toBe('ECDH-ES+A256KW')
-    expect(protectedJson.recipients).toHaveLength(1)
-    const matchedKid = protectedJson.recipients?.[0]?.header?.kid ?? recipientKey.keyId
+    expect(encrypted.recipients).toHaveLength(1)
+    const matchedKid = encrypted.recipients[0]?.header?.kid ?? recipientKey.keyId
     const { plaintext: decrypted, senderKey } = await envelopeService.unpack(agentContext, encrypted, {
       recipientKey,
       matchedKid,

--- a/packages/didcomm/src/v2/__tests__/__fixtures__/sicpa/authcrypt-x25519-a256cbc.json
+++ b/packages/didcomm/src/v2/__tests__/__fixtures__/sicpa/authcrypt-x25519-a256cbc.json
@@ -1,0 +1,57 @@
+{
+  "$description": "SICPA didcomm-python TEST_ENCRYPTED_DIDCOMM_MESSAGE_AUTH_X25519: authcrypt with ECDH-1PU+A256KW, A256CBC-HS512, X25519. Alice (sender) -> Bob (recipient, 4 X25519 keys).",
+  "$source": "https://github.com/sicpa-dlab/didcomm-python/blob/main/tests/test_vectors/didcomm_messages/spec/spec_test_vectors_auth_encrypted.py",
+  "$license": "Apache-2.0",
+  "encryptedMessage": {
+    "protected": "eyJ0eXAiOiJhcHBsaWNhdGlvbi9kaWRjb21tLWVuY3J5cHRlZCtqc29uIiwiYWxnIjoiRUNESC0xUFUrQTI1NktXIiwiZW5jIjoiQTI1NkNCQy1IUzUxMiIsImFwdSI6IlpHbGtPbVY0WVcxd2JHVTZZV3hwWTJVamEyVjVMWGd5TlRVeE9TMHgiLCJhcHYiOiJZMVl4d29Od1lORzRkSkZQSmp2bS05NGliYXVxQTlIcldLWVpobWNvZVNnIiwic2tpZCI6ImRpZDpleGFtcGxlOmFsaWNlI2tleS14MjU1MTktMSIsImVwayI6eyJjcnYiOiJYMjU1MTkiLCJ4Ijoib2dIbzBwSkRENDNTcVNXZUtPZHJCLXdpb1FIZlV3TGJPSHBJMmY1VU1pZyIsImt0eSI6Ik9LUCJ9fQ",
+    "recipients": [
+      {
+        "header": { "kid": "did:example:bob#key-x25519-1" },
+        "encrypted_key": "MmT3HsZZjZ_tn5Y8E1W5xY3kW0ay7PTuxYiPSFpTQmigeHyRA3xDPiFpFPDljmzgJQG-_KKa8llAsqcT-JBH4bKYzxAkZPV8"
+      },
+      {
+        "header": { "kid": "did:example:bob#key-x25519-2" },
+        "encrypted_key": "ahZ_wNMeygPtI_gkvCeEv71QlGC040iD5gFiAppu53WF1UglnUKF7Pe5jFcpTRSOZp-6PtJghXpmep9UDdqoD0SKriTiaMpQ"
+      },
+      {
+        "header": { "kid": "did:example:bob#key-x25519-3" },
+        "encrypted_key": "KRX2BLEhMZnWx7F44umOlRO6B2TLJFS5mBsaJCJW83NJuYYJNoM41TBg03kqkMbGm9Fs4UgunMNYjCAU3mDcjB8UY5oVZoC_"
+      },
+      {
+        "header": { "kid": "did:example:bob#key-x25519-4" },
+        "encrypted_key": "c0v4zw8JhCvOI5pkJo4mXRRsGl_liMyirGFdQkZWULIK_Urw5lm7KqeUXJsqvAPRBz6n9broQP75HCQ4QtDveYmVEVbVA3c3"
+      }
+    ],
+    "iv": "LqyZeQsKsQ_0CezRDIo4ng",
+    "ciphertext": "IvSZruHdIR0JGXRaXchiwAuwce6rqOmNQMBRaBgXn49PrlmroeBAQUa5yq1bek3HBljaNXXtCxWqBiW7i_EN5oJVVfUNQPUwDL_ozRfOncU3LmYnYFeVQ3C9mndFKITnxOxWqG3hhVlJw91IN9-sYXQCj0LbG3dbbiLuaN_CqJa-sIPZaNXpE5H11FQsw8owXzcEELO8zqSIlz_ZizLuRE-S24-_gzROKzpgL2qq-9fgkBVr28GQt0NHlGuSHUEq0tloIYLtILQ3UGoqyD2Ay5EJfEOL9pK4Vu-2_6pFxfvJowAk2EsLYO8fNvZJuM3Jw0HWe4MqtNxFa-_rSh3eNT7nyZecAgQ2vFtdAlIfcPMAbDqIE9UBIm2Ttie310j6F2IIRze1PMKNUH7Wf_PclQ",
+    "tag": "p8QNhwH3n0aFeh9qV6E3g6-iZzXe8hEMP1BbkU86PgY"
+  },
+  "expectedPlaintext": {
+    "id": "1234567890",
+    "thid": "1234567890",
+    "typ": "application/didcomm-plain+json",
+    "type": "http://example.com/protocols/lets_do_lunch/1.0/proposal",
+    "from": "did:example:alice",
+    "to": ["did:example:bob"],
+    "created_time": 1516269022,
+    "expires_time": 1516385931,
+    "body": { "messagespecificattribute": "and its value" }
+  },
+  "recipient": {
+    "kid": "did:example:bob#key-x25519-1",
+    "privateJwk": {
+      "kty": "OKP",
+      "crv": "X25519",
+      "d": "b9NnuOCB0hm7YGNvaE9DMhwH_wjZA1-gWD6dA0JWdL0",
+      "x": "GDTrI66K0pFfO54tlCSvfjjNapIs44dzpneBgyx0S3E"
+    }
+  },
+  "sender": {
+    "kid": "did:example:alice#key-x25519-1",
+    "publicJwk": {
+      "kty": "OKP",
+      "crv": "X25519",
+      "x": "avH0O2Y4tqLAq8y9zpianr8ajii5m4F_mICrzNlatXs"
+    }
+  }
+}

--- a/packages/didcomm/src/v2/__tests__/apuApv.test.ts
+++ b/packages/didcomm/src/v2/__tests__/apuApv.test.ts
@@ -1,0 +1,39 @@
+import { TypedArrayEncoder } from '@credo-ts/core'
+
+import { computeApu, computeApv } from '../apuApv'
+
+describe('computeApu', () => {
+  it('returns the UTF-8 bytes of the sender key id', () => {
+    const skid = 'did:example:alice#key-x25519-1'
+    expect(TypedArrayEncoder.toBase64Url(computeApu(skid))).toBe('ZGlkOmV4YW1wbGU6YWxpY2Uja2V5LXgyNTUxOS0x')
+  })
+})
+
+describe('computeApv', () => {
+  it('matches the SICPA TEST_ENCRYPTED_DIDCOMM_MESSAGE_AUTH_X25519 expected value', () => {
+    const kids = [
+      'did:example:bob#key-x25519-1',
+      'did:example:bob#key-x25519-2',
+      'did:example:bob#key-x25519-3',
+      'did:example:bob#key-x25519-4',
+    ]
+    expect(TypedArrayEncoder.toBase64Url(computeApv(kids))).toBe('Y1YxwoNwYNG4dJFPJjvm-94ibauqA9HrWKYZhmcoeSg')
+  })
+
+  it('produces the same digest regardless of input order', () => {
+    const sorted = ['did:example:bob#key-x25519-1', 'did:example:bob#key-x25519-2']
+    const unsorted = ['did:example:bob#key-x25519-2', 'did:example:bob#key-x25519-1']
+    expect(computeApv(unsorted)).toEqual(computeApv(sorted))
+  })
+
+  it('produces different digests for different recipient sets', () => {
+    expect(computeApv(['did:example:bob#key-x25519-1'])).not.toEqual(computeApv(['did:example:bob#key-x25519-2']))
+  })
+
+  it('does not mutate the caller-provided array', () => {
+    const kids = ['did:example:bob#key-x25519-2', 'did:example:bob#key-x25519-1']
+    const snapshot = [...kids]
+    computeApv(kids)
+    expect(kids).toEqual(snapshot)
+  })
+})

--- a/packages/didcomm/src/v2/__tests__/interop/sicpaAuthcryptInterop.test.ts
+++ b/packages/didcomm/src/v2/__tests__/interop/sicpaAuthcryptInterop.test.ts
@@ -27,9 +27,7 @@ interface X25519PublicJwk {
 }
 
 interface SicpaAuthcryptFixture {
-  encryptedMessage: DidCommV2EncryptedMessage & {
-    recipients: Array<{ header: { kid: string }; encrypted_key: string }>
-  }
+  encryptedMessage: DidCommV2EncryptedMessage
   expectedPlaintext: DidCommV2PlaintextMessage
   recipient: { kid: string; privateJwk: X25519PrivateJwk }
   sender: { kid: string; publicJwk: X25519PublicJwk }

--- a/packages/didcomm/src/v2/__tests__/interop/sicpaAuthcryptInterop.test.ts
+++ b/packages/didcomm/src/v2/__tests__/interop/sicpaAuthcryptInterop.test.ts
@@ -2,7 +2,7 @@ import { readFileSync } from 'node:fs'
 import path from 'node:path'
 
 import { InjectionSymbols, Kms } from '@credo-ts/core'
-import { askar } from '@openwallet-foundation/askar-shared'
+import { askar } from '@openwallet-foundation/askar-nodejs'
 
 import { AskarModuleConfig, AskarMultiWalletDatabaseScheme } from '../../../../../askar/src/AskarModuleConfig'
 import { AskarKeyManagementService } from '../../../../../askar/src/kms/AskarKeyManagementService'

--- a/packages/didcomm/src/v2/__tests__/interop/sicpaAuthcryptInterop.test.ts
+++ b/packages/didcomm/src/v2/__tests__/interop/sicpaAuthcryptInterop.test.ts
@@ -1,0 +1,94 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+import { InjectionSymbols, Kms } from '@credo-ts/core'
+import { askar } from '@openwallet-foundation/askar-shared'
+
+import { AskarModuleConfig, AskarMultiWalletDatabaseScheme } from '../../../../../askar/src/AskarModuleConfig'
+import { AskarKeyManagementService } from '../../../../../askar/src/kms/AskarKeyManagementService'
+import { getAgentConfig, getAgentContext } from '../../../../../core/tests/helpers'
+import testLogger from '../../../../../core/tests/logger'
+import { NodeFileSystem } from '../../../../../node/src/NodeFileSystem'
+
+import { DidCommV2EnvelopeService } from '../../DidCommV2EnvelopeService'
+import type { DidCommV2EncryptedMessage, DidCommV2PlaintextMessage } from '../../types'
+
+interface X25519PrivateJwk {
+  kty: 'OKP'
+  crv: 'X25519'
+  d: string
+  x: string
+}
+
+interface X25519PublicJwk {
+  kty: 'OKP'
+  crv: 'X25519'
+  x: string
+}
+
+interface SicpaAuthcryptFixture {
+  encryptedMessage: DidCommV2EncryptedMessage & {
+    recipients: Array<{ header: { kid: string }; encrypted_key: string }>
+  }
+  expectedPlaintext: DidCommV2PlaintextMessage
+  recipient: { kid: string; privateJwk: X25519PrivateJwk }
+  sender: { kid: string; publicJwk: X25519PublicJwk }
+}
+
+const fixture = JSON.parse(
+  readFileSync(path.join(__dirname, '../__fixtures__/sicpa/authcrypt-x25519-a256cbc.json'), 'utf-8')
+) as SicpaAuthcryptFixture
+
+describe('SICPA authcrypt X25519 + A256CBC-HS512 interop', () => {
+  const agentContext = getAgentContext({
+    contextCorrelationId: 'sicpa-authcrypt-x25519',
+    agentConfig: getAgentConfig('SicpaAuthcryptInterop'),
+    kmsBackends: [new AskarKeyManagementService()],
+    registerInstances: [
+      [InjectionSymbols.Logger, testLogger],
+      [InjectionSymbols.FileSystem, new NodeFileSystem()],
+      [
+        AskarModuleConfig,
+        new AskarModuleConfig({
+          multiWalletDatabaseScheme: AskarMultiWalletDatabaseScheme.ProfilePerWallet,
+          askar,
+          store: {
+            id: 'sicpa-authcrypt-x25519',
+            key: 'CwNJroKHTSSj3XvE7ZAnuKiTn2C4QkFvxEqfm5rzhNrb',
+            keyDerivationMethod: 'raw',
+            database: { type: 'sqlite', config: { inMemory: true } },
+          },
+        }),
+      ],
+    ],
+  })
+
+  let envelopeService: DidCommV2EnvelopeService
+  let recipientKey: Kms.PublicJwk<Kms.X25519PublicJwk> & { keyId: string }
+  let senderPublicJwk: Kms.PublicJwk<Kms.X25519PublicJwk>
+
+  beforeAll(async () => {
+    agentContext.dependencyManager.registerSingleton(DidCommV2EnvelopeService)
+    envelopeService = agentContext.dependencyManager.resolve(DidCommV2EnvelopeService)
+
+    const kms = agentContext.dependencyManager.resolve(Kms.KeyManagementApi)
+    const imported = await kms.importKey({ privateJwk: fixture.recipient.privateJwk })
+    const recipient = Kms.PublicJwk.fromPublicJwk(imported.publicJwk) as Kms.PublicJwk<Kms.X25519PublicJwk>
+    recipient.keyId = imported.keyId
+    recipientKey = recipient as Kms.PublicJwk<Kms.X25519PublicJwk> & { keyId: string }
+
+    senderPublicJwk = Kms.PublicJwk.fromPublicJwk(fixture.sender.publicJwk) as Kms.PublicJwk<Kms.X25519PublicJwk>
+    senderPublicJwk.keyId = fixture.sender.kid
+  })
+
+  it('decrypts SICPA TEST_ENCRYPTED_DIDCOMM_MESSAGE_AUTH_X25519', async () => {
+    const { plaintext, senderKey } = await envelopeService.unpack(agentContext, fixture.encryptedMessage, {
+      recipientKey,
+      matchedKid: fixture.recipient.kid,
+      resolveSenderKey: async (skid) => (skid === fixture.sender.kid ? senderPublicJwk : null),
+    })
+
+    expect(plaintext).toEqual(fixture.expectedPlaintext)
+    expect(senderKey).not.toBeNull()
+  })
+})

--- a/packages/didcomm/src/v2/apuApv.ts
+++ b/packages/didcomm/src/v2/apuApv.ts
@@ -1,0 +1,10 @@
+import { Hasher, TypedArrayEncoder } from '@credo-ts/core'
+
+export function computeApu(skid: string): Uint8Array {
+  return TypedArrayEncoder.fromUtf8String(skid)
+}
+
+export function computeApv(recipientKids: string[]): Uint8Array {
+  const sortedJoined = [...recipientKids].sort().join('.')
+  return Hasher.hash(sortedJoined, 'sha-256')
+}

--- a/packages/didcomm/src/v2/resolveV2Keys.ts
+++ b/packages/didcomm/src/v2/resolveV2Keys.ts
@@ -5,7 +5,6 @@ import {
   DidsApi,
   getPublicJwkFromVerificationMethod,
   injectable,
-  JsonEncoder,
   Kms,
   parseDid,
   RecordNotFoundError,
@@ -34,11 +33,7 @@ export class DidCommV2KeyResolver {
     agentContext: AgentContext,
     encrypted: DidCommV2EncryptedMessage
   ): Promise<{ recipientKey: Kms.PublicJwk<Kms.X25519PublicJwk> & { keyId: string }; matchedKid: string } | null> {
-    const protectedJson = JsonEncoder.fromBase64Url(encrypted.protected) as {
-      recipients?: Array<{ header?: { kid?: string } }>
-    }
-
-    const recipients = protectedJson.recipients ?? []
+    const recipients = encrypted.recipients ?? []
     const kms = agentContext.dependencyManager.resolve(Kms.KeyManagementApi)
 
     for (const recipient of recipients) {

--- a/packages/didcomm/src/v2/types.ts
+++ b/packages/didcomm/src/v2/types.ts
@@ -42,6 +42,13 @@ export interface DidCommV2Attachment {
 export const DIDCOMM_V2_PLAIN_MIME_TYPE = 'application/didcomm-plain+json'
 export const DIDCOMM_V2_ENCRYPTED_MIME_TYPE = 'application/didcomm-encrypted+json'
 
+export type DidCommV2ContentEncryptionAlgorithm = 'A256GCM' | 'A256CBC-HS512'
+
+export interface DidCommV2JweRecipient {
+  header: { kid: string }
+  encrypted_key: string
+}
+
 /**
  * DIDComm v2 encrypted message (JWE with typ application/didcomm-encrypted+json).
  * Same top-level structure as v1 for transport compatibility.

--- a/packages/didcomm/src/v2/types.ts
+++ b/packages/didcomm/src/v2/types.ts
@@ -50,11 +50,13 @@ export interface DidCommV2JweRecipient {
 }
 
 /**
- * DIDComm v2 encrypted message (JWE with typ application/didcomm-encrypted+json).
- * Same top-level structure as v1 for transport compatibility.
+ * DIDComm v2 encrypted message (JWE in JSON General Serialization, typ application/didcomm-encrypted+json).
+ * The shared ephemeral public key and all KDF/alg parameters live in the protected header;
+ * recipients is top-level and per-recipient headers contain only the kid.
  */
 export interface DidCommV2EncryptedMessage {
   protected: string
+  recipients: DidCommV2JweRecipient[]
   iv: string
   ciphertext: string
   tag: string

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -690,6 +690,12 @@ importers:
       '@animo-id/pex':
         specifier: 'catalog:'
         version: 6.1.1
+      '@openwallet-foundation/askar-nodejs':
+        specifier: 'catalog:'
+        version: 0.6.0
+      '@openwallet-foundation/askar-shared':
+        specifier: 'catalog:'
+        version: 0.6.0
       '@sphereon/pex-models':
         specifier: 'catalog:'
         version: 2.3.2
@@ -3763,6 +3769,7 @@ packages:
 
   '@sphereon/kmp-mdoc-core@0.2.0-SNAPSHOT.26':
     resolution: {integrity: sha512-QXJ6R8ENiZV2rPMbn06cw5JKwqUYN1kzVRbYfONqE1PEXx1noQ4md7uxr2zSczi0ubKkNcbyYDNtIMTZIhGzmQ==}
+    bundledDependencies: []
 
   '@sphereon/pex-models@2.3.2':
     resolution: {integrity: sha512-foFxfLkRwcn/MOp/eht46Q7wsvpQGlO7aowowIIb5Tz9u97kYZ2kz6K2h2ODxWuv5CRA7Q0MY8XUBGE2lfOhOQ==}
@@ -10801,7 +10808,7 @@ snapshots:
   '@grpc/proto-loader@0.7.15':
     dependencies:
       lodash.camelcase: 4.3.0
-      long: 5.3.1
+      long: 5.3.2
       protobufjs: 7.5.4
       yargs: 17.7.2
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -693,9 +693,6 @@ importers:
       '@openwallet-foundation/askar-nodejs':
         specifier: 'catalog:'
         version: 0.6.0
-      '@openwallet-foundation/askar-shared':
-        specifier: 'catalog:'
-        version: 0.6.0
       '@sphereon/pex-models':
         specifier: 'catalog:'
         version: 2.3.2


### PR DESCRIPTION
Brings `DidCommV2EnvelopeService` up to spec for ECDH-1PU + A256CBC-HS512 authcrypt: top-level `recipients`, shared `epk` in protected, `apu`/`apv`, JWE AAD, and the `ccTag`. The missing `ccTag` was the root cause of `Encryption error` at askar's `keyUnwrapKey` against SICPA-encrypted envelopes, also seen with RootsID Mediator.

X25519 only. P-256, signed messages, and XC20P anoncrypt are follow-ups.