### PR TITLE
feat(didcomm-v2): support P-256 keyAgreement

### DIFF
--- a/packages/askar/src/kms/crypto/deriveKey.ts
+++ b/packages/askar/src/kms/crypto/deriveKey.ts
@@ -35,14 +35,24 @@ export function encryptEcdh1Pu(options: {
 }) {
   const { keyAgreement, encryption, senderKey, recipientKey, data, ephemeralKey: providedEphemeralKey } = options
 
-  if (senderKey.algorithm !== KeyAlgorithm.X25519 || recipientKey.algorithm !== KeyAlgorithm.X25519) {
+  const supportedAlgorithms: KeyAlgorithm[] = [KeyAlgorithm.X25519, KeyAlgorithm.EcSecp256r1]
+  if (!supportedAlgorithms.includes(senderKey.algorithm) || !supportedAlgorithms.includes(recipientKey.algorithm)) {
     throw new Kms.KeyManagementAlgorithmNotSupportedError(
-      'ECDH-1PU+A256KW requires X25519 sender and recipient keys',
+      'ECDH-1PU+A256KW requires X25519 or P-256 sender and recipient keys',
       'askar'
     )
   }
-  if (providedEphemeralKey && providedEphemeralKey.algorithm !== KeyAlgorithm.X25519) {
-    throw new Kms.KeyManagementAlgorithmNotSupportedError('ECDH-1PU+A256KW requires an X25519 ephemeral key', 'askar')
+  if (senderKey.algorithm !== recipientKey.algorithm) {
+    throw new Kms.KeyManagementAlgorithmNotSupportedError(
+      'ECDH-1PU+A256KW sender and recipient keys must be on the same curve',
+      'askar'
+    )
+  }
+  if (providedEphemeralKey && providedEphemeralKey.algorithm !== recipientKey.algorithm) {
+    throw new Kms.KeyManagementAlgorithmNotSupportedError(
+      'ECDH-1PU+A256KW ephemeral key must match the recipient curve',
+      'askar'
+    )
   }
   const askarEncryptionAlgorithm = jwkEncToAskarAlg[encryption.algorithm as keyof typeof jwkEncToAskarAlg]
   if (!askarEncryptionAlgorithm) {
@@ -52,7 +62,7 @@ export function encryptEcdh1Pu(options: {
     )
   }
 
-  const ephemeralKey = providedEphemeralKey ?? Key.generate(KeyAlgorithm.X25519)
+  const ephemeralKey = providedEphemeralKey ?? Key.generate(recipientKey.algorithm)
   const ownsEphemeralKey = !providedEphemeralKey
   const apu = keyAgreement.apu ? new Uint8Array(keyAgreement.apu) : new Uint8Array([])
   const apv = keyAgreement.apv ? new Uint8Array(keyAgreement.apv) : new Uint8Array([])
@@ -77,11 +87,7 @@ export function encryptEcdh1Pu(options: {
       })
     )
     const wrappedKey = derivedKey.wrapKey({ other: contentEncryptionKey })
-    const ephemeralPublicKey = {
-      kty: 'OKP',
-      crv: 'X25519',
-      x: TypedArrayEncoder.toBase64Url(ephemeralKey.publicBytes),
-    } as const
+    const ephemeralPublicKey = ephemeralKey.jwkPublic as Kms.KmsJwkPublicEcdh
 
     return {
       encrypted: aeadResult.encrypted,
@@ -288,8 +294,18 @@ function deriveDecryptionKeyEcdh1Pu(options: {
 }) {
   const { keyAgreement, decryption, ephemeralKey, senderKey, recipientKey } = options
 
-  if (recipientKey.algorithm !== KeyAlgorithm.X25519) {
-    throw new Kms.KeyManagementAlgorithmNotSupportedError('ECDH-1PU+A256KW requires X25519 recipient key', 'askar')
+  const supportedAlgorithms: KeyAlgorithm[] = [KeyAlgorithm.X25519, KeyAlgorithm.EcSecp256r1]
+  if (!supportedAlgorithms.includes(recipientKey.algorithm)) {
+    throw new Kms.KeyManagementAlgorithmNotSupportedError(
+      'ECDH-1PU+A256KW requires X25519 or P-256 recipient key',
+      'askar'
+    )
+  }
+  if (ephemeralKey.algorithm !== recipientKey.algorithm || senderKey.algorithm !== recipientKey.algorithm) {
+    throw new Kms.KeyManagementAlgorithmNotSupportedError(
+      'ECDH-1PU+A256KW sender, ephemeral, and recipient keys must be on the same curve',
+      'askar'
+    )
   }
 
   const askarEncryptionAlgorithm = jwkEncToAskarAlg[decryption.algorithm as keyof typeof jwkEncToAskarAlg]

--- a/packages/core/src/modules/dids/domain/DidDocument.ts
+++ b/packages/core/src/modules/dids/domain/DidDocument.ts
@@ -246,7 +246,8 @@ export class DidDocument {
   }): Array<{
     verificationMethod: VerificationMethod
     publicJwk: PublicJwk<
-      MapX25519ToEd25519 extends true ? Ed25519PublicJwk : Ed25519PublicJwk | X25519PublicJwk | P256PublicJwk
+      | (MapX25519ToEd25519 extends true ? Ed25519PublicJwk : Ed25519PublicJwk | X25519PublicJwk)
+      | P256PublicJwk
     >
   }> {
     const recipientKeys: Array<{
@@ -332,15 +333,15 @@ export class DidDocument {
     if (!mapX25519ToEd25519) {
       return recipientKeys as Array<{
         verificationMethod: VerificationMethod
-        publicJwk: PublicJwk<MapX25519ToEd25519 extends true ? Ed25519PublicJwk : Ed25519PublicJwk | X25519PublicJwk>
+        publicJwk: PublicJwk<
+          | (MapX25519ToEd25519 extends true ? Ed25519PublicJwk : Ed25519PublicJwk | X25519PublicJwk)
+          | P256PublicJwk
+        >
       }>
     }
 
     return recipientKeys.flatMap(({ publicJwk, verificationMethod }) => {
-      if (publicJwk.is(Ed25519PublicJwk)) return [{ publicJwk, verificationMethod }]
-
-      // P-256 has no Ed25519 birational sibling; skip in the v1-compatible mapping.
-      if (publicJwk.is(P256PublicJwk)) return []
+      if (publicJwk.is(Ed25519PublicJwk, P256PublicJwk)) return [{ publicJwk, verificationMethod }]
 
       const matchingEd25519Key = findMatchingEd25519Key(publicJwk as PublicJwk<X25519PublicJwk>, this)
 

--- a/packages/core/src/modules/dids/domain/DidDocument.ts
+++ b/packages/core/src/modules/dids/domain/DidDocument.ts
@@ -4,7 +4,7 @@ import { CredoError } from '../../../error'
 import { TypedArrayEncoder } from '../../../utils'
 import { JsonTransformer } from '../../../utils/JsonTransformer'
 import { IsStringOrStringArray } from '../../../utils/transformers'
-import { Ed25519PublicJwk, PublicJwk, X25519PublicJwk } from '../../kms'
+import { Ed25519PublicJwk, P256PublicJwk, PublicJwk, X25519PublicJwk } from '../../kms'
 import { findMatchingEd25519Key } from '../findMatchingEd25519Key'
 import { getPublicJwkFromVerificationMethod } from './key-type'
 import type { DidDocumentService } from './service'
@@ -227,7 +227,7 @@ export class DidDocument {
   }
 
   // TODO: it would probably be easier if we add a utility to each service so we don't have to handle logic for all service types here
-  public get recipientKeys(): PublicJwk<Ed25519PublicJwk | X25519PublicJwk>[] {
+  public get recipientKeys(): PublicJwk<Ed25519PublicJwk | X25519PublicJwk | P256PublicJwk>[] {
     return this.getRecipientKeysWithVerificationMethod({
       // False for now to avoid breaking changes
       mapX25519ToEd25519: false,
@@ -245,11 +245,13 @@ export class DidDocument {
     mapX25519ToEd25519: MapX25519ToEd25519
   }): Array<{
     verificationMethod: VerificationMethod
-    publicJwk: PublicJwk<MapX25519ToEd25519 extends true ? Ed25519PublicJwk : Ed25519PublicJwk | X25519PublicJwk>
+    publicJwk: PublicJwk<
+      MapX25519ToEd25519 extends true ? Ed25519PublicJwk : Ed25519PublicJwk | X25519PublicJwk | P256PublicJwk
+    >
   }> {
     const recipientKeys: Array<{
       verificationMethod: VerificationMethod
-      publicJwk: PublicJwk<Ed25519PublicJwk | X25519PublicJwk>
+      publicJwk: PublicJwk<Ed25519PublicJwk | X25519PublicJwk | P256PublicJwk>
     }> = []
 
     const seenVerificationMethodIds: string[] = []
@@ -314,7 +316,7 @@ export class DidDocument {
           }
 
           const publicJwk = getPublicJwkFromVerificationMethod(verificationMethod)
-          if (!publicJwk.is(Ed25519PublicJwk) && !publicJwk.is(X25519PublicJwk)) {
+          if (!publicJwk.is(Ed25519PublicJwk, X25519PublicJwk, P256PublicJwk)) {
             continue
           }
 
@@ -334,8 +336,11 @@ export class DidDocument {
       }>
     }
 
-    return recipientKeys.map(({ publicJwk, verificationMethod }) => {
-      if (publicJwk.is(Ed25519PublicJwk)) return { publicJwk, verificationMethod }
+    return recipientKeys.flatMap(({ publicJwk, verificationMethod }) => {
+      if (publicJwk.is(Ed25519PublicJwk)) return [{ publicJwk, verificationMethod }]
+
+      // P-256 has no Ed25519 birational sibling; skip in the v1-compatible mapping.
+      if (publicJwk.is(P256PublicJwk)) return []
 
       const matchingEd25519Key = findMatchingEd25519Key(publicJwk as PublicJwk<X25519PublicJwk>, this)
 
@@ -346,7 +351,7 @@ export class DidDocument {
         )
       }
 
-      return matchingEd25519Key
+      return [matchingEd25519Key]
     })
   }
 

--- a/packages/core/src/modules/kms/jwk/alg/keyDerivation.ts
+++ b/packages/core/src/modules/kms/jwk/alg/keyDerivation.ts
@@ -25,8 +25,12 @@ export function supportedKeyDerivationAlgsForKey(
     algs.push('ECDH-ES', 'ECDH-ES+A128KW', 'ECDH-ES+A192KW', 'ECDH-ES+A256KW')
   }
 
-  // ECDH-1PU+A256KW (e.g. DIDComm v2): X25519 natively; Ed25519 may be converted to X25519 by the KMS
+  // ECDH-1PU+A256KW (e.g. DIDComm v2): X25519 natively; Ed25519 may be converted to X25519 by the KMS.
+  // P-256 is also valid per DIDComm v2.1; askar-crypto's Ecdh1PU is generic over any KeyExchange curve.
   if (jwk.kty === 'OKP' && (jwk.crv === 'X25519' || jwk.crv === 'Ed25519')) {
+    algs.push('ECDH-1PU+A256KW')
+  }
+  if (jwk.kty === 'EC' && jwk.crv === 'P-256') {
     algs.push('ECDH-1PU+A256KW')
   }
   if (jwk.kty === 'OKP' && (jwk.crv === 'X25519' || jwk.crv === 'Ed25519')) {

--- a/packages/core/src/modules/kms/jwk/alg/keyDerivation.ts
+++ b/packages/core/src/modules/kms/jwk/alg/keyDerivation.ts
@@ -25,8 +25,7 @@ export function supportedKeyDerivationAlgsForKey(
     algs.push('ECDH-ES', 'ECDH-ES+A128KW', 'ECDH-ES+A192KW', 'ECDH-ES+A256KW')
   }
 
-  // ECDH-1PU+A256KW (e.g. DIDComm v2): X25519 natively; Ed25519 may be converted to X25519 by the KMS.
-  // P-256 is also valid per DIDComm v2.1; askar-crypto's Ecdh1PU is generic over any KeyExchange curve.
+  // ECDH-1PU+A256KW (e.g. DIDComm v2): X25519 natively; Ed25519 may be converted to X25519 by the KMS
   if (jwk.kty === 'OKP' && (jwk.crv === 'X25519' || jwk.crv === 'Ed25519')) {
     algs.push('ECDH-1PU+A256KW')
   }

--- a/packages/core/src/modules/kms/jwk/kty/ec/P256PublicJwk.ts
+++ b/packages/core/src/modules/kms/jwk/kty/ec/P256PublicJwk.ts
@@ -7,7 +7,13 @@ type Jwk = KmsJwkPublicEc & { crv: 'P-256' }
 
 export class P256PublicJwk implements PublicJwkType<Jwk> {
   public static supportedSignatureAlgorithms: KnownJwaSignatureAlgorithm[] = [KnownJwaSignatureAlgorithms.ES256]
-  public static supportedEncryptionKeyAgreementAlgorithms = [KnownJwaKeyAgreementAlgorithms.ECDH_ES]
+  public static supportedEncryptionKeyAgreementAlgorithms = [
+    KnownJwaKeyAgreementAlgorithms.ECDH_ES,
+    KnownJwaKeyAgreementAlgorithms.ECDH_ES_A128KW,
+    KnownJwaKeyAgreementAlgorithms.ECDH_ES_A192KW,
+    KnownJwaKeyAgreementAlgorithms.ECDH_ES_A256KW,
+    KnownJwaKeyAgreementAlgorithms.ECDH_1PU_A256KW,
+  ]
   public static multicodecPrefix = 4608
 
   public supportedEncryptionKeyAgreementAlgorithms = P256PublicJwk.supportedEncryptionKeyAgreementAlgorithms

--- a/packages/core/src/modules/kms/options/KmsKeyAgreementEncryptOptions.ts
+++ b/packages/core/src/modules/kms/options/KmsKeyAgreementEncryptOptions.ts
@@ -66,7 +66,7 @@ export type KmsKeyAgreementEncryptEcdhHsalsa20 = z.output<typeof zKmsKeyAgreemen
 const zKmsKeyAgreementEncryptEcdh1Pu = z.object({
   keyId: zKmsKeyId,
   algorithm: z.literal('ECDH-1PU+A256KW'),
-  externalPublicJwk: zKmsJwkPublicOkp.extend({ crv: zKmsJwkPublicOkp.shape.crv.extract(['X25519']) }),
+  externalPublicJwk: zKmsJwkPublicEcdh,
 
   /**
    * Optional id of a caller-provided ephemeral key. When set, the KMS uses this key for the

--- a/packages/core/tests/DidCommV2P256Connection.e2e.test.ts
+++ b/packages/core/tests/DidCommV2P256Connection.e2e.test.ts
@@ -1,5 +1,5 @@
 import { Agent } from '../src/agent/Agent'
-import { getAgentOptions } from './helpers'
+import { getAgentOptions, waitForTrustPingResponseReceivedEvent } from './helpers'
 import { setupSubjectTransports } from './transport'
 
 const faberAgent = new Agent(
@@ -44,7 +44,7 @@ describe('DIDComm v2 P-256 connection', () => {
     await aliceAgent.shutdown()
   })
 
-  it('establishes a bidirectional v2 OOB connection with P-256 keyAgreement', async () => {
+  it('establishes a bidirectional v2 OOB connection and round-trips a trust ping over P-256', async () => {
     const invAlice = await aliceAgent.didcomm.oob.createInvitation({ didCommVersion: 'v2' })
     const aliceDid = invAlice.outOfBandInvitation.v2Invitation?.from as string
     const { connectionRecord: faberConn0, outOfBandRecord: faberOob0 } = await faberAgent.didcomm.oob.receiveInvitation(
@@ -75,5 +75,8 @@ describe('DIDComm v2 P-256 connection', () => {
     expect(aliceConnection.did).toBeDefined()
     expect(faberConnection.theirDid).toBe(aliceDid)
     expect(aliceConnection.theirDid).toBe(faberConnection.did)
+
+    const ping = await aliceAgent.didcomm.connections.sendPing(aliceConnection.id, {})
+    await waitForTrustPingResponseReceivedEvent(aliceAgent, { threadId: ping.threadId })
   }, 30000)
 })

--- a/packages/core/tests/DidCommV2P256Connection.e2e.test.ts
+++ b/packages/core/tests/DidCommV2P256Connection.e2e.test.ts
@@ -1,0 +1,79 @@
+import { Agent } from '../src/agent/Agent'
+import { getAgentOptions } from './helpers'
+import { setupSubjectTransports } from './transport'
+
+const faberAgent = new Agent(
+  getAgentOptions(
+    'Faber Agent DIDComm v2 P-256',
+    {
+      endpoints: ['rxjs:faber-p256'],
+      didcommVersions: ['v1', 'v2'],
+      v2KeyAgreementCurve: 'P-256',
+      connections: { autoAcceptConnections: true, autoCreateConnectionOnFirstMessage: true },
+    },
+    undefined,
+    undefined,
+    { requireDidcomm: true }
+  )
+)
+
+const aliceAgent = new Agent(
+  getAgentOptions(
+    'Alice Agent DIDComm v2 P-256',
+    {
+      endpoints: ['rxjs:alice-p256'],
+      didcommVersions: ['v1', 'v2'],
+      v2KeyAgreementCurve: 'P-256',
+      connections: { autoAcceptConnections: true, autoCreateConnectionOnFirstMessage: true },
+    },
+    undefined,
+    undefined,
+    { requireDidcomm: true }
+  )
+)
+
+describe('DIDComm v2 P-256 connection', () => {
+  beforeEach(async () => {
+    setupSubjectTransports([faberAgent, aliceAgent])
+    await faberAgent.initialize()
+    await aliceAgent.initialize()
+  })
+
+  afterEach(async () => {
+    await faberAgent.shutdown()
+    await aliceAgent.shutdown()
+  })
+
+  it('establishes a bidirectional v2 OOB connection with P-256 keyAgreement', async () => {
+    const invAlice = await aliceAgent.didcomm.oob.createInvitation({ didCommVersion: 'v2' })
+    const aliceDid = invAlice.outOfBandInvitation.v2Invitation?.from as string
+    const { connectionRecord: faberConn0, outOfBandRecord: faberOob0 } = await faberAgent.didcomm.oob.receiveInvitation(
+      invAlice.outOfBandInvitation,
+      { label: '' }
+    )
+    const faberConnId =
+      faberConn0?.id ?? (await faberAgent.didcomm.connections.findAllByOutOfBandId(faberOob0.id))[0]?.id
+    const faberConnection = await faberAgent.didcomm.connections.returnWhenIsConnected(faberConnId as string, {
+      timeoutMs: 20000,
+    })
+
+    const invFaber = await faberAgent.didcomm.oob.createInvitation({
+      didCommVersion: 'v2',
+      ourDid: faberConnection.did,
+    })
+    const { connectionRecord: aliceConn0, outOfBandRecord: aliceOob0 } = await aliceAgent.didcomm.oob.receiveInvitation(
+      invFaber.outOfBandInvitation,
+      { label: '', ourDid: aliceDid }
+    )
+    const aliceConnId =
+      aliceConn0?.id ?? (await aliceAgent.didcomm.connections.findAllByOutOfBandId(aliceOob0.id))[0]?.id
+    const aliceConnection = await aliceAgent.didcomm.connections.returnWhenIsConnected(aliceConnId as string, {
+      timeoutMs: 20000,
+    })
+
+    expect(faberConnection.did).toBeDefined()
+    expect(aliceConnection.did).toBeDefined()
+    expect(faberConnection.theirDid).toBe(aliceDid)
+    expect(aliceConnection.theirDid).toBe(faberConnection.did)
+  }, 30000)
+})

--- a/packages/didcomm/src/DidCommMessageSender.ts
+++ b/packages/didcomm/src/DidCommMessageSender.ts
@@ -30,13 +30,18 @@ import { MessageSendingError } from './errors'
 import { DidCommOutboundMessageContext, OutboundMessageSendStatus } from './models'
 import type { DidCommConnectionRecord } from './modules/connections/repository'
 import { DidCommConnectionMetadataKeys } from './modules/connections/repository/DidCommConnectionMetadataTypes'
-import { toX25519 } from './modules/connections/services/helpers'
+import { toKeyAgreement } from './modules/connections/services/helpers'
 import type { DidCommOutOfBandRecord } from './modules/oob/repository'
 import { DidCommOutOfBandRepository } from './modules/oob/repository'
 import { DidCommForwardV2Message } from './modules/routing/protocol/v2/messages'
 import { DidCommDocumentService } from './services/DidCommDocumentService'
 import type { DidCommEncryptedMessage, DidCommOutboundPackage } from './types'
-import { buildV2PlaintextFromMessage, DidCommV2EnvelopeService, type DidCommV2PlaintextMessage } from './v2'
+import {
+  buildV2PlaintextFromMessage,
+  DidCommV2EnvelopeService,
+  type DidCommV2KeyAgreementJwk,
+  type DidCommV2PlaintextMessage,
+} from './v2'
 
 export interface TransportPriorityOptions {
   schemes: string[]
@@ -122,14 +127,14 @@ export class DidCommMessageSender {
       keys.senderKey
     ) {
       try {
-        const recipientX25519 = toX25519(keys.recipientKeys[0])
+        const recipientKeyAgreement = toKeyAgreement(keys.recipientKeys[0])
         // Use did:key as kid when no explicit keyId — includes multicodec prefix so receiver
-        // can unambiguously determine the key type (Ed25519 vs X25519).
-        recipientX25519.keyId = keys.recipientKeys[0].hasKeyId
+        // can unambiguously determine the key type.
+        recipientKeyAgreement.keyId = keys.recipientKeys[0].hasKeyId
           ? keys.recipientKeys[0].keyId
           : new DidKey(keys.recipientKeys[0]).did
-        const senderX25519 = toX25519(keys.senderKey)
-        senderX25519.keyId = keys.senderKey.hasKeyId ? keys.senderKey.keyId : keys.senderKey.legacyKeyId
+        const senderKeyAgreementJwk = toKeyAgreement(keys.senderKey)
+        senderKeyAgreementJwk.keyId = keys.senderKey.hasKeyId ? keys.senderKey.keyId : keys.senderKey.legacyKeyId
         const plaintext = buildV2PlaintextFromMessage(message, {
           useDidSovPrefixWhereAllowed: this.didCommModuleConfig.useDidSovPrefixWhereAllowed,
           ...(connection?.did && connection?.theirDid
@@ -147,8 +152,8 @@ export class DidCommMessageSender {
           hasFromPrior: plaintext.from_prior !== undefined,
         })
         encryptedMessage = await this.v2EnvelopeService.pack(agentContext, plaintext, {
-          recipientKey: recipientX25519,
-          senderKey: senderX25519,
+          recipientKey: recipientKeyAgreement,
+          senderKey: senderKeyAgreementJwk,
           senderKeySkid: keys.senderKeySkid,
         })
       } catch (error) {
@@ -179,11 +184,11 @@ export class DidCommMessageSender {
     _plaintext: DidCommV2PlaintextMessage,
     keys: EnvelopeKeys
   ): string {
-    // toX25519 ensures we always build the did:key from an X25519 fingerprint,
+    // toKeyAgreement ensures we always build the did:key from a keyAgreement fingerprint,
     // so the form matches what the holder registered regardless of whether the
-    // peer DID stored an Ed25519 auth VM or an X25519 keyAgreement VM.
-    const x25519 = toX25519(keys.recipientKeys[0])
-    return new DidKey(x25519).did
+    // peer DID stored an Ed25519 auth VM or a keyAgreement VM (X25519 or P-256).
+    const keyAgreement = toKeyAgreement(keys.recipientKeys[0])
+    return new DidKey(keyAgreement).did
   }
 
   private async packV2WithForward(
@@ -192,15 +197,15 @@ export class DidCommMessageSender {
     keys: EnvelopeKeys,
     connection?: DidCommConnectionRecord
   ): Promise<DidCommEncryptedMessage> {
-    const recipientX25519 = toX25519(keys.recipientKeys[0])
-    recipientX25519.keyId = keys.recipientKeys[0].hasKeyId
+    const recipientKeyAgreement = toKeyAgreement(keys.recipientKeys[0])
+    recipientKeyAgreement.keyId = keys.recipientKeys[0].hasKeyId
       ? keys.recipientKeys[0].keyId
       : new DidKey(keys.recipientKeys[0]).did
     if (!keys.senderKey) {
       throw new CredoError('DIDComm v2 pack requires a sender key')
     }
-    const senderX25519 = toX25519(keys.senderKey)
-    senderX25519.keyId = keys.senderKey.hasKeyId ? keys.senderKey.keyId : keys.senderKey.legacyKeyId
+    const senderKeyAgreementJwk = toKeyAgreement(keys.senderKey)
+    senderKeyAgreementJwk.keyId = keys.senderKey.hasKeyId ? keys.senderKey.keyId : keys.senderKey.legacyKeyId
 
     const tagsTheirDid = connection?.getTags().theirDid
     const theirDidForEnvelope =
@@ -213,8 +218,8 @@ export class DidCommMessageSender {
     })
 
     let payload = await this.v2EnvelopeService.pack(agentContext, plaintext, {
-      recipientKey: recipientX25519,
-      senderKey: senderX25519,
+      recipientKey: recipientKeyAgreement,
+      senderKey: senderKeyAgreementJwk,
       senderKeySkid: keys.senderKeySkid,
     })
 
@@ -223,8 +228,8 @@ export class DidCommMessageSender {
     for (let i = 0; i < routingKeysReversed.length; i++) {
       const routingKey = routingKeysReversed[i]
       const next = i === routingKeysReversed.length - 1 ? recipientNext : new DidKey(routingKeysReversed[i + 1]).did
-      const routingKeyX25519 = toX25519(routingKey)
-      routingKeyX25519.keyId = new DidKey(routingKey).did
+      const routingKeyAgreement = toKeyAgreement(routingKey)
+      routingKeyAgreement.keyId = new DidKey(routingKey).did
       const attachment = {
         id: utils.uuid(),
         media_type: 'application/didcomm-encrypted+json',
@@ -236,7 +241,7 @@ export class DidCommMessageSender {
         attachments: [attachment],
       })
       payload = await this.v2EnvelopeService.packAnoncrypt(agentContext, forwardPlaintext, {
-        recipientKey: routingKeyX25519,
+        recipientKey: routingKeyAgreement,
       })
     }
     return payload
@@ -285,14 +290,14 @@ export class DidCommMessageSender {
       keys.senderKey
     ) {
       try {
-        const recipientX25519 = toX25519(keys.recipientKeys[0])
+        const recipientKeyAgreement = toKeyAgreement(keys.recipientKeys[0])
         // Use existing keyId (DID URL pointing to keyAgreement VM) when available,
         // otherwise fall back to did:key for connectionless return route
-        recipientX25519.keyId = keys.recipientKeys[0].hasKeyId
+        recipientKeyAgreement.keyId = keys.recipientKeys[0].hasKeyId
           ? keys.recipientKeys[0].keyId
           : new DidKey(keys.recipientKeys[0]).did
-        const senderX25519 = toX25519(keys.senderKey)
-        senderX25519.keyId = keys.senderKey.hasKeyId ? keys.senderKey.keyId : keys.senderKey.legacyKeyId
+        const senderKeyAgreementJwk = toKeyAgreement(keys.senderKey)
+        senderKeyAgreementJwk.keyId = keys.senderKey.hasKeyId ? keys.senderKey.keyId : keys.senderKey.legacyKeyId
         const plaintext = buildV2PlaintextFromMessage(message, {
           useDidSovPrefixWhereAllowed: this.didCommModuleConfig.useDidSovPrefixWhereAllowed,
           ...(connection?.did && connection?.theirDid
@@ -310,8 +315,8 @@ export class DidCommMessageSender {
           hasFromPrior: plaintext.from_prior !== undefined,
         })
         encryptedMessage = await this.v2EnvelopeService.pack(agentContext, plaintext, {
-          recipientKey: recipientX25519,
-          senderKey: senderX25519,
+          recipientKey: recipientKeyAgreement,
+          senderKey: senderKeyAgreementJwk,
           senderKeySkid: keys.senderKeySkid,
         })
       } catch (error) {
@@ -538,19 +543,19 @@ export class DidCommMessageSender {
       )
     }
 
-    // For DIDComm v2 authcrypt (ECDH-1PU): resolve the independent X25519 keyAgreement key
+    // For DIDComm v2 authcrypt (ECDH-1PU): resolve the independent keyAgreement key
     // if it has its own kmsKeyId. This avoids using the Ed25519-derived X25519 (which would
     // produce a different public key than what skid points to with independent keys).
-    let senderKeyAgreement: { publicJwk: Kms.PublicJwk<Kms.X25519PublicJwk>; vmId: string } | undefined
+    let senderKeyAgreement: { publicJwk: DidCommV2KeyAgreementJwk; vmId: string } | undefined
     for (const kaRef of didDocument.keyAgreement ?? []) {
       const vm = typeof kaRef === 'string' ? didDocument.dereferenceVerificationMethod(kaRef) : kaRef
       try {
         const jwk = getPublicJwkFromVerificationMethod(vm)
-        if (!jwk.is(Kms.X25519PublicJwk)) continue
+        if (!jwk.is(Kms.X25519PublicJwk, Kms.P256PublicJwk)) continue
         const kmsKeyId = keys?.find((key) => vm.id.endsWith(key.didDocumentRelativeKeyId))?.kmsKeyId
         if (kmsKeyId) {
           jwk.keyId = kmsKeyId
-          senderKeyAgreement = { publicJwk: jwk as Kms.PublicJwk<Kms.X25519PublicJwk>, vmId: vm.id }
+          senderKeyAgreement = { publicJwk: jwk as DidCommV2KeyAgreementJwk, vmId: vm.id }
           break
         }
       } catch {}

--- a/packages/didcomm/src/DidCommMessageSender.ts
+++ b/packages/didcomm/src/DidCommMessageSender.ts
@@ -565,14 +565,16 @@ export class DidCommMessageSender {
     const shouldAddReturnRoute =
       message.transport?.returnRoute === undefined && !this.transportService.hasInboundEndpoint(didDocument)
 
-    // When the connection uses DIDComm v2, prefer services with X25519 (keyAgreement) recipient keys.
-    // DID documents with dual v1/v2 services return both from resolveServicesFromDid; using v1
-    // recipientKeys (Ed25519) with v2 packing creates an incorrect kid (did:key:z6Mk… instead of
-    // a keyAgreement VM DID URL), which the recipient cannot resolve.
+    // When the connection uses DIDComm v2, prefer services with a keyAgreement (X25519 or P-256)
+    // recipient key. DID documents with dual v1/v2 services return both from resolveServicesFromDid;
+    // using v1 recipientKeys (Ed25519) with v2 packing creates an incorrect kid (did:key:z6Mk… instead
+    // of a keyAgreement VM DID URL), which the recipient cannot resolve.
     const useV2ForServiceOrder = (connection.didcommVersion ?? 'v1') === 'v2'
     const orderedServices = useV2ForServiceOrder
       ? (() => {
-          const v2Svcs = services.filter((s) => s.recipientKeys.some((k) => k.is(Kms.X25519PublicJwk)))
+          const v2Svcs = services.filter((s) =>
+            s.recipientKeys.some((k) => k.is(Kms.X25519PublicJwk, Kms.P256PublicJwk))
+          )
           return v2Svcs.length > 0 ? [...v2Svcs, ...services.filter((s) => !v2Svcs.includes(s))] : services
         })()
       : services
@@ -596,12 +598,12 @@ export class DidCommMessageSender {
         if (id.startsWith('#')) return `${didDocument.id}${id}`
         return undefined
       }
-      // Legacy fallback: find first X25519 keyAgreement VM
+      // Legacy fallback: find first keyAgreement VM (X25519 or P-256)
       const kaVm = (didDocument.keyAgreement ?? [])
         .map((ref) => (typeof ref === 'string' ? didDocument.dereferenceVerificationMethod(ref) : ref))
         .find((vm) => {
           try {
-            return getPublicJwkFromVerificationMethod(vm).is(Kms.X25519PublicJwk)
+            return getPublicJwkFromVerificationMethod(vm).is(Kms.X25519PublicJwk, Kms.P256PublicJwk)
           } catch {
             return false
           }
@@ -936,7 +938,7 @@ export class DidCommMessageSender {
                   typeof keyRef === 'string' ? didDocument.dereferenceVerificationMethod(keyRef) : keyRef
                 if (seen.has(verificationMethod.id)) continue
                 const publicJwk = getPublicJwkFromVerificationMethod(verificationMethod)
-                if (publicJwk.is(Kms.Ed25519PublicJwk) || publicJwk.is(Kms.X25519PublicJwk)) {
+                if (publicJwk.is(Kms.Ed25519PublicJwk, Kms.X25519PublicJwk, Kms.P256PublicJwk)) {
                   seen.add(verificationMethod.id)
                   const jwk = publicJwk
                   if (verificationMethod?.id && !jwk.hasKeyId) {

--- a/packages/didcomm/src/DidCommModuleConfig.ts
+++ b/packages/didcomm/src/DidCommModuleConfig.ts
@@ -1,4 +1,4 @@
-import { PeerDidNumAlgo } from '@credo-ts/core'
+import { CredoError, PeerDidNumAlgo } from '@credo-ts/core'
 import { DID_COMM_TRANSPORT_QUEUE } from './constants'
 import type {
   DidCommBasicMessagesModuleConfigOptions,
@@ -21,6 +21,7 @@ import {
 } from './transport'
 import { DidCommMimeType } from './types'
 import type { DidCommVersion } from './util/didcommVersion'
+import type { DidCommV2KeyAgreementCurve } from './v2/types'
 
 export interface DidCommModuleConfigOptions {
   endpoints?: string[]
@@ -49,6 +50,14 @@ export interface DidCommModuleConfigOptions {
    * @default PeerDidNumAlgo.ShortFormAndLongForm (did:peer:4)
    */
   peerDidNumAlgoForV2OOB?: PeerDidNumAlgo.MultipleInceptionKeyWithoutDoc | PeerDidNumAlgo.ShortFormAndLongForm
+
+  /**
+   * keyAgreement curve for DIDComm v2 outbound routing. Both X25519 and P-256 are MUST-support
+   * curves per DIDComm Messaging v2.1. P-256 requires 'v2' in `didcommVersions`.
+   *
+   * @default 'X25519'
+   */
+  v2KeyAgreementCurve?: DidCommV2KeyAgreementCurve
 
   /**
    * Configuration for the connection module.
@@ -159,6 +168,10 @@ export class DidCommModuleConfig<Options extends DidCommModuleConfigOptions = Di
     this._outboundTransports = options?.transports?.outbound ?? []
     this._queueTransportRepository = options?.queueTransportRepository ?? new InMemoryQueueTransportRepository()
 
+    if (this.options.v2KeyAgreementCurve === 'P-256' && !(this.options.didcommVersions ?? ['v1']).includes('v2')) {
+      throw new CredoError("v2KeyAgreementCurve 'P-256' requires 'v2' in didcommVersions")
+    }
+
     this.enabledModules = {
       connections: true,
       oob: true,
@@ -250,5 +263,10 @@ export class DidCommModuleConfig<Options extends DidCommModuleConfigOptions = Di
   /** Peer DID numAlgo for V2 OOB. Defaults to did:peer:4. */
   public get peerDidNumAlgoForV2OOB() {
     return this.options.peerDidNumAlgoForV2OOB ?? PeerDidNumAlgo.ShortFormAndLongForm
+  }
+
+  /** keyAgreement curve for DIDComm v2 outbound routing. Defaults to X25519. */
+  public get v2KeyAgreementCurve(): DidCommV2KeyAgreementCurve {
+    return this.options.v2KeyAgreementCurve ?? 'X25519'
   }
 }

--- a/packages/didcomm/src/__tests__/DidCommModuleConfig.test.ts
+++ b/packages/didcomm/src/__tests__/DidCommModuleConfig.test.ts
@@ -1,0 +1,32 @@
+import { DidCommModuleConfig } from '../DidCommModuleConfig'
+
+describe('DidCommModuleConfig', () => {
+  describe('v2KeyAgreementCurve', () => {
+    it("defaults to 'X25519'", () => {
+      const config = new DidCommModuleConfig()
+      expect(config.v2KeyAgreementCurve).toBe('X25519')
+    })
+
+    it("returns 'P-256' when configured with v2 enabled", () => {
+      const config = new DidCommModuleConfig({ didcommVersions: ['v1', 'v2'], v2KeyAgreementCurve: 'P-256' })
+      expect(config.v2KeyAgreementCurve).toBe('P-256')
+    })
+
+    it("returns 'X25519' when explicitly configured", () => {
+      const config = new DidCommModuleConfig({ didcommVersions: ['v1', 'v2'], v2KeyAgreementCurve: 'X25519' })
+      expect(config.v2KeyAgreementCurve).toBe('X25519')
+    })
+
+    it("throws when 'P-256' is set without v2 in didcommVersions", () => {
+      expect(() => new DidCommModuleConfig({ v2KeyAgreementCurve: 'P-256' })).toThrow(
+        /v2KeyAgreementCurve 'P-256' requires 'v2' in didcommVersions/
+      )
+    })
+
+    it("throws when 'P-256' is set with only v1 in didcommVersions", () => {
+      expect(() => new DidCommModuleConfig({ didcommVersions: ['v1'], v2KeyAgreementCurve: 'P-256' })).toThrow(
+        /v2KeyAgreementCurve 'P-256' requires 'v2' in didcommVersions/
+      )
+    })
+  })
+})

--- a/packages/didcomm/src/getDidCommOutboundMessageContext.ts
+++ b/packages/didcomm/src/getDidCommOutboundMessageContext.ts
@@ -16,6 +16,7 @@ import {
 import { DidCommOutOfBandRecordMetadataKeys } from './modules/oob/repository/outOfBandRecordMetadataTypes'
 import { DidCommRoutingService } from './modules/routing'
 import { DidCommMessageRepository, DidCommMessageRole } from './repository'
+import type { DidCommV2KeyAgreementJwk } from './v2/types'
 
 /**
  * Maybe these methods should be moved to a service, but that would require
@@ -284,12 +285,12 @@ async function createOurService(
 
     recipientPublicJwk.keyId = oobRecordRecipientRouting.recipientKeyId ?? recipientPublicJwk.legacyKeyId
 
-    // Restore the independent X25519 key agreement key from metadata if available.
-    let keyAgreementKey: Kms.PublicJwk<Kms.X25519PublicJwk> | undefined
+    // Restore the independent keyAgreement key (X25519 or P-256) from metadata if available.
+    let keyAgreementKey: DidCommV2KeyAgreementJwk | undefined
     if (oobRecordRecipientRouting.keyAgreementKeyFingerprint) {
       keyAgreementKey = Kms.PublicJwk.fromFingerprint(
         oobRecordRecipientRouting.keyAgreementKeyFingerprint
-      ) as Kms.PublicJwk<Kms.X25519PublicJwk>
+      ) as DidCommV2KeyAgreementJwk
       keyAgreementKey.keyId = oobRecordRecipientRouting.keyAgreementKeyId ?? keyAgreementKey.legacyKeyId
     }
 

--- a/packages/didcomm/src/models/DidCommRouting.ts
+++ b/packages/didcomm/src/models/DidCommRouting.ts
@@ -1,16 +1,18 @@
 import type { Kms } from '@credo-ts/core'
+import type { DidCommV2KeyAgreementJwk } from '../v2/types'
 
 export interface DidCommRouting {
   endpoints: string[]
   recipientKey: Kms.PublicJwk<Kms.Ed25519PublicJwk>
   /**
-   * Separate X25519 key for DIDComm V2 key agreement. Stored independently in the KMS
+   * Separate keyAgreement key for DIDComm V2 (X25519 or P-256). Stored independently in the KMS
    * (not derived from recipientKey at runtime). Used as the `keyAgreement` verification
    * method in the DID document and for ECDH-ES / ECDH-1PU encryption.
    *
-   * When not set, the X25519 key will be derived from `recipientKey` at runtime (legacy behavior).
+   * When not set, an X25519 key is derived from `recipientKey` at runtime via the Ed25519
+   * birational map (X25519 only; no P-256 fallback).
    */
-  keyAgreementKey?: Kms.PublicJwk<Kms.X25519PublicJwk>
+  keyAgreementKey?: DidCommV2KeyAgreementJwk
   routingKeys: Kms.PublicJwk<Kms.Ed25519PublicJwk>[]
   mediatorId?: string
   /**

--- a/packages/didcomm/src/modules/connections/__tests__/helpers.test.ts
+++ b/packages/didcomm/src/modules/connections/__tests__/helpers.test.ts
@@ -8,7 +8,7 @@ import {
   ReferencedAuthentication,
   RsaSig2018,
 } from '../models'
-import { convertToNewDidDocument, toKeyAgreement } from '../services/helpers'
+import { convertToNewDidDocument, keyAgreementsEqual, toKeyAgreement } from '../services/helpers'
 
 const key = new Ed25119Sig2018({
   id: 'did:sov:SKJVx2kn373FNgvff1SbJo#4',
@@ -246,5 +246,65 @@ describe('toKeyAgreement', () => {
       y: 'B33OmdK_FrhqAjjlZGFNlImd_5HFGtj0VyEYqsQqg2X-XnQv6KjC9X3rL5GqxKlF',
     })
     expect(() => toKeyAgreement(p384Jwk)).toThrow(/P-384/)
+  })
+})
+
+describe('keyAgreementsEqual', () => {
+  const ed25519A = Kms.PublicJwk.fromFingerprint(
+    'z6MkmjY8GnV5i9YTDtPETC2uUAW6ejw3nk5mXF5yci5ab7th'
+  ) as Kms.PublicJwk<Kms.Ed25519PublicJwk>
+  const ed25519B = Kms.PublicJwk.fromFingerprint(
+    'z6MkfV5QFybBws9PpkRoYjeUuiacFB7N3pmqWxFwBpY1uPdv'
+  ) as Kms.PublicJwk<Kms.Ed25519PublicJwk>
+
+  const x25519FromA = ed25519A.convertTo(Kms.X25519PublicJwk)
+
+  const p256A = Kms.PublicJwk.fromPublicJwk({
+    kty: 'EC',
+    crv: 'P-256',
+    x: 'FQVaTOksf-XsCUrt4J1L2UGvtWaDwpboVlqbKBY2AIo',
+    y: '6XFB9PYo7dyC5ViJSO9uXNYkxTJWn0d_mqJ__ZYhcNY',
+  })
+
+  const p256B = Kms.PublicJwk.fromPublicJwk({
+    kty: 'EC',
+    crv: 'P-256',
+    x: 'L0crjMN1g0Ih4sYAJ_nGoHUck2cloltUpUVQDhF2nHE',
+    y: 'SxYgE7CmEJYi7IDhgK5jI4ZiajO8jPRZDldVhqFpYoo',
+  })
+
+  it('matches identical X25519 keys', () => {
+    expect(keyAgreementsEqual(x25519FromA, x25519FromA)).toBe(true)
+  })
+
+  it('matches identical P-256 keys', () => {
+    expect(keyAgreementsEqual(p256A, p256A)).toBe(true)
+  })
+
+  it('matches identical Ed25519 keys', () => {
+    expect(keyAgreementsEqual(ed25519A, ed25519A)).toBe(true)
+  })
+
+  it('bridges Ed25519 to X25519 birationally', () => {
+    expect(keyAgreementsEqual(ed25519A, x25519FromA)).toBe(true)
+    expect(keyAgreementsEqual(x25519FromA, ed25519A)).toBe(true)
+  })
+
+  it('does not match different Ed25519 keys', () => {
+    expect(keyAgreementsEqual(ed25519A, ed25519B)).toBe(false)
+  })
+
+  it('does not match different P-256 keys', () => {
+    expect(keyAgreementsEqual(p256A, p256B)).toBe(false)
+  })
+
+  it('does not match P-256 against X25519', () => {
+    expect(keyAgreementsEqual(p256A, x25519FromA)).toBe(false)
+    expect(keyAgreementsEqual(x25519FromA, p256A)).toBe(false)
+  })
+
+  it('does not match P-256 against Ed25519', () => {
+    expect(keyAgreementsEqual(p256A, ed25519A)).toBe(false)
+    expect(keyAgreementsEqual(ed25519A, p256A)).toBe(false)
   })
 })

--- a/packages/didcomm/src/modules/connections/__tests__/helpers.test.ts
+++ b/packages/didcomm/src/modules/connections/__tests__/helpers.test.ts
@@ -1,3 +1,4 @@
+import { Kms } from '@credo-ts/core'
 import { DidCommV1Service, IndyAgentService, VerificationMethod } from '../../../../../core/src/modules/dids'
 import {
   DidDoc,
@@ -7,7 +8,7 @@ import {
   ReferencedAuthentication,
   RsaSig2018,
 } from '../models'
-import { convertToNewDidDocument } from '../services/helpers'
+import { convertToNewDidDocument, toKeyAgreement } from '../services/helpers'
 
 const key = new Ed25119Sig2018({
   id: 'did:sov:SKJVx2kn373FNgvff1SbJo#4',
@@ -169,5 +170,81 @@ describe('convertToNewDidDocument', () => {
         priority: 5,
       }),
     ])
+  })
+})
+
+describe('toKeyAgreement', () => {
+  const ed25519Fingerprint = 'z6MkmjY8GnV5i9YTDtPETC2uUAW6ejw3nk5mXF5yci5ab7th'
+
+  const x25519Jwk = Kms.PublicJwk.fromPublicJwk({
+    kty: 'OKP',
+    crv: 'X25519',
+    x: 'L-V9o0fNYkMVKNqsX7spBzD_9oSvxM_C7ZCZX1jLO3Q',
+  })
+
+  const p256Jwk = Kms.PublicJwk.fromPublicJwk({
+    kty: 'EC',
+    crv: 'P-256',
+    x: 'FQVaTOksf-XsCUrt4J1L2UGvtWaDwpboVlqbKBY2AIo',
+    y: '6XFB9PYo7dyC5ViJSO9uXNYkxTJWn0d_mqJ__ZYhcNY',
+  })
+
+  it('passes X25519 keys through unchanged', () => {
+    const result = toKeyAgreement(x25519Jwk)
+    expect(result).toBe(x25519Jwk)
+    expect(result.is(Kms.X25519PublicJwk)).toBe(true)
+  })
+
+  it('passes P-256 keys through unchanged', () => {
+    const result = toKeyAgreement(p256Jwk)
+    expect(result).toBe(p256Jwk)
+    expect(result.is(Kms.P256PublicJwk)).toBe(true)
+  })
+
+  it('birationally converts Ed25519 to X25519', () => {
+    const ed25519 = Kms.PublicJwk.fromFingerprint(ed25519Fingerprint) as Kms.PublicJwk<Kms.Ed25519PublicJwk>
+    const expectedX25519 = ed25519.convertTo(Kms.X25519PublicJwk)
+    const result = toKeyAgreement(ed25519)
+    expect(result.is(Kms.X25519PublicJwk)).toBe(true)
+    expect(result.fingerprint).toBe(expectedX25519.fingerprint)
+  })
+
+  it('throws on P-384', () => {
+    const p384Jwk = Kms.PublicJwk.fromPublicJwk({
+      kty: 'EC',
+      crv: 'P-384',
+      x: 'lInTxl8fjLKp_UCrxI0WDklcl9VuTGyM5h6yIQXVbPxBu8t-9rJW6vMzpgWf3-Pp',
+      y: 'B33OmdK_FrhqAjjlZGFNlImd_5HFGtj0VyEYqsQqg2X-XnQv6KjC9X3rL5GqxKlF',
+    })
+    expect(() => toKeyAgreement(p384Jwk)).toThrow(/Unsupported keyAgreement curve/)
+  })
+
+  it('throws on secp256k1', () => {
+    const secp256k1Jwk = Kms.PublicJwk.fromPublicJwk({
+      kty: 'EC',
+      crv: 'secp256k1',
+      x: 'LowlbeS1Y_OWnnLrwxQRoLSY8VnGgKpAhMfeY9MEjcs',
+      y: 'EmxC44wNJp_2EVUyMv-Zo2sj_HCmGRfL6QyJUkBNbHc',
+    })
+    expect(() => toKeyAgreement(secp256k1Jwk)).toThrow(/Unsupported keyAgreement curve/)
+  })
+
+  it('throws on RSA', () => {
+    const rsaJwk = Kms.PublicJwk.fromPublicJwk({
+      kty: 'RSA',
+      n: 'sXchDaQebHnPiGvyDOAT4saGEUetSyo9MKLOoWFsueri23bOdgWp4Dy1WlUzewbgBHod5pcM9H95GQRV3JDXboIRROSBigeC5yjU1hGzHHyXss8UDprecbAYxknTcQkhslANGRUZmdTOQ5qTRsLAt6BTYuyvVRdhS-V3RbYJsXzYC2gAaUVqzpVOQpYpKBYV4M9bxQ_KQwgKZGUFcGuCfDQjVOmrFcSnPnk6Yn_OazPSCWNG_8VLnj4yKaP7QHWNfsTyqU6mCQc4mLdnPgcDxJX9w-uW1F-Y66z4MUmKBmGZ8ufLG3-rwPLEf25cw-IRpdyNzVf1xY83Gv2tCm7sbZw',
+      e: 'AQAB',
+    })
+    expect(() => toKeyAgreement(rsaJwk)).toThrow(/Unsupported keyAgreement curve/)
+  })
+
+  it('includes the offending JWK description in the error message', () => {
+    const p384Jwk = Kms.PublicJwk.fromPublicJwk({
+      kty: 'EC',
+      crv: 'P-384',
+      x: 'lInTxl8fjLKp_UCrxI0WDklcl9VuTGyM5h6yIQXVbPxBu8t-9rJW6vMzpgWf3-Pp',
+      y: 'B33OmdK_FrhqAjjlZGFNlImd_5HFGtj0VyEYqsQqg2X-XnQv6KjC9X3rL5GqxKlF',
+    })
+    expect(() => toKeyAgreement(p384Jwk)).toThrow(/P-384/)
   })
 })

--- a/packages/didcomm/src/modules/connections/handlers/DidCommDidExchangeResponseHandler.ts
+++ b/packages/didcomm/src/modules/connections/handlers/DidCommDidExchangeResponseHandler.ts
@@ -9,7 +9,7 @@ import type { DidCommConnectionsModuleConfig, DidExchangeProtocol } from '..'
 import { DidCommDidExchangeResponseMessage } from '../messages'
 import { DidCommDidExchangeRole, DidCommHandshakeProtocol } from '../models'
 import type { DidCommConnectionService } from '../services'
-import { toX25519 } from '../services/helpers'
+import { keyAgreementsEqual } from '../services/helpers'
 
 export class DidCommDidExchangeResponseHandler implements DidCommMessageHandler {
   private didExchangeProtocol: DidExchangeProtocol
@@ -59,9 +59,9 @@ export class DidCommDidExchangeResponseHandler implements DidCommMessageHandler 
     }
 
     // Validate if recipient key is included in recipient keys of the did document resolved by
-    // connection record did. DIDComm v2 uses X25519 for decryption; did document may have Ed25519.
-    const recipientX25519 = toX25519(recipientKey)
-    const recipientKeyFound = ourDidDocument.recipientKeys.some((key) => recipientX25519.equals(toX25519(key)))
+    // connection record did. The compare bridges Ed25519 <-> X25519 (legacy v1) and matches
+    // same-curve keys directly for v2 X25519 / P-256.
+    const recipientKeyFound = ourDidDocument.recipientKeys.some((key) => keyAgreementsEqual(recipientKey, key))
     if (!recipientKeyFound) {
       throw new CredoError(`Recipient key ${recipientKey.fingerprint} not found in did document recipient keys.`)
     }

--- a/packages/didcomm/src/modules/connections/services/DidCommConnectionService.ts
+++ b/packages/didcomm/src/modules/connections/services/DidCommConnectionService.ts
@@ -56,7 +56,7 @@ import {
   assertNoCreatedDidExistsForKeys,
   convertToNewDidDocument,
   getResolvedDidcommServiceWithSigningKeyId,
-  toX25519,
+  keyAgreementsEqual,
 } from './helpers'
 
 export interface ConnectionRequestParams {
@@ -619,21 +619,18 @@ export class DidCommConnectionService {
         )
       }
 
-      // Check if recipientKey is in ourService
-      // DIDComm v2 decrypt returns X25519; ourService may have Ed25519. Normalize both to X25519 for comparison.
+      // Check if recipientKey is in ourService. Compare bridges Ed25519 <-> X25519 (legacy v1)
+      // and matches same-curve keys directly for v2 X25519 / P-256.
       if (recipientKey && ourService) {
-        const recipientX25519 = toX25519(recipientKey)
-        const recipientKeyFound = ourService.recipientKeys.some((key) => recipientX25519.equals(toX25519(key)))
+        const recipientKeyFound = ourService.recipientKeys.some((key) => keyAgreementsEqual(recipientKey, key))
         if (!recipientKeyFound) {
           throw new CredoError(`Recipient key ${recipientKey.fingerprint} not found in our service`)
         }
       }
 
-      // Check if senderKey is in theirService
-      // DIDComm v2 returns X25519; theirService may have Ed25519. Normalize both to X25519 for comparison.
+      // Check if senderKey is in theirService. Same compare semantics as the recipient check above.
       if (senderKey && theirService) {
-        const senderX25519 = toX25519(senderKey)
-        const senderKeyFound = theirService.recipientKeys.some((key) => senderX25519.equals(toX25519(key)))
+        const senderKeyFound = theirService.recipientKeys.some((key) => keyAgreementsEqual(senderKey, key))
         if (!senderKeyFound) {
           throw new CredoError(`Sender key ${senderKey.fingerprint} not found in their service.`)
         }

--- a/packages/didcomm/src/modules/connections/services/DidCommDidRotateV2Service.ts
+++ b/packages/didcomm/src/modules/connections/services/DidCommDidRotateV2Service.ts
@@ -33,7 +33,7 @@ import { DidCommConnectionEventTypes } from '../DidCommConnectionEvents'
 import type { DidCommConnectionRecord } from '../repository'
 import { DidCommConnectionMetadataKeys } from '../repository/DidCommConnectionMetadataTypes'
 import { DidCommConnectionService } from './DidCommConnectionService'
-import { createPeerDidForV2OOB, toX25519 } from './helpers'
+import { createPeerDidForV2OOB, toKeyAgreement } from './helpers'
 
 export interface FromPriorPayload {
   iss: string
@@ -253,8 +253,8 @@ export class DidCommDidRotateV2Service {
     }
 
     const recipientEd25519 = service.recipientKeys[0]
-    const recipientX25519 = toX25519(recipientEd25519)
-    recipientX25519.keyId = recipientEd25519.hasKeyId ? recipientEd25519.keyId : new DidKey(recipientEd25519).did
+    const recipientKeyAgreement = toKeyAgreement(recipientEd25519)
+    recipientKeyAgreement.keyId = recipientEd25519.hasKeyId ? recipientEd25519.keyId : new DidKey(recipientEd25519).did
 
     const empty = new DidCommEmptyMessage({ fromPrior: fromPriorJwt })
     const plaintext: DidCommV2PlaintextMessage = {
@@ -267,17 +267,17 @@ export class DidCommDidRotateV2Service {
 
     const v2EnvelopeService = agentContext.dependencyManager.resolve(DidCommV2EnvelopeService)
     let payload = await v2EnvelopeService.packAnoncrypt(agentContext, plaintext, {
-      recipientKey: recipientX25519,
+      recipientKey: recipientKeyAgreement,
     })
 
     if (service.routingKeys.length > 0) {
-      const recipientNext = new DidKey(toX25519(recipientEd25519)).did
+      const recipientNext = new DidKey(toKeyAgreement(recipientEd25519)).did
       const reversed = [...service.routingKeys].reverse()
       for (let i = 0; i < reversed.length; i++) {
         const routingKey = reversed[i]
         const next = i === reversed.length - 1 ? recipientNext : new DidKey(reversed[i + 1]).did
-        const routingX25519 = toX25519(routingKey)
-        routingX25519.keyId = new DidKey(routingKey).did
+        const routingKeyAgreement = toKeyAgreement(routingKey)
+        routingKeyAgreement.keyId = new DidKey(routingKey).did
         const forwardPlaintext = DidCommForwardV2Message.createV2PlaintextMessage({
           to: [new DidKey(routingKey).did],
           next,
@@ -290,7 +290,7 @@ export class DidCommDidRotateV2Service {
           ],
         })
         payload = await v2EnvelopeService.packAnoncrypt(agentContext, forwardPlaintext, {
-          recipientKey: routingX25519,
+          recipientKey: routingKeyAgreement,
         })
       }
     }

--- a/packages/didcomm/src/modules/connections/services/helpers.ts
+++ b/packages/didcomm/src/modules/connections/services/helpers.ts
@@ -12,6 +12,7 @@ import {
   didToNumAlgo2DidDocument,
   didToNumAlgo4DidDocument,
   getEd25519VerificationKey2018,
+  getJsonWebKey2020,
   getPublicJwkFromVerificationMethod,
   getX25519KeyAgreementKey2019,
   IndyAgentService,
@@ -285,9 +286,10 @@ export async function createPeerDidForV2OOB(
     throw new CredoError('DIDComm v2 OOB requires Ed25519 recipient key')
   }
 
-  // Use separate X25519 key from routing if available (independent KMS key),
-  // otherwise fall back to deriving from Ed25519 (legacy behavior).
-  const x25519Key = routing.keyAgreementKey
+  // Use separate keyAgreement key from routing if available (independent KMS key),
+  // otherwise derive X25519 from Ed25519 via the birational map. There is no birational
+  // derivation to P-256, so a P-256 keyAgreement must be supplied via routing.keyAgreementKey.
+  const keyAgreementJwk: DidCommV2KeyAgreementJwk = routing.keyAgreementKey
     ? routing.keyAgreementKey
     : Kms.PublicJwk.fromPublicKey({
         crv: 'X25519',
@@ -301,12 +303,10 @@ export async function createPeerDidForV2OOB(
     publicJwk: recipientKey,
     controller: '#id',
   })
-  const x25519Vm = getX25519KeyAgreementKey2019({
-    id: '#key-2',
-    publicJwk: x25519Key,
-    controller: '#id',
-  })
-  didDocumentBuilder.addAuthentication(ed25519Vm).addKeyAgreement(x25519Vm)
+  const keyAgreementVm = keyAgreementJwk.is(Kms.X25519PublicJwk)
+    ? getX25519KeyAgreementKey2019({ id: '#key-2', publicJwk: keyAgreementJwk, controller: '#id' })
+    : getJsonWebKey2020({ did: '#id', publicJwk: keyAgreementJwk, verificationMethodId: '#key-2' })
+  didDocumentBuilder.addAuthentication(ed25519Vm).addKeyAgreement(keyAgreementVm)
 
   // For v2 peer DIDs, keep the routing DID as the service URI (CM 2.0 DID-as-endpoint).
   // v2 senders resolve this via DidCommDocumentService.expandV2EndpointIfRoutingDid which
@@ -334,13 +334,13 @@ export async function createPeerDidForV2OOB(
   const didDocument = didDocumentBuilder.build()
   // Map each verification method to its own KMS key ID.
   // #key-1 (Ed25519 auth) → Ed25519 KMS key
-  // #key-2 (X25519 keyAgreement) → X25519 KMS key (independent, or Ed25519 fallback)
-  const x25519KmsKeyId = routing.keyAgreementKey
+  // #key-2 (keyAgreement) → independent keyAgreement KMS key, or Ed25519 fallback (X25519 only)
+  const keyAgreementKmsKeyId = routing.keyAgreementKey
     ? (routing.keyAgreementKey.keyId ?? routing.keyAgreementKey.legacyKeyId)
     : (recipientKey.keyId ?? recipientKey.legacyKeyId)
   const keys: DidDocumentKey[] = [
     { didDocumentRelativeKeyId: '#key-1', kmsKeyId: recipientKey.keyId ?? recipientKey.legacyKeyId },
-    { didDocumentRelativeKeyId: '#key-2', kmsKeyId: x25519KmsKeyId },
+    { didDocumentRelativeKeyId: '#key-2', kmsKeyId: keyAgreementKmsKeyId },
   ]
 
   await assertNoCreatedDidExistsForKeys(agentContext, [recipientKey])

--- a/packages/didcomm/src/modules/connections/services/helpers.ts
+++ b/packages/didcomm/src/modules/connections/services/helpers.ts
@@ -39,6 +39,20 @@ export function toX25519(jwk: Kms.PublicJwk): Kms.PublicJwk<Kms.X25519PublicJwk>
   return jwk.is(Kms.X25519PublicJwk) ? jwk : (jwk as Kms.PublicJwk<Kms.Ed25519PublicJwk>).convertTo(Kms.X25519PublicJwk)
 }
 
+/**
+ * Normalize a PublicJwk to a DIDComm v2 keyAgreement key (X25519 or P-256).
+ * Ed25519 inputs are birationally converted to X25519 per RFC 7748.
+ */
+export function toKeyAgreement(jwk: Kms.PublicJwk): Kms.PublicJwk<Kms.X25519PublicJwk | Kms.P256PublicJwk> {
+  if (jwk.is(Kms.X25519PublicJwk, Kms.P256PublicJwk)) {
+    return jwk as Kms.PublicJwk<Kms.X25519PublicJwk | Kms.P256PublicJwk>
+  }
+  if (jwk.is(Kms.Ed25519PublicJwk)) {
+    return jwk.convertTo(Kms.X25519PublicJwk)
+  }
+  throw new CredoError(`Unsupported keyAgreement curve: ${jwk.jwkTypeHumanDescription}`)
+}
+
 export function convertToNewDidDocument(didDoc: DidDoc, keys?: DidDocumentKey[]) {
   const didDocumentBuilder = new DidDocumentBuilder('')
 

--- a/packages/didcomm/src/modules/connections/services/helpers.ts
+++ b/packages/didcomm/src/modules/connections/services/helpers.ts
@@ -25,6 +25,7 @@ import {
 import { convertPublicKeyToX25519 } from '@stablelib/ed25519'
 import { DidCommModuleConfig } from '../../../DidCommModuleConfig'
 import type { DidCommRouting } from '../../../models'
+import type { DidCommV2KeyAgreementJwk } from '../../../v2/types'
 import { OutOfBandDidCommService } from '../../oob/domain/OutOfBandDidCommService'
 import type { DidCommOutOfBandInlineServiceKey } from '../../oob/repository/DidCommOutOfBandRecord'
 import type { DidDoc, PublicKey } from '../models'
@@ -43,9 +44,9 @@ export function toX25519(jwk: Kms.PublicJwk): Kms.PublicJwk<Kms.X25519PublicJwk>
  * Normalize a PublicJwk to a DIDComm v2 keyAgreement key (X25519 or P-256).
  * Ed25519 inputs are birationally converted to X25519 per RFC 7748.
  */
-export function toKeyAgreement(jwk: Kms.PublicJwk): Kms.PublicJwk<Kms.X25519PublicJwk | Kms.P256PublicJwk> {
+export function toKeyAgreement(jwk: Kms.PublicJwk): DidCommV2KeyAgreementJwk {
   if (jwk.is(Kms.X25519PublicJwk, Kms.P256PublicJwk)) {
-    return jwk as Kms.PublicJwk<Kms.X25519PublicJwk | Kms.P256PublicJwk>
+    return jwk as DidCommV2KeyAgreementJwk
   }
   if (jwk.is(Kms.Ed25519PublicJwk)) {
     return jwk.convertTo(Kms.X25519PublicJwk)

--- a/packages/didcomm/src/modules/connections/services/helpers.ts
+++ b/packages/didcomm/src/modules/connections/services/helpers.ts
@@ -55,6 +55,22 @@ export function toKeyAgreement(jwk: Kms.PublicJwk): DidCommV2KeyAgreementJwk {
   throw new CredoError(`Unsupported keyAgreement curve: ${jwk.jwkTypeHumanDescription}`)
 }
 
+/**
+ * Compare two keys for keyAgreement equivalence. Direct fingerprint match for same-curve keys;
+ * bridges Ed25519 <-> X25519 via the RFC 7748 birational map. Returns false for non-bridgeable
+ * cross-curve combinations (e.g. P-256 vs Ed25519).
+ */
+export function keyAgreementsEqual(a: Kms.PublicJwk, b: Kms.PublicJwk): boolean {
+  if (a.fingerprint === b.fingerprint) return true
+  if (a.is(Kms.Ed25519PublicJwk) && b.is(Kms.X25519PublicJwk)) {
+    return a.convertTo(Kms.X25519PublicJwk).fingerprint === b.fingerprint
+  }
+  if (a.is(Kms.X25519PublicJwk) && b.is(Kms.Ed25519PublicJwk)) {
+    return a.fingerprint === b.convertTo(Kms.X25519PublicJwk).fingerprint
+  }
+  return false
+}
+
 export function convertToNewDidDocument(didDoc: DidDoc, keys?: DidDocumentKey[]) {
   const didDocumentBuilder = new DidDocumentBuilder('')
 

--- a/packages/didcomm/src/modules/oob/DidCommOutOfBandApi.ts
+++ b/packages/didcomm/src/modules/oob/DidCommOutOfBandApi.ts
@@ -36,7 +36,7 @@ import {
   supportsIncomingMessageType,
 } from '../../util/messageType'
 import { parseInvitationShortUrl } from '../../util/parseInvitation'
-import type { DidCommV2Attachment } from '../../v2/types'
+import type { DidCommV2Attachment, DidCommV2KeyAgreementJwk } from '../../v2/types'
 import {
   DidCommConnectionInvitationMessage,
   DidCommConnectionRecord,
@@ -792,12 +792,12 @@ export class DidCommOutOfBandApi {
       ) as Kms.PublicJwk<Kms.Ed25519PublicJwk>
       recipientPublicJwk.keyId = recipientRouting.recipientKeyId ?? recipientPublicJwk.legacyKeyId
 
-      // Restore the independent X25519 key agreement key from metadata if available.
-      let keyAgreementKey: Kms.PublicJwk<Kms.X25519PublicJwk> | undefined
+      // Restore the independent keyAgreement key (X25519 or P-256) from metadata if available.
+      let keyAgreementKey: DidCommV2KeyAgreementJwk | undefined
       if (recipientRouting.keyAgreementKeyFingerprint) {
         keyAgreementKey = Kms.PublicJwk.fromFingerprint(
           recipientRouting.keyAgreementKeyFingerprint
-        ) as Kms.PublicJwk<Kms.X25519PublicJwk>
+        ) as DidCommV2KeyAgreementJwk
         keyAgreementKey.keyId = recipientRouting.keyAgreementKeyId ?? keyAgreementKey.legacyKeyId
       }
 

--- a/packages/didcomm/src/modules/oob/DidCommOutOfBandService.ts
+++ b/packages/didcomm/src/modules/oob/DidCommOutOfBandService.ts
@@ -296,7 +296,8 @@ export class DidCommOutOfBandService {
       if (typeof service === 'string') {
         const allServices = await this.didCommDocumentService.resolveServicesFromDid(agentContext, service)
         const didService = preferDidcommV2
-          ? (allServices.find((s) => s.recipientKeys.some((k) => k.is(Kms.X25519PublicJwk))) ?? allServices[0])
+          ? (allServices.find((s) => s.recipientKeys.some((k) => k.is(Kms.X25519PublicJwk, Kms.P256PublicJwk))) ??
+            allServices[0])
           : allServices[0]
 
         if (didService) return didService

--- a/packages/didcomm/src/modules/routing/services/DidCommRoutingService.ts
+++ b/packages/didcomm/src/modules/routing/services/DidCommRoutingService.ts
@@ -2,6 +2,7 @@ import type { AgentContext } from '@credo-ts/core'
 import { EventEmitter, injectable, Kms } from '@credo-ts/core'
 import { DidCommModuleConfig } from '../../../DidCommModuleConfig'
 import type { DidCommRouting } from '../../../models'
+import type { DidCommV2KeyAgreementJwk } from '../../../v2/types'
 import type { DidCommRoutingCreatedEvent } from '../DidCommRoutingEvents'
 import { DidCommRoutingEventTypes } from '../DidCommRoutingEvents'
 
@@ -31,14 +32,18 @@ export class DidCommRoutingService {
     const recipientKey = Kms.PublicJwk.fromPublicJwk(createdKey.publicJwk)
     recipientKey.keyId = createdKey.keyId
 
-    // Create separate X25519 key for V2 key agreement (ECDH-ES / ECDH-1PU) only
-    // when the agent supports DIDComm V2. V1-only agents derive X25519 from Ed25519
-    // at runtime via Askar's birational map, so no separate key is needed.
-    let keyAgreementKey: Kms.PublicJwk<Kms.X25519PublicJwk> | undefined
+    // Create separate keyAgreement key for V2 (ECDH-ES / ECDH-1PU) only when the agent
+    // supports DIDComm V2. V1-only agents derive X25519 from Ed25519 at runtime via Askar's
+    // birational map, so no separate key is needed. Curve selected via
+    // DidCommModuleConfig.v2KeyAgreementCurve (X25519 default; P-256 supported).
+    let keyAgreementKey: DidCommV2KeyAgreementJwk | undefined
     if (didcommConfig.acceptsV2) {
-      const createdX25519Key = await kms.createKey({ type: { kty: 'OKP', crv: 'X25519' } })
-      keyAgreementKey = Kms.PublicJwk.fromPublicJwk(createdX25519Key.publicJwk)
-      keyAgreementKey.keyId = createdX25519Key.keyId
+      const curve = didcommConfig.v2KeyAgreementCurve
+      const createdKeyAgreementKey = await kms.createKey({
+        type: curve === 'P-256' ? { kty: 'EC', crv: 'P-256' } : { kty: 'OKP', crv: 'X25519' },
+      })
+      keyAgreementKey = Kms.PublicJwk.fromPublicJwk(createdKeyAgreementKey.publicJwk) as DidCommV2KeyAgreementJwk
+      keyAgreementKey.keyId = createdKeyAgreementKey.keyId
     }
 
     let routing: DidCommRouting = {

--- a/packages/didcomm/src/modules/routing/services/helpers.ts
+++ b/packages/didcomm/src/modules/routing/services/helpers.ts
@@ -1,12 +1,16 @@
-import { type AgentContext, type DidDocument, TypedArrayEncoder } from '@credo-ts/core'
+import { type AgentContext, type DidDocument, Kms, TypedArrayEncoder } from '@credo-ts/core'
 
 import { DidCommMediationRecipientService } from './DidCommMediationRecipientService'
 
 export async function getMediationRecordForDidDocument(agentContext: AgentContext, didDocument: DidDocument) {
+  // Mediator routing keys are stored as Ed25519 base58 strings; filter to Ed25519/X25519
+  // since P-256 keys never appear in this wire format.
   const [mediatorRecord] = await agentContext
     .resolve(DidCommMediationRecipientService)
     .findAllMediatorsByQuery(agentContext, {
-      recipientKeys: didDocument.recipientKeys.map((key) => TypedArrayEncoder.toBase58(key.publicKey.publicKey)),
+      recipientKeys: didDocument.recipientKeys
+        .filter((key) => key.is(Kms.Ed25519PublicJwk, Kms.X25519PublicJwk))
+        .map((key) => TypedArrayEncoder.toBase58(key.publicKey.publicKey)),
     })
   return mediatorRecord
 }

--- a/packages/didcomm/src/services/DidCommDocumentService.ts
+++ b/packages/didcomm/src/services/DidCommDocumentService.ts
@@ -300,7 +300,7 @@ export class DidCommDocumentService {
           const verificationMethod =
             typeof keyRef === 'string' ? didDocument.dereferenceVerificationMethod(keyRef) : keyRef
           const publicJwk = getPublicJwkFromVerificationMethod(verificationMethod)
-          if (!publicJwk.is(Kms.X25519PublicJwk) && !publicJwk.is(Kms.Ed25519PublicJwk)) {
+          if (!publicJwk.is(Kms.X25519PublicJwk, Kms.Ed25519PublicJwk, Kms.P256PublicJwk)) {
             continue
           }
           if (!publicJwk.hasKeyId) {

--- a/packages/didcomm/src/v2/DidCommV2EnvelopeService.ts
+++ b/packages/didcomm/src/v2/DidCommV2EnvelopeService.ts
@@ -12,9 +12,13 @@ import {
 import { computeApu, computeApv } from './apuApv'
 import type { DidCommV2ContentEncryptionAlgorithm, DidCommV2EncryptedMessage, DidCommV2PlaintextMessage } from './types'
 
+export type DidCommV2KeyAgreementJwk = Kms.PublicJwk<Kms.X25519PublicJwk | Kms.P256PublicJwk>
+
+type EpkJwk = { kty: 'OKP'; crv: 'X25519'; x: string } | { kty: 'EC'; crv: 'P-256'; x: string; y: string }
+
 export interface DidCommV2EnvelopeKeys {
-  recipientKey: Kms.PublicJwk<Kms.X25519PublicJwk>
-  senderKey: Kms.PublicJwk<Kms.X25519PublicJwk>
+  recipientKey: DidCommV2KeyAgreementJwk
+  senderKey: DidCommV2KeyAgreementJwk
   /** DID URL of the sender key; used as skid in JWE so recipient can resolve it. Falls back to senderKey.keyId if absent. */
   senderKeySkid?: string
   /** Content encryption algorithm. Defaults to A256CBC-HS512 (mandatory authcrypt enc per DIDComm v2.1). */
@@ -23,7 +27,7 @@ export interface DidCommV2EnvelopeKeys {
 
 /** Keys for anoncrypt: only recipient key; no sender (anonymous). */
 export interface DidCommV2AnoncryptKeys {
-  recipientKey: Kms.PublicJwk<Kms.X25519PublicJwk>
+  recipientKey: DidCommV2KeyAgreementJwk
   /** Content encryption algorithm. Defaults to A256CBC-HS512; A256GCM is also accepted. */
   contentEncryptionAlgorithm?: DidCommV2ContentEncryptionAlgorithm
 }
@@ -52,9 +56,10 @@ export class DidCommV2EnvelopeService {
     const kms = agentContext.dependencyManager.resolve(Kms.KeyManagementApi)
     const plaintextBytes = JsonEncoder.toUint8Array(plaintext)
 
-    const recipientX25519 = keys.recipientKey
-    if (!recipientX25519.is(Kms.X25519PublicJwk)) {
-      throw new CredoError('DIDComm v2 authcrypt requires X25519 recipient key')
+    const recipientCurve = getKeyAgreementCurve(keys.recipientKey)
+    const senderCurve = getKeyAgreementCurve(keys.senderKey)
+    if (recipientCurve !== senderCurve) {
+      throw new CredoError('DIDComm v2 authcrypt requires sender and recipient on the same curve')
     }
 
     const enc: DidCommV2ContentEncryptionAlgorithm = keys.contentEncryptionAlgorithm ?? 'A256CBC-HS512'
@@ -63,13 +68,11 @@ export class DidCommV2EnvelopeService {
     const apu = computeApu(skid)
     const apv = computeApv([recipientKid])
 
-    const ephemeralKey = await kms.createKey({ type: { kty: 'OKP', crv: 'X25519' } })
+    const ephemeralKey = await kms.createKey({
+      type: recipientCurve === 'X25519' ? { kty: 'OKP', crv: 'X25519' } : { kty: 'EC', crv: 'P-256' },
+    })
     try {
-      const epk = ephemeralKey.publicJwk
-      if (!epk || (epk as { kty?: string }).kty !== 'OKP' || (epk as { crv?: string }).crv !== 'X25519') {
-        throw new CredoError('Expected X25519 ephemeral public key')
-      }
-      const epkJwk = epk as { kty: 'OKP'; crv: 'X25519'; x: string }
+      const epkJwk = toEpkJwk(ephemeralKey.publicJwk, recipientCurve)
 
       const protectedHeader = JsonEncoder.toBase64Url({
         typ: 'application/didcomm-encrypted+json',
@@ -78,7 +81,7 @@ export class DidCommV2EnvelopeService {
         skid,
         apu: TypedArrayEncoder.toBase64Url(apu),
         apv: TypedArrayEncoder.toBase64Url(apv),
-        epk: { kty: epkJwk.kty, crv: epkJwk.crv, x: epkJwk.x },
+        epk: epkJwk,
       })
 
       const { encrypted, iv, tag, encryptedKey } = await kms.encrypt({
@@ -87,7 +90,7 @@ export class DidCommV2EnvelopeService {
             algorithm: 'ECDH-1PU+A256KW',
             keyId: keys.senderKey.keyId,
             ephemeralKeyId: ephemeralKey.keyId,
-            externalPublicJwk: recipientX25519.toJson(),
+            externalPublicJwk: keys.recipientKey.toJson() as Kms.KmsJwkPublicEcdh,
             apu,
             apv,
           },
@@ -137,30 +140,25 @@ export class DidCommV2EnvelopeService {
     const kms = agentContext.dependencyManager.resolve(Kms.KeyManagementApi)
     const plaintextBytes = JsonEncoder.toUint8Array(plaintext)
 
-    const recipientX25519 = keys.recipientKey
-    if (!recipientX25519.is(Kms.X25519PublicJwk)) {
-      throw new CredoError('DIDComm v2 anoncrypt requires X25519 recipient key')
-    }
+    const recipientCurve = getKeyAgreementCurve(keys.recipientKey)
 
     const enc: DidCommV2ContentEncryptionAlgorithm = keys.contentEncryptionAlgorithm ?? 'A256CBC-HS512'
     const recipientKid = keys.recipientKey.keyId
     const apv = computeApv([recipientKid])
 
-    const ephemeralKey = await kms.createKey({ type: { kty: 'OKP', crv: 'X25519' } })
+    const ephemeralKey = await kms.createKey({
+      type: recipientCurve === 'X25519' ? { kty: 'OKP', crv: 'X25519' } : { kty: 'EC', crv: 'P-256' },
+    })
 
     try {
-      const epk = ephemeralKey.publicJwk
-      if (!epk || (epk as { kty?: string }).kty !== 'OKP' || (epk as { crv?: string }).crv !== 'X25519') {
-        throw new CredoError('Expected X25519 ephemeral public key')
-      }
-      const epkJwk = epk as { kty: 'OKP'; crv: 'X25519'; x: string }
+      const epkJwk = toEpkJwk(ephemeralKey.publicJwk, recipientCurve)
 
       const protectedHeader = JsonEncoder.toBase64Url({
         typ: 'application/didcomm-encrypted+json',
         alg: 'ECDH-ES+A256KW',
         enc,
         apv: TypedArrayEncoder.toBase64Url(apv),
-        epk: { kty: epkJwk.kty, crv: epkJwk.crv, x: epkJwk.x },
+        epk: epkJwk,
       })
 
       const { encrypted, iv, tag, encryptedKey } = await kms.encrypt({
@@ -168,7 +166,7 @@ export class DidCommV2EnvelopeService {
           keyAgreement: {
             algorithm: 'ECDH-ES+A256KW',
             keyId: ephemeralKey.keyId,
-            externalPublicJwk: recipientX25519.toJson(),
+            externalPublicJwk: keys.recipientKey.toJson() as Kms.KmsJwkPublicEcdh,
             apv,
           },
         },
@@ -212,14 +210,14 @@ export class DidCommV2EnvelopeService {
     agentContext: AgentContext,
     encrypted: DidCommV2EncryptedMessage,
     keys: {
-      recipientKey: Kms.PublicJwk<Kms.X25519PublicJwk> & { keyId: string }
+      recipientKey: DidCommV2KeyAgreementJwk & { keyId: string }
       /** Kid from the JWE recipient header we matched; used to select the recipient entry when it differs from recipientKey.keyId */
       matchedKid: string
-      resolveSenderKey: (skid: string) => Promise<Kms.PublicJwk<Kms.X25519PublicJwk> | null>
+      resolveSenderKey: (skid: string) => Promise<Kms.PublicJwk | null>
     }
   ): Promise<{
     plaintext: DidCommV2PlaintextMessage
-    senderKey: Kms.PublicJwk<Kms.X25519PublicJwk> | null
+    senderKey: DidCommV2KeyAgreementJwk | null
   }> {
     const kms = agentContext.dependencyManager.resolve(Kms.KeyManagementApi)
     const protectedJson = JsonEncoder.fromBase64Url(encrypted.protected)
@@ -238,16 +236,14 @@ export class DidCommV2EnvelopeService {
       throw new CredoError('No matching recipient in envelope')
     }
 
-    const epk = protectedJson.epk as { kty?: string; crv?: string; x?: string } | undefined
-    if (!epk || epk.kty !== 'OKP' || epk.crv !== 'X25519' || !epk.x) {
-      throw new CredoError('Invalid ephemeral public key in protected header')
-    }
+    const recipientCurve = getKeyAgreementCurve(keys.recipientKey)
+    const epkJwk = toEpkJwk(protectedJson.epk, recipientCurve)
 
     const aad = TypedArrayEncoder.fromUtf8String(encrypted.protected)
     const apv = this.parseAndValidateApv(protectedJson, encrypted.recipients)
 
     if (protectedJson.alg === 'ECDH-ES+A256KW') {
-      return this.unpackAnoncrypt(agentContext, encrypted, keys, recipient, epk.x, enc, aad, apv)
+      return this.unpackAnoncrypt(agentContext, encrypted, keys, recipient, epkJwk, enc, aad, apv)
     }
 
     if (protectedJson.alg !== 'ECDH-1PU+A256KW') {
@@ -263,9 +259,18 @@ export class DidCommV2EnvelopeService {
     if (!senderKey) {
       throw new CredoError('Could not resolve sender key for skid')
     }
-    const senderX25519 = senderKey.is(Kms.X25519PublicJwk)
-      ? senderKey
-      : (senderKey as Kms.PublicJwk<Kms.Ed25519PublicJwk>).convertTo(Kms.X25519PublicJwk)
+
+    let senderForKdf: DidCommV2KeyAgreementJwk
+    if (recipientCurve === 'P-256') {
+      if (!senderKey.is(Kms.P256PublicJwk)) {
+        throw new CredoError('Sender key must be P-256 when recipient is P-256')
+      }
+      senderForKdf = senderKey
+    } else {
+      senderForKdf = senderKey.is(Kms.X25519PublicJwk)
+        ? senderKey
+        : (senderKey as Kms.PublicJwk<Kms.Ed25519PublicJwk>).convertTo(Kms.X25519PublicJwk)
+    }
 
     const { data } = await kms.decrypt({
       key: {
@@ -275,8 +280,8 @@ export class DidCommV2EnvelopeService {
           encryptedKey: {
             encrypted: TypedArrayEncoder.fromBase64Url(recipient.encrypted_key),
           },
-          ephemeralPublicJwk: { kty: 'OKP', crv: 'X25519', x: epk.x },
-          senderPublicJwk: senderX25519.toJson(),
+          ephemeralPublicJwk: epkJwk,
+          senderPublicJwk: senderForKdf.toJson() as Kms.KmsJwkPublicEcdh,
           apu,
           apv,
         },
@@ -293,24 +298,24 @@ export class DidCommV2EnvelopeService {
     const plaintext = JsonEncoder.fromUint8Array(data) as DidCommV2PlaintextMessage
     this.logger.debug('Unpacked DIDComm v2 authcrypt message', { type: plaintext.type })
 
-    return { plaintext, senderKey: senderX25519 }
+    return { plaintext, senderKey: senderForKdf }
   }
 
   private async unpackAnoncrypt(
     agentContext: AgentContext,
     encrypted: DidCommV2EncryptedMessage,
     keys: {
-      recipientKey: Kms.PublicJwk<Kms.X25519PublicJwk> & { keyId: string }
+      recipientKey: DidCommV2KeyAgreementJwk & { keyId: string }
       matchedKid: string
     },
     recipient: { header: { kid: string }; encrypted_key: string },
-    epkX: string,
+    epkJwk: EpkJwk,
     enc: DidCommV2ContentEncryptionAlgorithm,
     aad: Uint8Array,
     apv: Uint8Array
   ): Promise<{
     plaintext: DidCommV2PlaintextMessage
-    senderKey: Kms.PublicJwk<Kms.X25519PublicJwk> | null
+    senderKey: DidCommV2KeyAgreementJwk | null
   }> {
     const kms = agentContext.dependencyManager.resolve(Kms.KeyManagementApi)
 
@@ -319,7 +324,7 @@ export class DidCommV2EnvelopeService {
         keyAgreement: {
           algorithm: 'ECDH-ES+A256KW',
           keyId: keys.recipientKey.keyId,
-          externalPublicJwk: { kty: 'OKP', crv: 'X25519', x: epkX },
+          externalPublicJwk: epkJwk,
           encryptedKey: {
             encrypted: TypedArrayEncoder.fromBase64Url(recipient.encrypted_key),
           },
@@ -376,4 +381,27 @@ function constantTimeEqual(a: Uint8Array, b: Uint8Array): boolean {
   let diff = 0
   for (let i = 0; i < a.length; i++) diff |= a[i] ^ b[i]
   return diff === 0
+}
+
+function getKeyAgreementCurve(jwk: DidCommV2KeyAgreementJwk): 'X25519' | 'P-256' {
+  if (jwk.is(Kms.X25519PublicJwk)) return 'X25519'
+  if (jwk.is(Kms.P256PublicJwk)) return 'P-256'
+  throw new CredoError('Unsupported keyAgreement curve for DIDComm v2')
+}
+
+function toEpkJwk(publicJwk: unknown, expectedCurve: 'X25519' | 'P-256'): EpkJwk {
+  if (typeof publicJwk !== 'object' || publicJwk === null) {
+    throw new CredoError('Invalid ephemeral public key')
+  }
+  const jwk = publicJwk as { kty?: unknown; crv?: unknown; x?: unknown; y?: unknown }
+  if (expectedCurve === 'X25519') {
+    if (jwk.kty !== 'OKP' || jwk.crv !== 'X25519' || typeof jwk.x !== 'string') {
+      throw new CredoError('Expected OKP/X25519 ephemeral key for DIDComm v2 envelope')
+    }
+    return { kty: 'OKP', crv: 'X25519', x: jwk.x }
+  }
+  if (jwk.kty !== 'EC' || jwk.crv !== 'P-256' || typeof jwk.x !== 'string' || typeof jwk.y !== 'string') {
+    throw new CredoError('Expected EC/P-256 ephemeral key for DIDComm v2 envelope')
+  }
+  return { kty: 'EC', crv: 'P-256', x: jwk.x, y: jwk.y }
 }

--- a/packages/didcomm/src/v2/DidCommV2EnvelopeService.ts
+++ b/packages/didcomm/src/v2/DidCommV2EnvelopeService.ts
@@ -206,7 +206,7 @@ export class DidCommV2EnvelopeService {
    *
    * @param agentContext - The agent context (for KMS access)
    * @param encrypted - The v2 encrypted message
-   * @param keys - Recipient key and sender key resolver (skid → X25519); resolveSenderKey not used for anoncrypt
+   * @param keys - Recipient key and sender key resolver; resolveSenderKey not used for anoncrypt
    * @returns The plaintext message and sender key (null for anoncrypt)
    */
   public async unpack(

--- a/packages/didcomm/src/v2/DidCommV2EnvelopeService.ts
+++ b/packages/didcomm/src/v2/DidCommV2EnvelopeService.ts
@@ -10,9 +10,12 @@ import {
   TypedArrayEncoder,
 } from '@credo-ts/core'
 import { computeApu, computeApv } from './apuApv'
-import type { DidCommV2ContentEncryptionAlgorithm, DidCommV2EncryptedMessage, DidCommV2PlaintextMessage } from './types'
-
-export type DidCommV2KeyAgreementJwk = Kms.PublicJwk<Kms.X25519PublicJwk | Kms.P256PublicJwk>
+import type {
+  DidCommV2ContentEncryptionAlgorithm,
+  DidCommV2EncryptedMessage,
+  DidCommV2KeyAgreementJwk,
+  DidCommV2PlaintextMessage,
+} from './types'
 
 type EpkJwk = { kty: 'OKP'; crv: 'X25519'; x: string } | { kty: 'EC'; crv: 'P-256'; x: string; y: string }
 

--- a/packages/didcomm/src/v2/__tests__/DidCommV2EnvelopeService.askar.test.ts
+++ b/packages/didcomm/src/v2/__tests__/DidCommV2EnvelopeService.askar.test.ts
@@ -139,4 +139,87 @@ describe('DidCommV2EnvelopeService (Askar round-trip)', () => {
       expect(resolvedSender).toBeNull()
     })
   })
+
+  describe('P-256 keyAgreement', () => {
+    let p256SenderKey: Kms.PublicJwk<Kms.P256PublicJwk>
+    let p256RecipientKey: Kms.PublicJwk<Kms.P256PublicJwk>
+
+    beforeAll(async () => {
+      const kms = agentContext.dependencyManager.resolve(Kms.KeyManagementApi)
+      const sender = await kms.createKey({ type: { kty: 'EC', crv: 'P-256' } })
+      const recipient = await kms.createKey({ type: { kty: 'EC', crv: 'P-256' } })
+
+      p256SenderKey = Kms.PublicJwk.fromPublicJwk(sender.publicJwk) as Kms.PublicJwk<Kms.P256PublicJwk>
+      p256SenderKey.keyId = sender.keyId
+      p256RecipientKey = Kms.PublicJwk.fromPublicJwk(recipient.publicJwk) as Kms.PublicJwk<Kms.P256PublicJwk>
+      p256RecipientKey.keyId = recipient.keyId
+    })
+
+    it.each<DidCommV2ContentEncryptionAlgorithm>([
+      'A256CBC-HS512',
+      'A256GCM',
+    ])('authcrypt round-trips with %s content encryption', async (enc) => {
+      const encrypted = await envelopeService.pack(agentContext, plaintext, {
+        senderKey: p256SenderKey,
+        recipientKey: p256RecipientKey,
+        contentEncryptionAlgorithm: enc,
+      })
+
+      const protectedJson = JsonEncoder.fromBase64Url(encrypted.protected)
+      expect(protectedJson).toMatchObject({
+        alg: 'ECDH-1PU+A256KW',
+        enc,
+        skid: p256SenderKey.keyId,
+        epk: { kty: 'EC', crv: 'P-256', x: expect.any(String), y: expect.any(String) },
+      })
+      expect(protectedJson.apu).toBe(TypedArrayEncoder.toBase64Url(computeApu(p256SenderKey.keyId)))
+      expect(protectedJson.apv).toBe(TypedArrayEncoder.toBase64Url(computeApv([p256RecipientKey.keyId])))
+
+      const { plaintext: decrypted, senderKey: resolvedSender } = await envelopeService.unpack(
+        agentContext,
+        encrypted,
+        {
+          recipientKey: p256RecipientKey as Kms.PublicJwk<Kms.P256PublicJwk> & { keyId: string },
+          matchedKid: p256RecipientKey.keyId,
+          resolveSenderKey: async (skid) => (skid === p256SenderKey.keyId ? p256SenderKey : null),
+        }
+      )
+
+      expect(decrypted).toEqual(plaintext)
+      expect(resolvedSender).not.toBeNull()
+    })
+
+    it.each<DidCommV2ContentEncryptionAlgorithm>([
+      'A256CBC-HS512',
+      'A256GCM',
+    ])('anoncrypt round-trips with %s content encryption', async (enc) => {
+      const encrypted = await envelopeService.packAnoncrypt(agentContext, plaintext, {
+        recipientKey: p256RecipientKey,
+        contentEncryptionAlgorithm: enc,
+      })
+
+      const protectedJson = JsonEncoder.fromBase64Url(encrypted.protected)
+      expect(protectedJson).toMatchObject({
+        alg: 'ECDH-ES+A256KW',
+        enc,
+        epk: { kty: 'EC', crv: 'P-256', x: expect.any(String), y: expect.any(String) },
+      })
+      expect(protectedJson.skid).toBeUndefined()
+      expect(protectedJson.apu).toBeUndefined()
+      expect(protectedJson.apv).toBe(TypedArrayEncoder.toBase64Url(computeApv([p256RecipientKey.keyId])))
+
+      const { plaintext: decrypted, senderKey: resolvedSender } = await envelopeService.unpack(
+        agentContext,
+        encrypted,
+        {
+          recipientKey: p256RecipientKey as Kms.PublicJwk<Kms.P256PublicJwk> & { keyId: string },
+          matchedKid: p256RecipientKey.keyId,
+          resolveSenderKey: async () => null,
+        }
+      )
+
+      expect(decrypted).toEqual(plaintext)
+      expect(resolvedSender).toBeNull()
+    })
+  })
 })

--- a/packages/didcomm/src/v2/__tests__/__fixtures__/sicpa/authcrypt-p256-a256cbc.json
+++ b/packages/didcomm/src/v2/__tests__/__fixtures__/sicpa/authcrypt-p256-a256cbc.json
@@ -1,5 +1,5 @@
 {
-  "$description": "SICPA didcomm-python TEST_ENCRYPTED_DIDCOMM_MESSAGE_AUTH_P256: authcrypt with ECDH-1PU+A256KW, A256CBC-HS512, P-256. Alice (sender) -> Bob (recipient, 2 P-256 keys).",
+  "$description": "SICPA didcomm-python TEST_ENCRYPTED_DIDCOMM_MESSAGE_AUTH_P256: sign-then-encrypt with ECDH-1PU+A256KW, A256CBC-HS512, P-256. The ciphertext decrypts to a JWS envelope whose inner payload matches expectedInnerPayload. Alice (sender) -> Bob (recipient, 2 P-256 keys).",
   "$source": "https://github.com/sicpa-dlab/didcomm-python/blob/main/tests/test_vectors/didcomm_messages/spec/spec_test_vectors_auth_encrypted.py",
   "$license": "Apache-2.0",
   "encryptedMessage": {
@@ -18,9 +18,8 @@
     "iv": "mLqi1bZLz7VwqtVVFsDiLg",
     "ciphertext": "WCufCs2lMZfkxQ0JCK92lPtLFgwWk_FtRWOMj52bQISa94nEbIYqHDUohIbvLMgbSjRcJVusZO04UthDuOpSSTcV5GBi3O0cMrjyI_PZnTb1yikLXpXma1bT10D2r5TPtzRMxXF3nFsr9y0JKV1TsMtn70Df2fERx2bAGxcflmd-A2sMlSTT8b7QqPtn17Yb-pA8gr4i0Bqb2WfDzwnbfewbukpRmPA2hsEs9oLKypbniAafSpoiQjfb19oDfsYaWWXqsdjTYMflqH__DqSmW52M-SUp6or0xU0ujbHmOkRkcdh9PsR5YsPuIWAqYa2hfjz_KIrGTxvCos0DMiZ4Lh_lPIYQqBufSdFH5AGChoekFbQ1vcyIyYMFugzOHOgZ2TwEzv94GCgokBHQR4_qaU_f4Mva64KPwqOYdm5f4KX16afTJa-IV7ar7__2L-A-LyxmC5KIHeGOedV9kzZBLC7TuzRAuE3vY7pkhLB1jPE6XpTeKXldljaeOSEVcbFUQtsHOSPz9JXuhqZ1fdAx8qV7hUnSAd_YMMDR3S6SXtem8ak2m98WPvKIxhCbcto7W2qoNYMT7MPvvid-QzUvTdKtyovCvLzhyYJzMjZxmn9-EnGhZ5ITPL_xFfLyKxhSSUVz3kSwK9xuOj3KpJnrrD7xrp5FKzEaJVIHWrUW90V_9QVLjriThZ36fA3ipvs8ZJ8QSTnGAmuIQ6Z2u_r4KsjL_mGAgn47qyqRm-OSLEUE4_2qB0Q9Z7EBKakCH8VPt09hTMDR62aYZYwtmpNs9ISu0VPvFjh8UmKbFcQsVrz90-x-r-Q1fTX9JaIFcDy7aqKcI-ai3tVF_HDR60Jaiw"
   },
-  "expectedPlaintext": {
+  "expectedInnerPayload": {
     "id": "1234567890",
-    "thid": "1234567890",
     "typ": "application/didcomm-plain+json",
     "type": "http://example.com/protocols/lets_do_lunch/1.0/proposal",
     "from": "did:example:alice",

--- a/packages/didcomm/src/v2/__tests__/__fixtures__/sicpa/authcrypt-p256-a256cbc.json
+++ b/packages/didcomm/src/v2/__tests__/__fixtures__/sicpa/authcrypt-p256-a256cbc.json
@@ -1,0 +1,51 @@
+{
+  "$description": "SICPA didcomm-python TEST_ENCRYPTED_DIDCOMM_MESSAGE_AUTH_P256: authcrypt with ECDH-1PU+A256KW, A256CBC-HS512, P-256. Alice (sender) -> Bob (recipient, 2 P-256 keys).",
+  "$source": "https://github.com/sicpa-dlab/didcomm-python/blob/main/tests/test_vectors/didcomm_messages/spec/spec_test_vectors_auth_encrypted.py",
+  "$license": "Apache-2.0",
+  "encryptedMessage": {
+    "protected": "eyJlcGsiOnsia3R5IjoiRUMiLCJjcnYiOiJQLTI1NiIsIngiOiJObHJ3UHZ0SUluZWNpeUVrYTRzMi00czhPalRidEZFQVhmTC12Z2x5enFvIiwieSI6ImhiMnZkWE5zSzVCQ2U3LVhaQ0dfLTY0R21UT19rNUlNWFBaQ00xdGFUQmcifSwiYXB2Ijoiei1McXB2VlhEYl9zR1luM21qUUxwdXUyQ1FMZXdZdVpvVFdPSVhQSDNGTSIsInNraWQiOiJkaWQ6ZXhhbXBsZTphbGljZSNrZXktcDI1Ni0xIiwiYXB1IjoiWkdsa09tVjRZVzF3YkdVNllXeHBZMlVqYTJWNUxYQXlOVFl0TVEiLCJ0eXAiOiJhcHBsaWNhdGlvbi9kaWRjb21tLWVuY3J5cHRlZCtqc29uIiwiZW5jIjoiQTI1NkNCQy1IUzUxMiIsImFsZyI6IkVDREgtMVBVK0EyNTZLVyJ9",
+    "recipients": [
+      {
+        "encrypted_key": "ZIL6Leligq1Xps_229nlo1xB_tGxOEVoEEMF-XTOltI0QXjyUoq_pFQBCAnVdcWNH5bmaiuzCYOmZ9lkyXBkfHO90KkGgODG",
+        "header": { "kid": "did:example:bob#key-p256-1" }
+      },
+      {
+        "encrypted_key": "sOjs0A0typIRSshhQoiJPoM4o7YpR5LA8SSieHZzmMyIDdD8ww-4JyyQhqFYuvfS4Yt37VF4z7Nd0OjYVNRL-iqPnoJ3iCOr",
+        "header": { "kid": "did:example:bob#key-p256-2" }
+      }
+    ],
+    "tag": "nIpa3EQ29hgCkA2cBPde2HpKXK4_bvmL2x7h39rtVEc",
+    "iv": "mLqi1bZLz7VwqtVVFsDiLg",
+    "ciphertext": "WCufCs2lMZfkxQ0JCK92lPtLFgwWk_FtRWOMj52bQISa94nEbIYqHDUohIbvLMgbSjRcJVusZO04UthDuOpSSTcV5GBi3O0cMrjyI_PZnTb1yikLXpXma1bT10D2r5TPtzRMxXF3nFsr9y0JKV1TsMtn70Df2fERx2bAGxcflmd-A2sMlSTT8b7QqPtn17Yb-pA8gr4i0Bqb2WfDzwnbfewbukpRmPA2hsEs9oLKypbniAafSpoiQjfb19oDfsYaWWXqsdjTYMflqH__DqSmW52M-SUp6or0xU0ujbHmOkRkcdh9PsR5YsPuIWAqYa2hfjz_KIrGTxvCos0DMiZ4Lh_lPIYQqBufSdFH5AGChoekFbQ1vcyIyYMFugzOHOgZ2TwEzv94GCgokBHQR4_qaU_f4Mva64KPwqOYdm5f4KX16afTJa-IV7ar7__2L-A-LyxmC5KIHeGOedV9kzZBLC7TuzRAuE3vY7pkhLB1jPE6XpTeKXldljaeOSEVcbFUQtsHOSPz9JXuhqZ1fdAx8qV7hUnSAd_YMMDR3S6SXtem8ak2m98WPvKIxhCbcto7W2qoNYMT7MPvvid-QzUvTdKtyovCvLzhyYJzMjZxmn9-EnGhZ5ITPL_xFfLyKxhSSUVz3kSwK9xuOj3KpJnrrD7xrp5FKzEaJVIHWrUW90V_9QVLjriThZ36fA3ipvs8ZJ8QSTnGAmuIQ6Z2u_r4KsjL_mGAgn47qyqRm-OSLEUE4_2qB0Q9Z7EBKakCH8VPt09hTMDR62aYZYwtmpNs9ISu0VPvFjh8UmKbFcQsVrz90-x-r-Q1fTX9JaIFcDy7aqKcI-ai3tVF_HDR60Jaiw"
+  },
+  "expectedPlaintext": {
+    "id": "1234567890",
+    "thid": "1234567890",
+    "typ": "application/didcomm-plain+json",
+    "type": "http://example.com/protocols/lets_do_lunch/1.0/proposal",
+    "from": "did:example:alice",
+    "to": ["did:example:bob"],
+    "created_time": 1516269022,
+    "expires_time": 1516385931,
+    "body": { "messagespecificattribute": "and its value" }
+  },
+  "recipient": {
+    "kid": "did:example:bob#key-p256-1",
+    "privateJwk": {
+      "kty": "EC",
+      "crv": "P-256",
+      "d": "PgwHnlXxt8pwR6OCTUwwWx-P51BiLkFZyqHzquKddXQ",
+      "x": "FQVaTOksf-XsCUrt4J1L2UGvtWaDwpboVlqbKBY2AIo",
+      "y": "6XFB9PYo7dyC5ViJSO9uXNYkxTJWn0d_mqJ__ZYhcNY"
+    }
+  },
+  "sender": {
+    "kid": "did:example:alice#key-p256-1",
+    "publicJwk": {
+      "kty": "EC",
+      "crv": "P-256",
+      "x": "L0crjMN1g0Ih4sYAJ_nGoHUck2cloltUpUVQDhF2nHE",
+      "y": "SxYgE7CmEJYi7IDhgK5jI4ZiajO8jPRZDldVhqFpYoo"
+    }
+  }
+}

--- a/packages/didcomm/src/v2/__tests__/interop/sicpaAuthcryptP256Interop.test.ts
+++ b/packages/didcomm/src/v2/__tests__/interop/sicpaAuthcryptP256Interop.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from 'node:fs'
 import path from 'node:path'
 
-import { InjectionSymbols, Kms } from '@credo-ts/core'
+import { InjectionSymbols, JsonEncoder, Kms } from '@credo-ts/core'
 import { askar } from '@openwallet-foundation/askar-nodejs'
 
 import { AskarModuleConfig, AskarMultiWalletDatabaseScheme } from '../../../../../askar/src/AskarModuleConfig'
@@ -30,7 +30,7 @@ interface P256PublicJwk {
 
 interface SicpaAuthcryptP256Fixture {
   encryptedMessage: DidCommV2EncryptedMessage
-  expectedPlaintext: DidCommV2PlaintextMessage
+  expectedInnerPayload: DidCommV2PlaintextMessage
   recipient: { kid: string; privateJwk: P256PrivateJwk }
   sender: { kid: string; publicJwk: P256PublicJwk }
 }
@@ -83,13 +83,14 @@ describe('SICPA authcrypt P-256 + A256CBC-HS512 interop', () => {
 
   it('decrypts SICPA TEST_ENCRYPTED_DIDCOMM_MESSAGE_AUTH_P256', async () => {
     const { plaintext, senderKey } = await envelopeService.unpack(agentContext, fixture.encryptedMessage, {
-      recipientKey: recipientKey as unknown as Kms.PublicJwk<Kms.X25519PublicJwk> & { keyId: string },
+      recipientKey,
       matchedKid: fixture.recipient.kid,
-      resolveSenderKey: async (skid) =>
-        skid === fixture.sender.kid ? (senderPublicJwk as unknown as Kms.PublicJwk<Kms.X25519PublicJwk>) : null,
+      resolveSenderKey: async (skid) => (skid === fixture.sender.kid ? senderPublicJwk : null),
     })
 
-    expect(plaintext).toEqual(fixture.expectedPlaintext)
+    expect(Array.isArray(plaintext.signatures)).toBe(true)
+    expect(typeof plaintext.payload).toBe('string')
+    expect(JsonEncoder.fromBase64Url(plaintext.payload as string)).toEqual(fixture.expectedInnerPayload)
     expect(senderKey).not.toBeNull()
   })
 })

--- a/packages/didcomm/src/v2/__tests__/interop/sicpaAuthcryptP256Interop.test.ts
+++ b/packages/didcomm/src/v2/__tests__/interop/sicpaAuthcryptP256Interop.test.ts
@@ -1,0 +1,95 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+import { InjectionSymbols, Kms } from '@credo-ts/core'
+import { askar } from '@openwallet-foundation/askar-nodejs'
+
+import { AskarModuleConfig, AskarMultiWalletDatabaseScheme } from '../../../../../askar/src/AskarModuleConfig'
+import { AskarKeyManagementService } from '../../../../../askar/src/kms/AskarKeyManagementService'
+import { getAgentConfig, getAgentContext } from '../../../../../core/tests/helpers'
+import testLogger from '../../../../../core/tests/logger'
+import { NodeFileSystem } from '../../../../../node/src/NodeFileSystem'
+
+import { DidCommV2EnvelopeService } from '../../DidCommV2EnvelopeService'
+import type { DidCommV2EncryptedMessage, DidCommV2PlaintextMessage } from '../../types'
+
+interface P256PrivateJwk {
+  kty: 'EC'
+  crv: 'P-256'
+  d: string
+  x: string
+  y: string
+}
+
+interface P256PublicJwk {
+  kty: 'EC'
+  crv: 'P-256'
+  x: string
+  y: string
+}
+
+interface SicpaAuthcryptP256Fixture {
+  encryptedMessage: DidCommV2EncryptedMessage
+  expectedPlaintext: DidCommV2PlaintextMessage
+  recipient: { kid: string; privateJwk: P256PrivateJwk }
+  sender: { kid: string; publicJwk: P256PublicJwk }
+}
+
+const fixture = JSON.parse(
+  readFileSync(path.join(__dirname, '../__fixtures__/sicpa/authcrypt-p256-a256cbc.json'), 'utf-8')
+) as SicpaAuthcryptP256Fixture
+
+describe('SICPA authcrypt P-256 + A256CBC-HS512 interop', () => {
+  const agentContext = getAgentContext({
+    contextCorrelationId: 'sicpa-authcrypt-p256',
+    agentConfig: getAgentConfig('SicpaAuthcryptP256Interop'),
+    kmsBackends: [new AskarKeyManagementService()],
+    registerInstances: [
+      [InjectionSymbols.Logger, testLogger],
+      [InjectionSymbols.FileSystem, new NodeFileSystem()],
+      [
+        AskarModuleConfig,
+        new AskarModuleConfig({
+          multiWalletDatabaseScheme: AskarMultiWalletDatabaseScheme.ProfilePerWallet,
+          askar,
+          store: {
+            id: 'sicpa-authcrypt-p256',
+            key: 'CwNJroKHTSSj3XvE7ZAnuKiTn2C4QkFvxEqfm5rzhNrb',
+            keyDerivationMethod: 'raw',
+            database: { type: 'sqlite', config: { inMemory: true } },
+          },
+        }),
+      ],
+    ],
+  })
+
+  let envelopeService: DidCommV2EnvelopeService
+  let recipientKey: Kms.PublicJwk<Kms.P256PublicJwk> & { keyId: string }
+  let senderPublicJwk: Kms.PublicJwk<Kms.P256PublicJwk>
+
+  beforeAll(async () => {
+    agentContext.dependencyManager.registerSingleton(DidCommV2EnvelopeService)
+    envelopeService = agentContext.dependencyManager.resolve(DidCommV2EnvelopeService)
+
+    const kms = agentContext.dependencyManager.resolve(Kms.KeyManagementApi)
+    const imported = await kms.importKey({ privateJwk: fixture.recipient.privateJwk })
+    const recipient = Kms.PublicJwk.fromPublicJwk(imported.publicJwk) as Kms.PublicJwk<Kms.P256PublicJwk>
+    recipient.keyId = imported.keyId
+    recipientKey = recipient as Kms.PublicJwk<Kms.P256PublicJwk> & { keyId: string }
+
+    senderPublicJwk = Kms.PublicJwk.fromPublicJwk(fixture.sender.publicJwk) as Kms.PublicJwk<Kms.P256PublicJwk>
+    senderPublicJwk.keyId = fixture.sender.kid
+  })
+
+  it('decrypts SICPA TEST_ENCRYPTED_DIDCOMM_MESSAGE_AUTH_P256', async () => {
+    const { plaintext, senderKey } = await envelopeService.unpack(agentContext, fixture.encryptedMessage, {
+      recipientKey: recipientKey as unknown as Kms.PublicJwk<Kms.X25519PublicJwk> & { keyId: string },
+      matchedKid: fixture.recipient.kid,
+      resolveSenderKey: async (skid) =>
+        skid === fixture.sender.kid ? (senderPublicJwk as unknown as Kms.PublicJwk<Kms.X25519PublicJwk>) : null,
+    })
+
+    expect(plaintext).toEqual(fixture.expectedPlaintext)
+    expect(senderKey).not.toBeNull()
+  })
+})

--- a/packages/didcomm/src/v2/index.ts
+++ b/packages/didcomm/src/v2/index.ts
@@ -10,5 +10,6 @@ export {
   DIDCOMM_V2_ENCRYPTED_MIME_TYPE,
   DIDCOMM_V2_PLAIN_MIME_TYPE,
   type DidCommV2EncryptedMessage,
+  type DidCommV2KeyAgreementJwk,
   type DidCommV2PlaintextMessage,
 } from './types'

--- a/packages/didcomm/src/v2/index.ts
+++ b/packages/didcomm/src/v2/index.ts
@@ -10,6 +10,7 @@ export {
   DIDCOMM_V2_ENCRYPTED_MIME_TYPE,
   DIDCOMM_V2_PLAIN_MIME_TYPE,
   type DidCommV2EncryptedMessage,
+  type DidCommV2KeyAgreementCurve,
   type DidCommV2KeyAgreementJwk,
   type DidCommV2PlaintextMessage,
 } from './types'

--- a/packages/didcomm/src/v2/resolveV2Keys.ts
+++ b/packages/didcomm/src/v2/resolveV2Keys.ts
@@ -11,29 +11,23 @@ import {
   parseDid,
   RecordNotFoundError,
 } from '@credo-ts/core'
-import { getResolvedDidcommServiceWithSigningKeyId } from '../modules/connections/services/helpers'
+import { getResolvedDidcommServiceWithSigningKeyId, toKeyAgreement } from '../modules/connections/services/helpers'
 import { DidCommOutOfBandRole } from '../modules/oob/domain/DidCommOutOfBandRole'
 import { DidCommOutOfBandRepository } from '../modules/oob/repository/DidCommOutOfBandRepository'
 import { DidCommOutOfBandRecordMetadataKeys } from '../modules/oob/repository/outOfBandRecordMetadataTypes'
 import { DidCommMediatorRoutingRepository } from '../modules/routing/repository'
 import { DidCommDocumentService } from '../services/DidCommDocumentService'
-import type { DidCommV2EncryptedMessage } from './types'
+import type { DidCommV2EncryptedMessage, DidCommV2KeyAgreementJwk } from './types'
 
 type ResolvedRecipientKey = {
-  recipientKey: Kms.PublicJwk<Kms.X25519PublicJwk> & { keyId: string }
+  recipientKey: DidCommV2KeyAgreementJwk & { keyId: string }
   matchedKid: string
 }
 
-/**
- * Ensure the JWK is X25519. If it's Ed25519, convert via birational map (legacy compat).
- * If it's already X25519, return as-is.
- */
-function toX25519WithKeyId(jwk: Kms.PublicJwk, keyId: string): Kms.PublicJwk<Kms.X25519PublicJwk> & { keyId: string } {
-  const x25519 = jwk.is(Kms.X25519PublicJwk)
-    ? (jwk as Kms.PublicJwk<Kms.X25519PublicJwk>)
-    : (jwk as Kms.PublicJwk<Kms.Ed25519PublicJwk>).convertTo(Kms.X25519PublicJwk)
-  x25519.keyId = keyId
-  return x25519 as Kms.PublicJwk<Kms.X25519PublicJwk> & { keyId: string }
+function toKeyAgreementWithKeyId(jwk: Kms.PublicJwk, keyId: string): DidCommV2KeyAgreementJwk & { keyId: string } {
+  const ka = toKeyAgreement(jwk)
+  ka.keyId = keyId
+  return ka as DidCommV2KeyAgreementJwk & { keyId: string }
 }
 
 /**
@@ -115,10 +109,7 @@ export class DidCommV2KeyResolver {
    * Per DIDComm v2 spec, `skid` is a DID URL into the sender's `keyAgreement`.
    * Used for ECDH-1PU authcrypt verification.
    */
-  public async resolveSenderKey(
-    agentContext: AgentContext,
-    skid: string
-  ): Promise<Kms.PublicJwk<Kms.X25519PublicJwk> | null> {
+  public async resolveSenderKey(agentContext: AgentContext, skid: string): Promise<DidCommV2KeyAgreementJwk | null> {
     if (!skid.startsWith('did:')) return null
 
     try {
@@ -143,17 +134,11 @@ export class DidCommV2KeyResolver {
 
       if (!senderJwk) return null
 
-      const x25519 = senderJwk.is(Kms.X25519PublicJwk)
-        ? senderJwk
-        : (senderJwk as Kms.PublicJwk<Kms.Ed25519PublicJwk>).convertTo(Kms.X25519PublicJwk)
-      if (vmId && !x25519.hasKeyId) {
-        x25519.keyId = vmId.startsWith('did:')
-          ? vmId
-          : vmId.startsWith('#')
-            ? `${didOnly}${vmId}`
-            : `${didOnly}#${vmId}`
+      const ka = toKeyAgreement(senderJwk)
+      if (vmId && !ka.hasKeyId) {
+        ka.keyId = vmId.startsWith('did:') ? vmId : vmId.startsWith('#') ? `${didOnly}${vmId}` : `${didOnly}#${vmId}`
       }
-      return x25519 as Kms.PublicJwk<Kms.X25519PublicJwk>
+      return ka
     } catch {
       return null
     }
@@ -186,7 +171,7 @@ export class DidCommV2KeyResolver {
       }
 
       const keyId = kmsKeyId ?? (publicJwk.hasKeyId ? publicJwk.keyId : publicJwk.legacyKeyId)
-      return { recipientKey: toX25519WithKeyId(publicJwk, keyId), matchedKid: kid }
+      return { recipientKey: toKeyAgreementWithKeyId(publicJwk, keyId), matchedKid: kid }
     } catch {
       return null
     }
@@ -212,7 +197,7 @@ export class DidCommV2KeyResolver {
         })
         const routingKey = record?.routingKeysWithKeyId.find((rk) => kidPublicJwk.equals(rk))
         if (routingKey?.keyId) {
-          return { recipientKey: toX25519WithKeyId(routingKey, routingKey.keyId), matchedKid: kid }
+          return { recipientKey: toKeyAgreementWithKeyId(routingKey, routingKey.keyId), matchedKid: kid }
         }
       }
 
@@ -226,7 +211,7 @@ export class DidCommV2KeyResolver {
             try {
               const derivedX25519 = (routingKey as Kms.PublicJwk<Kms.Ed25519PublicJwk>).convertTo(Kms.X25519PublicJwk)
               if (derivedX25519.fingerprint === kidPublicJwk.fingerprint && routingKey.keyId) {
-                return { recipientKey: toX25519WithKeyId(derivedX25519, routingKey.keyId), matchedKid: kid }
+                return { recipientKey: toKeyAgreementWithKeyId(derivedX25519, routingKey.keyId), matchedKid: kid }
               }
             } catch {}
           }
@@ -275,7 +260,7 @@ export class DidCommV2KeyResolver {
           vm.id.endsWith(didDocumentRelativeKeyId)
         )?.kmsKeyId
         const keyId = kmsKeyId ?? (vmJwk.hasKeyId ? vmJwk.keyId : vmJwk.legacyKeyId)
-        return { recipientKey: toX25519WithKeyId(vmJwk, keyId), matchedKid: kid }
+        return { recipientKey: toKeyAgreementWithKeyId(vmJwk, keyId), matchedKid: kid }
       }
     } catch (error) {
       if (!(error instanceof RecordNotFoundError)) throw error
@@ -310,7 +295,7 @@ export class DidCommV2KeyResolver {
         const recipientKey = resolvedService.recipientKeys.find((rk) => rk.fingerprint === fingerprint)
         if (!recipientKey) continue
         const keyId = recipientKey.hasKeyId ? recipientKey.keyId : recipientKey.legacyKeyId
-        return { recipientKey: toX25519WithKeyId(recipientKey, keyId), matchedKid: kid }
+        return { recipientKey: toKeyAgreementWithKeyId(recipientKey, keyId), matchedKid: kid }
       }
     }
 
@@ -321,12 +306,12 @@ export class DidCommV2KeyResolver {
       // Independent X25519 key — direct match
       if (recipientRouting.keyAgreementKeyFingerprint === fingerprint) {
         const keyId = recipientRouting.keyAgreementKeyId ?? kidPublicJwk.legacyKeyId
-        return { recipientKey: toX25519WithKeyId(kidPublicJwk, keyId), matchedKid: kid }
+        return { recipientKey: toKeyAgreementWithKeyId(kidPublicJwk, keyId), matchedKid: kid }
       }
       // Legacy Ed25519 fallback
       if (recipientRouting.recipientKeyFingerprint === fingerprint) {
         const keyId = recipientRouting.recipientKeyId ?? kidPublicJwk.legacyKeyId
-        return { recipientKey: toX25519WithKeyId(kidPublicJwk, keyId), matchedKid: kid }
+        return { recipientKey: toKeyAgreementWithKeyId(kidPublicJwk, keyId), matchedKid: kid }
       }
     }
 
@@ -343,7 +328,7 @@ export class DidCommV2KeyResolver {
     })
     if (!kmsPublic) return null
 
-    const publicJwk = Kms.PublicJwk.fromPublicJwk(kmsPublic as Kms.KmsJwkPublicOkp)
-    return { recipientKey: toX25519WithKeyId(publicJwk, kid), matchedKid: kid }
+    const publicJwk = Kms.PublicJwk.fromPublicJwk(kmsPublic as Kms.KmsJwkPublicAsymmetric)
+    return { recipientKey: toKeyAgreementWithKeyId(publicJwk, kid), matchedKid: kid }
   }
 }

--- a/packages/didcomm/src/v2/types.ts
+++ b/packages/didcomm/src/v2/types.ts
@@ -1,3 +1,7 @@
+import type { Kms } from '@credo-ts/core'
+
+export type DidCommV2KeyAgreementJwk = Kms.PublicJwk<Kms.X25519PublicJwk | Kms.P256PublicJwk>
+
 /**
  * DIDComm v2 plaintext message format (DIF DIDComm Messaging spec).
  * Uses headers + body structure; `type` and `id` (no @ prefix).

--- a/packages/didcomm/src/v2/types.ts
+++ b/packages/didcomm/src/v2/types.ts
@@ -2,6 +2,8 @@ import type { Kms } from '@credo-ts/core'
 
 export type DidCommV2KeyAgreementJwk = Kms.PublicJwk<Kms.X25519PublicJwk | Kms.P256PublicJwk>
 
+export type DidCommV2KeyAgreementCurve = 'X25519' | 'P-256'
+
 /**
  * DIDComm v2 plaintext message format (DIF DIDComm Messaging spec).
  * Uses headers + body structure; `type` and `id` (no @ prefix).


### PR DESCRIPTION
Adds P-256 keyAgreement support for DIDComm v2. Opt in via `DidCommModuleConfig.v2KeyAgreementCurve: 'X25519' | 'P-256'` (default X25519, throws at construction if 'P-256' is set without 'v2' in didcommVersions).

KMS layer accepts P-256 in ECDH-1PU+A256KW with a same-curve sender/recipient invariant. Envelope service generates P-256 ephemerals, emits EC/P-256 EPK with `x` and `y`, dispatches KDF per curve. OOB peer-DID builder emits the keyAgreement VM as `JsonWebKey2020` for P-256, preserving the existing `X25519KeyAgreementKey2019` path for X25519.

`resolveV2Keys` and the v2 connection equality checks widen to `X25519 | P-256`. New `keyAgreementsEqual(a, b)` helper replaces `toX25519(a).equals(toX25519(b))` and only bridges Ed25519 to X25519 birationally as per RFC 7748 (P-256 is direct-compare only). Core's `DidDocument.recipientKeys` widens to include P-256 (additive; v1 paths skip P-256 via existing curve guards).