### PR TITLE
feat(didcomm-v2): add XC20P anoncrypt and configurable content-encryption defaults

### DIFF
--- a/packages/didcomm/src/DidCommMessageSender.ts
+++ b/packages/didcomm/src/DidCommMessageSender.ts
@@ -150,6 +150,7 @@ export class DidCommMessageSender {
           recipientKey: recipientX25519,
           senderKey: senderX25519,
           senderKeySkid: keys.senderKeySkid,
+          contentEncryptionAlgorithm: this.didCommModuleConfig.v2DefaultAuthcryptContentEncryption,
         })
       } catch (error) {
         agentContext.config.logger.debug('DIDComm v2 authcrypt pack failed, falling back to v1', { error })
@@ -216,6 +217,7 @@ export class DidCommMessageSender {
       recipientKey: recipientX25519,
       senderKey: senderX25519,
       senderKeySkid: keys.senderKeySkid,
+      contentEncryptionAlgorithm: this.didCommModuleConfig.v2DefaultAuthcryptContentEncryption,
     })
 
     const recipientNext = this.resolveRecipientNextForMediationForward(connection, plaintext, keys)
@@ -237,6 +239,7 @@ export class DidCommMessageSender {
       })
       payload = await this.v2EnvelopeService.packAnoncrypt(agentContext, forwardPlaintext, {
         recipientKey: routingKeyX25519,
+        contentEncryptionAlgorithm: this.didCommModuleConfig.v2DefaultAnoncryptContentEncryption,
       })
     }
     return payload
@@ -313,6 +316,7 @@ export class DidCommMessageSender {
           recipientKey: recipientX25519,
           senderKey: senderX25519,
           senderKeySkid: keys.senderKeySkid,
+          contentEncryptionAlgorithm: this.didCommModuleConfig.v2DefaultAuthcryptContentEncryption,
         })
       } catch (error) {
         agentContext.config.logger.debug('DIDComm v2 authcrypt pack failed, falling back to v1', { error })

--- a/packages/didcomm/src/DidCommModuleConfig.ts
+++ b/packages/didcomm/src/DidCommModuleConfig.ts
@@ -55,18 +55,18 @@ export interface DidCommModuleConfigOptions {
   peerDidNumAlgoForV2OOB?: PeerDidNumAlgo.MultipleInceptionKeyWithoutDoc | PeerDidNumAlgo.ShortFormAndLongForm
 
   /**
-   * Default content encryption algorithm for DIDComm v2 authcrypt envelopes. Per spec, authcrypt
-   * MUST use A256CBC-HS512; A256GCM is also accepted for backward compatibility.
+   * Default content encryption algorithm for DIDComm v2 authcrypt envelopes. Spec restricts
+   * authcrypt to A256CBC-HS512.
    *
    * @default 'A256CBC-HS512'
    */
   v2DefaultAuthcryptContentEncryption?: DidCommV2AuthcryptContentEncryptionAlgorithm
 
   /**
-   * Default content encryption algorithm for DIDComm v2 anoncrypt envelopes. Set to 'XC20P' to
-   * match the SICPA stack default.
+   * Default content encryption algorithm for DIDComm v2 anoncrypt envelopes. A256CBC-HS512 is
+   * REQUIRED per spec; A256GCM is RECOMMENDED; XC20P is OPTIONAL (SICPA's default).
    *
-   * @default 'A256GCM'
+   * @default 'A256CBC-HS512'
    */
   v2DefaultAnoncryptContentEncryption?: DidCommV2AnoncryptContentEncryptionAlgorithm
 
@@ -277,6 +277,6 @@ export class DidCommModuleConfig<Options extends DidCommModuleConfigOptions = Di
   }
 
   public get v2DefaultAnoncryptContentEncryption(): DidCommV2AnoncryptContentEncryptionAlgorithm {
-    return this.options.v2DefaultAnoncryptContentEncryption ?? 'A256GCM'
+    return this.options.v2DefaultAnoncryptContentEncryption ?? 'A256CBC-HS512'
   }
 }

--- a/packages/didcomm/src/DidCommModuleConfig.ts
+++ b/packages/didcomm/src/DidCommModuleConfig.ts
@@ -21,6 +21,10 @@ import {
 } from './transport'
 import { DidCommMimeType } from './types'
 import type { DidCommVersion } from './util/didcommVersion'
+import type {
+  DidCommV2AnoncryptContentEncryptionAlgorithm,
+  DidCommV2AuthcryptContentEncryptionAlgorithm,
+} from './v2/types'
 
 export interface DidCommModuleConfigOptions {
   endpoints?: string[]
@@ -49,6 +53,22 @@ export interface DidCommModuleConfigOptions {
    * @default PeerDidNumAlgo.ShortFormAndLongForm (did:peer:4)
    */
   peerDidNumAlgoForV2OOB?: PeerDidNumAlgo.MultipleInceptionKeyWithoutDoc | PeerDidNumAlgo.ShortFormAndLongForm
+
+  /**
+   * Default content encryption algorithm for DIDComm v2 authcrypt envelopes. Per spec, authcrypt
+   * MUST use A256CBC-HS512; A256GCM is also accepted for backward compatibility.
+   *
+   * @default 'A256CBC-HS512'
+   */
+  v2DefaultAuthcryptContentEncryption?: DidCommV2AuthcryptContentEncryptionAlgorithm
+
+  /**
+   * Default content encryption algorithm for DIDComm v2 anoncrypt envelopes. Set to 'XC20P' to
+   * match the SICPA stack default.
+   *
+   * @default 'A256GCM'
+   */
+  v2DefaultAnoncryptContentEncryption?: DidCommV2AnoncryptContentEncryptionAlgorithm
 
   /**
    * Configuration for the connection module.
@@ -250,5 +270,13 @@ export class DidCommModuleConfig<Options extends DidCommModuleConfigOptions = Di
   /** Peer DID numAlgo for V2 OOB. Defaults to did:peer:4. */
   public get peerDidNumAlgoForV2OOB() {
     return this.options.peerDidNumAlgoForV2OOB ?? PeerDidNumAlgo.ShortFormAndLongForm
+  }
+
+  public get v2DefaultAuthcryptContentEncryption(): DidCommV2AuthcryptContentEncryptionAlgorithm {
+    return this.options.v2DefaultAuthcryptContentEncryption ?? 'A256CBC-HS512'
+  }
+
+  public get v2DefaultAnoncryptContentEncryption(): DidCommV2AnoncryptContentEncryptionAlgorithm {
+    return this.options.v2DefaultAnoncryptContentEncryption ?? 'A256GCM'
   }
 }

--- a/packages/didcomm/src/__tests__/DidCommModuleConfig.test.ts
+++ b/packages/didcomm/src/__tests__/DidCommModuleConfig.test.ts
@@ -1,0 +1,25 @@
+import { DidCommModuleConfig } from '../DidCommModuleConfig'
+
+describe('DidCommModuleConfig', () => {
+  describe('v2 default content encryption', () => {
+    test('defaults to A256CBC-HS512 for authcrypt', () => {
+      const config = new DidCommModuleConfig()
+      expect(config.v2DefaultAuthcryptContentEncryption).toBe('A256CBC-HS512')
+    })
+
+    test('defaults to A256CBC-HS512 for anoncrypt', () => {
+      const config = new DidCommModuleConfig()
+      expect(config.v2DefaultAnoncryptContentEncryption).toBe('A256CBC-HS512')
+    })
+
+    test('honors a configured anoncrypt override (A256GCM)', () => {
+      const config = new DidCommModuleConfig({ v2DefaultAnoncryptContentEncryption: 'A256GCM' })
+      expect(config.v2DefaultAnoncryptContentEncryption).toBe('A256GCM')
+    })
+
+    test('honors a configured anoncrypt override', () => {
+      const config = new DidCommModuleConfig({ v2DefaultAnoncryptContentEncryption: 'XC20P' })
+      expect(config.v2DefaultAnoncryptContentEncryption).toBe('XC20P')
+    })
+  })
+})

--- a/packages/didcomm/src/v2/DidCommV2EnvelopeService.ts
+++ b/packages/didcomm/src/v2/DidCommV2EnvelopeService.ts
@@ -22,7 +22,7 @@ export interface DidCommV2EnvelopeKeys {
   senderKey: Kms.PublicJwk<Kms.X25519PublicJwk>
   /** DID URL of the sender key; used as skid in JWE so recipient can resolve it. Falls back to senderKey.keyId if absent. */
   senderKeySkid?: string
-  /** Content encryption algorithm. Defaults to A256CBC-HS512 (mandatory authcrypt enc per DIDComm v2.1). XC20P is not allowed for authcrypt. */
+  /** Content encryption algorithm. Authcrypt is restricted to A256CBC-HS512 per DIDComm v2.1. */
   contentEncryptionAlgorithm?: DidCommV2AuthcryptContentEncryptionAlgorithm
 }
 

--- a/packages/didcomm/src/v2/DidCommV2EnvelopeService.ts
+++ b/packages/didcomm/src/v2/DidCommV2EnvelopeService.ts
@@ -10,22 +10,27 @@ import {
   TypedArrayEncoder,
 } from '@credo-ts/core'
 import { computeApu, computeApv } from './apuApv'
-import type { DidCommV2ContentEncryptionAlgorithm, DidCommV2EncryptedMessage, DidCommV2PlaintextMessage } from './types'
+import type {
+  DidCommV2AnoncryptContentEncryptionAlgorithm,
+  DidCommV2AuthcryptContentEncryptionAlgorithm,
+  DidCommV2EncryptedMessage,
+  DidCommV2PlaintextMessage,
+} from './types'
 
 export interface DidCommV2EnvelopeKeys {
   recipientKey: Kms.PublicJwk<Kms.X25519PublicJwk>
   senderKey: Kms.PublicJwk<Kms.X25519PublicJwk>
   /** DID URL of the sender key; used as skid in JWE so recipient can resolve it. Falls back to senderKey.keyId if absent. */
   senderKeySkid?: string
-  /** Content encryption algorithm. Defaults to A256CBC-HS512 (mandatory authcrypt enc per DIDComm v2.1). */
-  contentEncryptionAlgorithm?: DidCommV2ContentEncryptionAlgorithm
+  /** Content encryption algorithm. Defaults to A256CBC-HS512 (mandatory authcrypt enc per DIDComm v2.1). XC20P is not allowed for authcrypt. */
+  contentEncryptionAlgorithm?: DidCommV2AuthcryptContentEncryptionAlgorithm
 }
 
 /** Keys for anoncrypt: only recipient key; no sender (anonymous). */
 export interface DidCommV2AnoncryptKeys {
   recipientKey: Kms.PublicJwk<Kms.X25519PublicJwk>
   /** Content encryption algorithm. Defaults to A256CBC-HS512; A256GCM is also accepted. */
-  contentEncryptionAlgorithm?: DidCommV2ContentEncryptionAlgorithm
+  contentEncryptionAlgorithm?: DidCommV2AnoncryptContentEncryptionAlgorithm
 }
 
 @injectable()
@@ -57,7 +62,7 @@ export class DidCommV2EnvelopeService {
       throw new CredoError('DIDComm v2 authcrypt requires X25519 recipient key')
     }
 
-    const enc: DidCommV2ContentEncryptionAlgorithm = keys.contentEncryptionAlgorithm ?? 'A256CBC-HS512'
+    const enc: DidCommV2AuthcryptContentEncryptionAlgorithm = keys.contentEncryptionAlgorithm ?? 'A256CBC-HS512'
     const skid = keys.senderKeySkid ?? keys.senderKey.keyId
     const recipientKid = keys.recipientKey.keyId
     const apu = computeApu(skid)
@@ -142,7 +147,7 @@ export class DidCommV2EnvelopeService {
       throw new CredoError('DIDComm v2 anoncrypt requires X25519 recipient key')
     }
 
-    const enc: DidCommV2ContentEncryptionAlgorithm = keys.contentEncryptionAlgorithm ?? 'A256CBC-HS512'
+    const enc: DidCommV2AnoncryptContentEncryptionAlgorithm = keys.contentEncryptionAlgorithm ?? 'A256CBC-HS512'
     const recipientKid = keys.recipientKey.keyId
     const apv = computeApv([recipientKid])
 
@@ -305,7 +310,7 @@ export class DidCommV2EnvelopeService {
     },
     recipient: { header: { kid: string }; encrypted_key: string },
     epkX: string,
-    enc: DidCommV2ContentEncryptionAlgorithm,
+    enc: DidCommV2AnoncryptContentEncryptionAlgorithm,
     aad: Uint8Array,
     apv: Uint8Array
   ): Promise<{

--- a/packages/didcomm/src/v2/DidCommV2EnvelopeService.ts
+++ b/packages/didcomm/src/v2/DidCommV2EnvelopeService.ts
@@ -234,7 +234,7 @@ export class DidCommV2EnvelopeService {
     }
 
     const enc = protectedJson.enc
-    if (enc !== 'A256GCM' && enc !== 'A256CBC-HS512') {
+    if (enc !== 'A256GCM' && enc !== 'A256CBC-HS512' && enc !== 'XC20P') {
       throw new CredoError(`Unsupported enc: ${enc}`)
     }
 
@@ -257,6 +257,9 @@ export class DidCommV2EnvelopeService {
 
     if (protectedJson.alg !== 'ECDH-1PU+A256KW') {
       throw new CredoError(`Unsupported pack algorithm: ${protectedJson.alg}`)
+    }
+    if (enc === 'XC20P') {
+      throw new CredoError('XC20P content encryption is only valid with anoncrypt (ECDH-ES+A256KW)')
     }
 
     const skid = protectedJson.skid as string | undefined

--- a/packages/didcomm/src/v2/__tests__/DidCommV2EnvelopeService.askar.test.ts
+++ b/packages/didcomm/src/v2/__tests__/DidCommV2EnvelopeService.askar.test.ts
@@ -9,7 +9,11 @@ import { NodeFileSystem } from '../../../../node/src/NodeFileSystem'
 
 import { computeApu, computeApv } from '../apuApv'
 import { DidCommV2EnvelopeService } from '../DidCommV2EnvelopeService'
-import type { DidCommV2ContentEncryptionAlgorithm, DidCommV2PlaintextMessage } from '../types'
+import type {
+  DidCommV2AnoncryptContentEncryptionAlgorithm,
+  DidCommV2AuthcryptContentEncryptionAlgorithm,
+  DidCommV2PlaintextMessage,
+} from '../types'
 
 describe('DidCommV2EnvelopeService (Askar round-trip)', () => {
   const agentContext = getAgentContext({
@@ -62,7 +66,7 @@ describe('DidCommV2EnvelopeService (Askar round-trip)', () => {
   }
 
   describe('authcrypt', () => {
-    it.each<DidCommV2ContentEncryptionAlgorithm>([
+    it.each<DidCommV2AuthcryptContentEncryptionAlgorithm>([
       'A256CBC-HS512',
       'A256GCM',
     ])('round-trips with %s content encryption', async (enc) => {
@@ -102,7 +106,7 @@ describe('DidCommV2EnvelopeService (Askar round-trip)', () => {
   })
 
   describe('anoncrypt', () => {
-    it.each<DidCommV2ContentEncryptionAlgorithm>([
+    it.each<DidCommV2AnoncryptContentEncryptionAlgorithm>([
       'A256CBC-HS512',
       'A256GCM',
     ])('round-trips with %s content encryption', async (enc) => {

--- a/packages/didcomm/src/v2/__tests__/DidCommV2EnvelopeService.askar.test.ts
+++ b/packages/didcomm/src/v2/__tests__/DidCommV2EnvelopeService.askar.test.ts
@@ -109,6 +109,7 @@ describe('DidCommV2EnvelopeService (Askar round-trip)', () => {
     it.each<DidCommV2AnoncryptContentEncryptionAlgorithm>([
       'A256CBC-HS512',
       'A256GCM',
+      'XC20P',
     ])('round-trips with %s content encryption', async (enc) => {
       const encrypted = await envelopeService.packAnoncrypt(agentContext, plaintext, {
         recipientKey,

--- a/packages/didcomm/src/v2/__tests__/DidCommV2EnvelopeService.askar.test.ts
+++ b/packages/didcomm/src/v2/__tests__/DidCommV2EnvelopeService.askar.test.ts
@@ -68,7 +68,6 @@ describe('DidCommV2EnvelopeService (Askar round-trip)', () => {
   describe('authcrypt', () => {
     it.each<DidCommV2AuthcryptContentEncryptionAlgorithm>([
       'A256CBC-HS512',
-      'A256GCM',
     ])('round-trips with %s content encryption', async (enc) => {
       const encrypted = await envelopeService.pack(agentContext, plaintext, {
         senderKey,

--- a/packages/didcomm/src/v2/__tests__/DidCommV2EnvelopeService.test.ts
+++ b/packages/didcomm/src/v2/__tests__/DidCommV2EnvelopeService.test.ts
@@ -26,13 +26,20 @@ class MockEcdh1PuKeyManagementService implements Kms.KeyManagementService {
 
   isOperationSupported(_ctx: AgentContext, operation: Kms.KmsOperation): boolean {
     if (operation.operation === 'createKey') return operation.type.kty === 'OKP' && operation.type.crv === 'X25519'
+    const supportedEnc = ['A256GCM', 'A256CBC-HS512', 'XC20P']
     if (operation.operation === 'encrypt') {
       const alg = operation.keyAgreement?.algorithm
-      return operation.encryption?.algorithm === 'A256GCM' && (alg === 'ECDH-1PU+A256KW' || alg === 'ECDH-ES+A256KW')
+      return (
+        supportedEnc.includes(operation.encryption?.algorithm ?? '') &&
+        (alg === 'ECDH-1PU+A256KW' || alg === 'ECDH-ES+A256KW')
+      )
     }
     if (operation.operation === 'decrypt') {
       const alg = operation.keyAgreement?.algorithm
-      return operation.decryption?.algorithm === 'A256GCM' && (alg === 'ECDH-1PU+A256KW' || alg === 'ECDH-ES+A256KW')
+      return (
+        supportedEnc.includes(operation.decryption?.algorithm ?? '') &&
+        (alg === 'ECDH-1PU+A256KW' || alg === 'ECDH-ES+A256KW')
+      )
     }
     if (operation.operation === 'randomBytes') return true
     if (operation.operation === 'deleteKey') return true
@@ -86,8 +93,11 @@ class MockEcdh1PuKeyManagementService implements Kms.KeyManagementService {
     ) {
       throw new Error('Mock only supports ECDH-1PU+A256KW and ECDH-ES+A256KW')
     }
-    const iv = randomBytes(12)
-    const tag = randomBytes(16)
+    const enc = options.encryption.algorithm
+    const ivSize = enc === 'A256CBC-HS512' ? 16 : enc === 'XC20P' ? 24 : 12
+    const tagSize = enc === 'A256CBC-HS512' ? 32 : 16
+    const iv = randomBytes(ivSize)
+    const tag = randomBytes(tagSize)
     const epkX = TypedArrayEncoder.toBase64Url(randomBytes(32))
     const ephemeralPublicKey = { kty: 'OKP' as const, crv: 'X25519' as const, x: epkX }
     return {
@@ -165,7 +175,7 @@ describe('DidCommV2EnvelopeService', () => {
     const encrypted = await envelopeService.pack(agentContext, plaintext, {
       senderKey,
       recipientKey,
-      contentEncryptionAlgorithm: 'A256GCM',
+      contentEncryptionAlgorithm: 'A256CBC-HS512',
     })
 
     expect(encrypted).toMatchObject({
@@ -197,7 +207,7 @@ describe('DidCommV2EnvelopeService', () => {
 
     const encrypted = await envelopeService.packAnoncrypt(agentContext, plaintext, {
       recipientKey,
-      contentEncryptionAlgorithm: 'A256GCM',
+      contentEncryptionAlgorithm: 'A256CBC-HS512',
     })
 
     expect(encrypted).toMatchObject({

--- a/packages/didcomm/src/v2/__tests__/__fixtures__/sicpa/anoncrypt-x25519-xc20p.json
+++ b/packages/didcomm/src/v2/__tests__/__fixtures__/sicpa/anoncrypt-x25519-xc20p.json
@@ -1,0 +1,49 @@
+{
+  "$description": "SICPA didcomm-python TEST_ENCRYPTED_DIDCOMM_MESSAGE_ANON_XC20P_1: anoncrypt with ECDH-ES+A256KW, XC20P, X25519. Anonymous sender -> Bob (4 X25519 keys).",
+  "$source": "https://github.com/sicpa-dlab/didcomm-python/blob/main/tests/test_vectors/didcomm_messages/spec/spec_test_vectors_anon_encrypted.py",
+  "$license": "Apache-2.0",
+  "encryptedMessage": {
+    "protected": "eyJ0eXAiOiJhcHBsaWNhdGlvbi9kaWRjb21tLWVuY3J5cHRlZCtqc29uIiwiYWxnIjoiRUNESC1FUytBMjU2S1ciLCJlbmMiOiJYQzIwUCIsImFwdiI6IlkxWXh3b053WU5HNGRKRlBKanZtLTk0aWJhdXFBOUhyV0tZWmhtY29lU2ciLCJlcGsiOnsiY3J2IjoiWDI1NTE5IiwieCI6ImFNZzU4X1JqT2dGcjhZQWtCdmptOXhKYVZ3bnlXRVRmRFpYaGMyWVctamMiLCJrdHkiOiJPS1AifX0",
+    "recipients": [
+      {
+        "header": { "kid": "did:example:bob#key-x25519-1" },
+        "encrypted_key": "ThzyeMnViwuOEK3LLAhKXyoTUCOcBhaa4FxMvC1F3nLI9oXeKJjtPQ"
+      },
+      {
+        "header": { "kid": "did:example:bob#key-x25519-2" },
+        "encrypted_key": "yglsPC468bnwGL2aPcbGZUdvWFSipmoP9wJoaWqWVc3Ce56jI5v9xQ"
+      },
+      {
+        "header": { "kid": "did:example:bob#key-x25519-3" },
+        "encrypted_key": "SpAP0Gzo2lazwfAPyMhaTd1GlO6aRTmXngDu3j9iFwXetow_FkVxsw"
+      },
+      {
+        "header": { "kid": "did:example:bob#key-x25519-4" },
+        "encrypted_key": "_bWWYGGUZ2ITqcGDdP7C1_LkYb_2qtOaXQ3sWyoK6g161SGxsWEpoQ"
+      }
+    ],
+    "iv": "9AVo9rQR0ZX7QEhguuRWV-JcCbwkaa3x",
+    "ciphertext": "lSto80zaVP0ywIYzF2ecD01SM1xyqqPexRcZ8f-7D1T00AEWdTfJxw3Hp1ktNJFHpj5RHbFomrJy9LXErJWZXQWxmZBhmcIfZwu0b70Nq20m8I4oI-ZN2twVGMApFj-M98aZ11M17SI8jToOPPFJAdfLKBM3Q1nFW4LoqJZQgbRt0T2pHhgeS-xlwzSbC3aNpYPcfm-eceDrZis_GKgvCx5Jqw6BQdSYRxAXIwIM68owSAn9wAPTZlAqgyMXs3aZGvVSGYx6_PnWIqBhubdQ9hod2-XHUzT054MUJPCF16jC1K1qgOYrZguQC6FF0Ly9_Zcr1NQCZSeJLSuSP6BWtDsFaoVC5bLVDAtmqjKgI2uRlo6KaBaXq1f_nzIx_JfBPX8fmSI9k9nfBU0",
+    "tag": "NW406iWJxQucfftvd5Cy9Q"
+  },
+  "expectedPlaintext": {
+    "id": "1234567890",
+    "thid": "1234567890",
+    "typ": "application/didcomm-plain+json",
+    "type": "http://example.com/protocols/lets_do_lunch/1.0/proposal",
+    "from": "did:example:alice",
+    "to": ["did:example:bob"],
+    "created_time": 1516269022,
+    "expires_time": 1516385931,
+    "body": { "messagespecificattribute": "and its value" }
+  },
+  "recipient": {
+    "kid": "did:example:bob#key-x25519-1",
+    "privateJwk": {
+      "kty": "OKP",
+      "crv": "X25519",
+      "d": "b9NnuOCB0hm7YGNvaE9DMhwH_wjZA1-gWD6dA0JWdL0",
+      "x": "GDTrI66K0pFfO54tlCSvfjjNapIs44dzpneBgyx0S3E"
+    }
+  }
+}

--- a/packages/didcomm/src/v2/__tests__/interop/sicpaAnoncryptInterop.test.ts
+++ b/packages/didcomm/src/v2/__tests__/interop/sicpaAnoncryptInterop.test.ts
@@ -1,0 +1,81 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+import { InjectionSymbols, Kms } from '@credo-ts/core'
+import { askar } from '@openwallet-foundation/askar-nodejs'
+
+import { AskarModuleConfig, AskarMultiWalletDatabaseScheme } from '../../../../../askar/src/AskarModuleConfig'
+import { AskarKeyManagementService } from '../../../../../askar/src/kms/AskarKeyManagementService'
+import { getAgentConfig, getAgentContext } from '../../../../../core/tests/helpers'
+import testLogger from '../../../../../core/tests/logger'
+import { NodeFileSystem } from '../../../../../node/src/NodeFileSystem'
+
+import { DidCommV2EnvelopeService } from '../../DidCommV2EnvelopeService'
+import type { DidCommV2EncryptedMessage, DidCommV2PlaintextMessage } from '../../types'
+
+interface X25519PrivateJwk {
+  kty: 'OKP'
+  crv: 'X25519'
+  d: string
+  x: string
+}
+
+interface SicpaAnoncryptFixture {
+  encryptedMessage: DidCommV2EncryptedMessage
+  expectedPlaintext: DidCommV2PlaintextMessage
+  recipient: { kid: string; privateJwk: X25519PrivateJwk }
+}
+
+const fixture = JSON.parse(
+  readFileSync(path.join(__dirname, '../__fixtures__/sicpa/anoncrypt-x25519-xc20p.json'), 'utf-8')
+) as SicpaAnoncryptFixture
+
+describe('SICPA anoncrypt X25519 + XC20P interop', () => {
+  const agentContext = getAgentContext({
+    contextCorrelationId: 'sicpa-anoncrypt-x25519-xc20p',
+    agentConfig: getAgentConfig('SicpaAnoncryptXC20PInterop'),
+    kmsBackends: [new AskarKeyManagementService()],
+    registerInstances: [
+      [InjectionSymbols.Logger, testLogger],
+      [InjectionSymbols.FileSystem, new NodeFileSystem()],
+      [
+        AskarModuleConfig,
+        new AskarModuleConfig({
+          multiWalletDatabaseScheme: AskarMultiWalletDatabaseScheme.ProfilePerWallet,
+          askar,
+          store: {
+            id: 'sicpa-anoncrypt-x25519-xc20p',
+            key: 'CwNJroKHTSSj3XvE7ZAnuKiTn2C4QkFvxEqfm5rzhNrb',
+            keyDerivationMethod: 'raw',
+            database: { type: 'sqlite', config: { inMemory: true } },
+          },
+        }),
+      ],
+    ],
+  })
+
+  let envelopeService: DidCommV2EnvelopeService
+  let recipientKey: Kms.PublicJwk<Kms.X25519PublicJwk> & { keyId: string }
+
+  beforeAll(async () => {
+    agentContext.dependencyManager.registerSingleton(DidCommV2EnvelopeService)
+    envelopeService = agentContext.dependencyManager.resolve(DidCommV2EnvelopeService)
+
+    const kms = agentContext.dependencyManager.resolve(Kms.KeyManagementApi)
+    const imported = await kms.importKey({ privateJwk: fixture.recipient.privateJwk })
+    const recipient = Kms.PublicJwk.fromPublicJwk(imported.publicJwk) as Kms.PublicJwk<Kms.X25519PublicJwk>
+    recipient.keyId = imported.keyId
+    recipientKey = recipient as Kms.PublicJwk<Kms.X25519PublicJwk> & { keyId: string }
+  })
+
+  it('decrypts SICPA TEST_ENCRYPTED_DIDCOMM_MESSAGE_ANON_XC20P_1', async () => {
+    const { plaintext, senderKey } = await envelopeService.unpack(agentContext, fixture.encryptedMessage, {
+      recipientKey,
+      matchedKid: fixture.recipient.kid,
+      resolveSenderKey: async () => null,
+    })
+
+    expect(plaintext).toEqual(fixture.expectedPlaintext)
+    expect(senderKey).toBeNull()
+  })
+})

--- a/packages/didcomm/src/v2/types.ts
+++ b/packages/didcomm/src/v2/types.ts
@@ -42,8 +42,8 @@ export interface DidCommV2Attachment {
 export const DIDCOMM_V2_PLAIN_MIME_TYPE = 'application/didcomm-plain+json'
 export const DIDCOMM_V2_ENCRYPTED_MIME_TYPE = 'application/didcomm-encrypted+json'
 
-export type DidCommV2AuthcryptContentEncryptionAlgorithm = 'A256GCM' | 'A256CBC-HS512'
-export type DidCommV2AnoncryptContentEncryptionAlgorithm = 'A256GCM' | 'A256CBC-HS512' | 'XC20P'
+export type DidCommV2AuthcryptContentEncryptionAlgorithm = 'A256CBC-HS512'
+export type DidCommV2AnoncryptContentEncryptionAlgorithm = 'A256CBC-HS512' | 'A256GCM' | 'XC20P'
 export type DidCommV2ContentEncryptionAlgorithm =
   | DidCommV2AuthcryptContentEncryptionAlgorithm
   | DidCommV2AnoncryptContentEncryptionAlgorithm

--- a/packages/didcomm/src/v2/types.ts
+++ b/packages/didcomm/src/v2/types.ts
@@ -42,7 +42,11 @@ export interface DidCommV2Attachment {
 export const DIDCOMM_V2_PLAIN_MIME_TYPE = 'application/didcomm-plain+json'
 export const DIDCOMM_V2_ENCRYPTED_MIME_TYPE = 'application/didcomm-encrypted+json'
 
-export type DidCommV2ContentEncryptionAlgorithm = 'A256GCM' | 'A256CBC-HS512'
+export type DidCommV2AuthcryptContentEncryptionAlgorithm = 'A256GCM' | 'A256CBC-HS512'
+export type DidCommV2AnoncryptContentEncryptionAlgorithm = 'A256GCM' | 'A256CBC-HS512' | 'XC20P'
+export type DidCommV2ContentEncryptionAlgorithm =
+  | DidCommV2AuthcryptContentEncryptionAlgorithm
+  | DidCommV2AnoncryptContentEncryptionAlgorithm
 
 export interface DidCommV2JweRecipient {
   header: { kid: string }


### PR DESCRIPTION
Adds XC20P anoncrypt support and two `DidCommModuleConfig` options (`v2DefaultAuthcryptContentEncryption`, `v2DefaultAnoncryptContentEncryption`) for overriding the content-encryption defaults. Also tightens the authcrypt content-encryption type to A256CBC-HS512 only, since the DIDComm v2.1 algorithm table lists only A256CBC-HS512 for authcrypt and SICPA's `AuthCryptAlg` enum has a single variant. Anoncrypt default is now A256CBC-HS512 (Required per spec) instead of A256GCM.