### PR TITLE
feat(didcomm-v2): signed messages and sign-then-encrypt

### DIFF
--- a/packages/core/src/crypto/index.ts
+++ b/packages/core/src/crypto/index.ts
@@ -2,8 +2,11 @@ export * from './hashes'
 export { JwsService } from './JwsService'
 export type { JwsSigner, JwsSignerDid, JwsSignerJwk, JwsSignerWithJwk, JwsSignerX5c } from './JwsSigner'
 export type {
+  Jws,
+  JwsCompactFormat,
   JwsDetachedFormat,
   JwsFlattenedDetachedFormat,
+  JwsFlattenedFormat,
   JwsGeneralFormat,
   JwsProtectedHeaderOptions,
 } from './JwsTypes'

--- a/packages/didcomm/src/DidCommMessageReceiver.ts
+++ b/packages/didcomm/src/DidCommMessageReceiver.ts
@@ -4,6 +4,7 @@ import {
   CredoError,
   DidKey,
   DidsApi,
+  getPublicJwkFromVerificationMethod,
   InjectionSymbols,
   inject,
   injectable,
@@ -37,9 +38,10 @@ import { DidCommDidRotateV2Service } from './modules/connections/services/DidCom
 import { DidCommOutOfBandService } from './modules/oob/DidCommOutOfBandService'
 import { DidCommRoutingService } from './modules/routing/services/DidCommRoutingService'
 import type { DidCommEncryptedMessage, DidCommPlaintextMessage } from './types'
-import { isDidCommV2EncryptedMessage } from './util/didcommVersion'
+import { isDidCommV2EncryptedMessage, isDidCommV2SignedMessage } from './util/didcommVersion'
 import { isValidJweStructure } from './util/JWE'
 import { canHandleMessageType, parseMessageType, replaceLegacyDidSovPrefixOnMessage } from './util/messageType'
+import type { DidCommV2SignedMessage } from './v2'
 import { DidCommV2EnvelopeService, DidCommV2KeyResolver, normalizeV2PlaintextToV1 } from './v2'
 
 @injectable()
@@ -118,6 +120,8 @@ export class DidCommMessageReceiver {
     try {
       if (this.isEncryptedMessage(inboundMessage)) {
         await this.receiveEncryptedMessage(agentContext, inboundMessage as DidCommEncryptedMessage, session, receivedAt)
+      } else if (isDidCommV2SignedMessage(inboundMessage)) {
+        await this.receiveSignedMessage(agentContext, inboundMessage, connection, receivedAt)
       } else if (this.isPlaintextMessage(inboundMessage)) {
         await this.receivePlaintextMessage(agentContext, inboundMessage, connection, receivedAt)
       } else {
@@ -138,6 +142,35 @@ export class DidCommMessageReceiver {
     const message = await this.transformAndValidate(agentContext, plaintextMessage)
     const messageContext = new DidCommInboundMessageContext(message, { connection, agentContext, receivedAt })
     await this.dispatcher.dispatch(messageContext)
+  }
+
+  private async receiveSignedMessage(
+    agentContext: AgentContext,
+    signedMessage: DidCommV2SignedMessage,
+    connection?: DidCommConnectionRecord,
+    receivedAt?: Date
+  ) {
+    if (!this.config.didcommVersions.includes('v2')) {
+      throw new CredoError(
+        'Received DIDComm v2 signed message but v2 is not enabled. Add "v2" to didcommVersions in DidCommModuleConfig to accept v2 messages.'
+      )
+    }
+
+    const dids = agentContext.dependencyManager.resolve(DidsApi)
+
+    // resolveSignerJwk enforces the DIDComm v2.1 mandate that kid resolves to an authentication VM.
+    const { plaintext } = await this.v2EnvelopeService.verifySignedMessage(agentContext, signedMessage, {
+      resolveSignerJwk: async (kid) => {
+        const signerDid = kid.split('#')[0]
+        const didDocument = await dids.resolveDidDocument(signerDid)
+        const vm = didDocument.dereferenceKey(kid, ['authentication'])
+        return getPublicJwkFromVerificationMethod(vm)
+      },
+    })
+
+    this.logger.info(`Verified DIDComm v2 signed message of type '${plaintext.type}' from '${plaintext.from}'`)
+    const plaintextMessage = normalizeV2PlaintextToV1(plaintext)
+    await this.receivePlaintextMessage(agentContext, plaintextMessage, connection, receivedAt)
   }
 
   private async receiveEncryptedMessage(

--- a/packages/didcomm/src/DidCommMessageReceiver.ts
+++ b/packages/didcomm/src/DidCommMessageReceiver.ts
@@ -41,7 +41,7 @@ import type { DidCommEncryptedMessage, DidCommPlaintextMessage } from './types'
 import { isDidCommV2EncryptedMessage, isDidCommV2SignedMessage } from './util/didcommVersion'
 import { isValidJweStructure } from './util/JWE'
 import { canHandleMessageType, parseMessageType, replaceLegacyDidSovPrefixOnMessage } from './util/messageType'
-import type { DidCommV2SignedMessage } from './v2'
+import type { DidCommV2PlaintextMessage, DidCommV2SignedMessage } from './v2'
 import { DidCommV2EnvelopeService, DidCommV2KeyResolver, normalizeV2PlaintextToV1 } from './v2'
 
 @injectable()
@@ -312,16 +312,37 @@ export class DidCommMessageReceiver {
             ? async () => null
             : (sid) => this.v2KeyResolver.resolveSenderKey(agentContext, sid),
         })
+
+        // Sign-then-encrypt: the decrypted bytes are a JWS. Verify it and use the inner plaintext.
+        let unwrapped: DidCommV2PlaintextMessage = plaintext
+        if (isDidCommV2SignedMessage(plaintext as unknown)) {
+          const dids = agentContext.dependencyManager.resolve(DidsApi)
+          const { plaintext: verifiedInner } = await this.v2EnvelopeService.verifySignedMessage(
+            agentContext,
+            plaintext as unknown as DidCommV2SignedMessage,
+            {
+              resolveSignerJwk: async (kid) => {
+                const signerDid = kid.split('#')[0]
+                const didDocument = await dids.resolveDidDocument(signerDid)
+                const vm = didDocument.dereferenceKey(kid, ['authentication'])
+                return getPublicJwkFromVerificationMethod(vm)
+              },
+            }
+          )
+          unwrapped = verifiedInner
+          this.logger.debug('Verified nested DIDComm v2 signed message', { type: unwrapped.type, from: unwrapped.from })
+        }
+
         this.logger.debug('Raw DIDComm v2 plaintext (on-wire format, before normalization)', {
-          id: plaintext.id,
-          type: plaintext.type,
-          from: plaintext.from,
-          to: plaintext.to,
-          thid: plaintext.thid,
-          bodyKeys: plaintext.body ? Object.keys(plaintext.body) : undefined,
+          id: unwrapped.id,
+          type: unwrapped.type,
+          from: unwrapped.from,
+          to: unwrapped.to,
+          thid: unwrapped.thid,
+          bodyKeys: unwrapped.body ? Object.keys(unwrapped.body) : undefined,
         })
-        const plaintextMessage = normalizeV2PlaintextToV1(plaintext)
-        this.logger.debug('Unpacked DIDComm v2 message', { type: plaintext.type })
+        const plaintextMessage = normalizeV2PlaintextToV1(unwrapped)
+        this.logger.debug('Unpacked DIDComm v2 message', { type: unwrapped.type })
         return {
           plaintextMessage,
           senderKey: senderKey as unknown as DecryptedDidCommMessageContext['senderKey'],

--- a/packages/didcomm/src/__tests__/DidCommMessageReceiver.test.ts
+++ b/packages/didcomm/src/__tests__/DidCommMessageReceiver.test.ts
@@ -3,7 +3,7 @@ import { Agent } from '../../../core/src/agent/Agent'
 import { getAgentOptions } from '../../../core/tests/helpers'
 import { setupSubjectTransports } from '../../../core/tests/transport'
 import { DidCommMessageReceiver } from '../DidCommMessageReceiver'
-import { isDidCommV2EncryptedMessage } from '../util/didcommVersion'
+import { isDidCommV2EncryptedMessage, isDidCommV2SignedMessage } from '../util/didcommVersion'
 
 describe('DidCommMessageReceiver', () => {
   describe('v2 message handling', () => {
@@ -33,6 +33,34 @@ describe('DidCommMessageReceiver', () => {
 
       const receiver = agent.dependencyManager.resolve(DidCommMessageReceiver)
       await expect(receiver.receiveMessage(v2Message, { contextCorrelationId: 'default' })).rejects.toThrow(
+        /v2 is not enabled/
+      )
+
+      await agent.shutdown()
+    })
+
+    it('throws when receiving v2 signed message and v2 is not in didcommVersions', async () => {
+      const agent = new Agent(
+        getAgentOptions('ReceiverSignedTest', { didcommVersions: ['v1'] }, {}, undefined, { requireDidcomm: true })
+      )
+      setupSubjectTransports([agent])
+      await agent.initialize()
+
+      const protectedHeader = JsonEncoder.toBase64Url({
+        typ: 'application/didcomm-signed+json',
+        alg: 'EdDSA',
+        kid: 'did:example:alice#key-1',
+      })
+
+      const signedMessage = {
+        payload: JsonEncoder.toBase64Url({ id: 'm', type: 'test', from: 'did:example:alice' }),
+        signatures: [{ protected: protectedHeader, signature: 'AA' }],
+      }
+
+      expect(isDidCommV2SignedMessage(signedMessage)).toBe(true)
+
+      const receiver = agent.dependencyManager.resolve(DidCommMessageReceiver)
+      await expect(receiver.receiveMessage(signedMessage, { contextCorrelationId: 'default' })).rejects.toThrow(
         /v2 is not enabled/
       )
 

--- a/packages/didcomm/src/util/__tests__/didcommVersion.test.ts
+++ b/packages/didcomm/src/util/__tests__/didcommVersion.test.ts
@@ -5,6 +5,7 @@ import {
   isDidCommV1EncryptedMessage,
   isDidCommV2AuthcryptMessage,
   isDidCommV2EncryptedMessage,
+  isDidCommV2SignedMessage,
 } from '../didcommVersion'
 
 describe('didcommVersion', () => {
@@ -130,6 +131,54 @@ describe('didcommVersion', () => {
 
     it('returns false for non-JWE input', () => {
       expect(isDidCommV2AuthcryptMessage('invalid')).toBe(false)
+    })
+  })
+
+  describe('isDidCommV2SignedMessage', () => {
+    const signedProtected = JsonEncoder.toBase64Url({
+      typ: 'application/didcomm-signed+json',
+      alg: 'EdDSA',
+    })
+
+    it('returns false for non-object input', () => {
+      expect(isDidCommV2SignedMessage('invalid')).toBe(false)
+      expect(isDidCommV2SignedMessage(null)).toBe(false)
+      expect(isDidCommV2SignedMessage(undefined)).toBe(false)
+      expect(isDidCommV2SignedMessage({})).toBe(false)
+    })
+
+    it('returns true for v2 signed message', () => {
+      const message = {
+        payload: 'base64payload',
+        signatures: [
+          { protected: signedProtected, signature: 'base64sig', header: { kid: 'did:example:alice#key-1' } },
+        ],
+      }
+      expect(isDidCommV2SignedMessage(message)).toBe(true)
+    })
+
+    it('returns false when signatures array is empty', () => {
+      expect(isDidCommV2SignedMessage({ payload: 'p', signatures: [] })).toBe(false)
+    })
+
+    it('returns false for v2 encrypted message', () => {
+      const message = {
+        protected: v2AuthcryptProtected,
+        recipients: [],
+        iv: 'base64iv',
+        ciphertext: 'base64ciphertext',
+        tag: 'base64tag',
+      }
+      expect(isDidCommV2SignedMessage(message)).toBe(false)
+    })
+
+    it('returns false when a signature protected header has the wrong typ', () => {
+      const wrongTyp = JsonEncoder.toBase64Url({ typ: 'application/didcomm-plain+json', alg: 'EdDSA' })
+      const message = {
+        payload: 'base64payload',
+        signatures: [{ protected: wrongTyp, signature: 'base64sig', header: { kid: 'k' } }],
+      }
+      expect(isDidCommV2SignedMessage(message)).toBe(false)
     })
   })
 

--- a/packages/didcomm/src/util/didcommVersion.ts
+++ b/packages/didcomm/src/util/didcommVersion.ts
@@ -1,9 +1,10 @@
 import { CredoError, JsonEncoder } from '@credo-ts/core'
 import type { DidCommConnectionRecord } from '../modules/connections/repository'
-import type { DidCommV2EncryptedMessage } from '../v2/types'
+import type { DidCommV2EncryptedMessage, DidCommV2SignedMessage } from '../v2/types'
 import { isValidJweStructure } from './JWE'
 
 const DIDCOMM_V2_TYP = 'application/didcomm-encrypted+json'
+const DIDCOMM_V2_SIGNED_TYP = 'application/didcomm-signed+json'
 const DIDCOMM_V1_TYP = 'JWM/1.0'
 
 /**
@@ -60,6 +61,34 @@ export function isDidCommV2AuthcryptMessage(message: unknown): boolean {
   } catch {
     return false
   }
+}
+
+/**
+ * Detect whether a message is a DIDComm v2 signed message (JWS general serialization).
+ * v2 signed messages use typ: 'application/didcomm-signed+json' in each signature's protected header,
+ * with `payload` (base64url JWM bytes) and `signatures` (array with per-signature kid in unprotected header) at the top level.
+ *
+ * @param message - The message to check
+ * @returns true if the message is DIDComm v2 signed format
+ */
+export function isDidCommV2SignedMessage(message: unknown): message is DidCommV2SignedMessage {
+  if (!message || typeof message !== 'object') return false
+  const m = message as { payload?: unknown; signatures?: unknown }
+  if (typeof m.payload !== 'string' || !Array.isArray(m.signatures) || m.signatures.length === 0) {
+    return false
+  }
+  for (const sig of m.signatures) {
+    if (!sig || typeof sig !== 'object') return false
+    const s = sig as { protected?: unknown; signature?: unknown; header?: unknown }
+    if (typeof s.protected !== 'string' || typeof s.signature !== 'string') return false
+    try {
+      const protectedJson = JsonEncoder.fromBase64Url(s.protected)
+      if (protectedJson?.typ !== DIDCOMM_V2_SIGNED_TYP) return false
+    } catch {
+      return false
+    }
+  }
+  return true
 }
 
 /**

--- a/packages/didcomm/src/v2/DidCommV2EnvelopeService.ts
+++ b/packages/didcomm/src/v2/DidCommV2EnvelopeService.ts
@@ -62,19 +62,15 @@ export class DidCommV2EnvelopeService {
 
   /**
    * Pack a DIDComm v2 plaintext message into an encrypted v2 envelope using ECDH-1PU (authcrypt).
-   *
-   * @param agentContext - The agent context (for KMS access)
-   * @param plaintext - The v2 plaintext message to encrypt
-   * @param keys - Recipient and sender X25519 keys
-   * @returns The DIDComm v2 encrypted message (JWE with typ application/didcomm-encrypted+json)
+   * Accepts pre-serialized bytes for the sign-then-encrypt flow where the JWS itself is the payload.
    */
   public async pack(
     agentContext: AgentContext,
-    plaintext: DidCommV2PlaintextMessage,
+    payload: DidCommV2PlaintextMessage | Uint8Array,
     keys: DidCommV2EnvelopeKeys
   ): Promise<DidCommV2EncryptedMessage> {
     const kms = agentContext.dependencyManager.resolve(Kms.KeyManagementApi)
-    const plaintextBytes = JsonEncoder.toUint8Array(plaintext)
+    const plaintextBytes = payload instanceof Uint8Array ? payload : JsonEncoder.toUint8Array(payload)
 
     const recipientX25519 = keys.recipientKey
     if (!recipientX25519.is(Kms.X25519PublicJwk)) {
@@ -145,21 +141,16 @@ export class DidCommV2EnvelopeService {
   }
 
   /**
-   * Pack a DIDComm v2 plaintext message using ECDH-ES (anoncrypt).
-   * No sender identity; used for forwarded messages to mediators.
-   *
-   * @param agentContext - The agent context (for KMS access)
-   * @param plaintext - The v2 plaintext message to encrypt
-   * @param keys - Recipient X25519 key only
-   * @returns The DIDComm v2 encrypted message (JWE with typ application/didcomm-encrypted+json)
+   * Pack a DIDComm v2 plaintext message using ECDH-ES (anoncrypt). No sender identity;
+   * used for forwarded messages to mediators. Accepts pre-serialized bytes for sign-then-anoncrypt.
    */
   public async packAnoncrypt(
     agentContext: AgentContext,
-    plaintext: DidCommV2PlaintextMessage,
+    payload: DidCommV2PlaintextMessage | Uint8Array,
     keys: DidCommV2AnoncryptKeys
   ): Promise<DidCommV2EncryptedMessage> {
     const kms = agentContext.dependencyManager.resolve(Kms.KeyManagementApi)
-    const plaintextBytes = JsonEncoder.toUint8Array(plaintext)
+    const plaintextBytes = payload instanceof Uint8Array ? payload : JsonEncoder.toUint8Array(payload)
 
     const recipientX25519 = keys.recipientKey
     if (!recipientX25519.is(Kms.X25519PublicJwk)) {
@@ -257,6 +248,31 @@ export class DidCommV2EnvelopeService {
       payload: signed.payload,
       signatures: [{ protected: signed.protected, signature: signed.signature }],
     }
+  }
+
+  /**
+   * Sign then authcrypt: sign the plaintext, JWE-wrap the JWS using ECDH-1PU.
+   * Spec mandates this order (sign before encrypt) for non-repudiation over DIDComm v2.
+   */
+  public async packSignedAndEncrypted(
+    agentContext: AgentContext,
+    plaintext: DidCommV2PlaintextMessage,
+    signer: DidCommV2Signer,
+    keys: DidCommV2EnvelopeKeys
+  ): Promise<DidCommV2EncryptedMessage> {
+    const signed = await this.signPlaintext(agentContext, plaintext, signer)
+    return this.pack(agentContext, JsonEncoder.toUint8Array(signed), keys)
+  }
+
+  /** Sign then anoncrypt: hides sender identity on the wire while preserving the signature for the recipient. */
+  public async packSignedAndAnoncrypted(
+    agentContext: AgentContext,
+    plaintext: DidCommV2PlaintextMessage,
+    signer: DidCommV2Signer,
+    keys: DidCommV2AnoncryptKeys
+  ): Promise<DidCommV2EncryptedMessage> {
+    const signed = await this.signPlaintext(agentContext, plaintext, signer)
+    return this.packAnoncrypt(agentContext, JsonEncoder.toUint8Array(signed), keys)
   }
 
   /**

--- a/packages/didcomm/src/v2/DidCommV2EnvelopeService.ts
+++ b/packages/didcomm/src/v2/DidCommV2EnvelopeService.ts
@@ -233,20 +233,22 @@ export class DidCommV2EnvelopeService {
       )
     }
 
+    // SICPA's validate_jws requires kid in the unprotected per-signature header. The DIDComm
+    // v2.1 spec example shows kid in the protected header but doesn't normatively mandate it.
+    // We emit unprotected for interop; verify accepts either location.
     const signed = await this.jwsService.createJws(agentContext, {
       payload: JsonEncoder.toUint8Array(plaintext),
       keyId: signer.keyId,
-      header: {},
+      header: { kid: signer.kid },
       protectedHeaderOptions: {
         typ: DIDCOMM_V2_SIGNED_MIME_TYPE,
         alg: signer.alg,
-        kid: signer.kid,
       },
     })
 
     return {
       payload: signed.payload,
-      signatures: [{ protected: signed.protected, signature: signed.signature }],
+      signatures: [{ protected: signed.protected, signature: signed.signature, header: { kid: signer.kid } }],
     }
   }
 

--- a/packages/didcomm/src/v2/DidCommV2EnvelopeService.ts
+++ b/packages/didcomm/src/v2/DidCommV2EnvelopeService.ts
@@ -5,12 +5,21 @@ import {
   inject,
   injectable,
   JsonEncoder,
+  JwsService,
   Kms,
   type Logger,
   TypedArrayEncoder,
 } from '@credo-ts/core'
 import { computeApu, computeApv } from './apuApv'
-import type { DidCommV2ContentEncryptionAlgorithm, DidCommV2EncryptedMessage, DidCommV2PlaintextMessage } from './types'
+import {
+  DIDCOMM_V2_SIGNED_MIME_TYPE,
+  DIDCOMM_V2_SIGNING_ALGORITHMS,
+  type DidCommV2ContentEncryptionAlgorithm,
+  type DidCommV2EncryptedMessage,
+  type DidCommV2PlaintextMessage,
+  type DidCommV2SignedMessage,
+  type DidCommV2SigningAlgorithm,
+} from './types'
 
 export interface DidCommV2EnvelopeKeys {
   recipientKey: Kms.PublicJwk<Kms.X25519PublicJwk>
@@ -28,12 +37,27 @@ export interface DidCommV2AnoncryptKeys {
   contentEncryptionAlgorithm?: DidCommV2ContentEncryptionAlgorithm
 }
 
+export interface DidCommV2Signer {
+  keyId: string
+  /** DID URL emitted in the JWS protected header; recipients dereference it against authentication. */
+  kid: string
+  alg: DidCommV2SigningAlgorithm
+}
+
+export interface DidCommV2VerifiedSigner {
+  kid: string
+  alg: DidCommV2SigningAlgorithm
+  jwk: Kms.PublicJwk
+}
+
 @injectable()
 export class DidCommV2EnvelopeService {
   private logger: Logger
+  private jwsService: JwsService
 
-  public constructor(@inject(InjectionSymbols.Logger) logger: Logger) {
+  public constructor(@inject(InjectionSymbols.Logger) logger: Logger, jwsService: JwsService) {
     this.logger = logger
+    this.jwsService = jwsService
   }
 
   /**
@@ -200,6 +224,41 @@ export class DidCommV2EnvelopeService {
     }
   }
 
+  /** Sign a v2 plaintext into a single-signer JWS (typ application/didcomm-signed+json). */
+  public async signPlaintext(
+    agentContext: AgentContext,
+    plaintext: DidCommV2PlaintextMessage,
+    signer: DidCommV2Signer
+  ): Promise<DidCommV2SignedMessage> {
+    if (!DIDCOMM_V2_SIGNING_ALGORITHMS.includes(signer.alg)) {
+      throw new CredoError(
+        `Unsupported DIDComm v2 signing algorithm '${signer.alg}'. Expected one of ${DIDCOMM_V2_SIGNING_ALGORITHMS.join(', ')}`
+      )
+    }
+
+    if (plaintext.from && plaintext.from !== signer.kid.split('#')[0]) {
+      throw new CredoError(
+        `Plaintext 'from' (${plaintext.from}) does not match signer DID (${signer.kid.split('#')[0]})`
+      )
+    }
+
+    const signed = await this.jwsService.createJws(agentContext, {
+      payload: JsonEncoder.toUint8Array(plaintext),
+      keyId: signer.keyId,
+      header: {},
+      protectedHeaderOptions: {
+        typ: DIDCOMM_V2_SIGNED_MIME_TYPE,
+        alg: signer.alg,
+        kid: signer.kid,
+      },
+    })
+
+    return {
+      payload: signed.payload,
+      signatures: [{ protected: signed.protected, signature: signed.signature }],
+    }
+  }
+
   /**
    * Unpack a DIDComm v2 encrypted message (authcrypt or anoncrypt).
    *
@@ -339,6 +398,78 @@ export class DidCommV2EnvelopeService {
     this.logger.debug('Unpacked DIDComm v2 anoncrypt message', { type: plaintext.type })
 
     return { plaintext, senderKey: null }
+  }
+
+  /**
+   * Verify a single-signer DIDComm v2 signed message and return its plaintext.
+   * Enforces typ, alg allowlist, and that the plaintext `from` matches the signer DID.
+   */
+  public async verifySignedMessage(
+    agentContext: AgentContext,
+    signedMessage: DidCommV2SignedMessage,
+    options: { resolveSignerJwk: (kid: string) => Promise<Kms.PublicJwk | null> }
+  ): Promise<{ plaintext: DidCommV2PlaintextMessage; signers: DidCommV2VerifiedSigner[] }> {
+    if (signedMessage.signatures.length !== 1) {
+      throw new CredoError(
+        `DIDComm v2 signed message must have exactly one signature, found ${signedMessage.signatures.length}`
+      )
+    }
+
+    const [signature] = signedMessage.signatures
+    const protectedJson = JsonEncoder.fromBase64Url(signature.protected) as {
+      typ?: string
+      alg?: string
+      kid?: string
+    }
+    if (protectedJson.typ !== DIDCOMM_V2_SIGNED_MIME_TYPE) {
+      throw new CredoError(`Invalid DIDComm v2 signed message typ: ${protectedJson.typ}`)
+    }
+    if (!protectedJson.alg || !DIDCOMM_V2_SIGNING_ALGORITHMS.includes(protectedJson.alg as DidCommV2SigningAlgorithm)) {
+      throw new CredoError(
+        `Unsupported DIDComm v2 signing algorithm '${protectedJson.alg}'. Expected one of ${DIDCOMM_V2_SIGNING_ALGORITHMS.join(', ')}`
+      )
+    }
+    const alg = protectedJson.alg as DidCommV2SigningAlgorithm
+
+    // Spec puts kid in protected; SICPA fixtures put it in unprotected.
+    const kid = protectedJson.kid ?? signature.header?.kid
+    if (!kid || typeof kid !== 'string') {
+      throw new CredoError('DIDComm v2 signed message signature missing kid in protected or unprotected header')
+    }
+
+    const signerJwk = await options.resolveSignerJwk(kid)
+    if (!signerJwk) {
+      throw new CredoError(`Could not resolve DIDComm v2 signer JWK for kid '${kid}'`)
+    }
+
+    // JwsService.verifyJws requires `header` on each signature entry; v2 wire format may omit it.
+    const normalizedJws = {
+      payload: signedMessage.payload,
+      signatures: signedMessage.signatures.map((s) => ({
+        protected: s.protected,
+        signature: s.signature,
+        header: s.header ?? {},
+      })),
+    }
+    const result = await this.jwsService.verifyJws(agentContext, {
+      jws: normalizedJws,
+      jwsSigner: { method: 'jwk', jwk: signerJwk },
+      allowedJwsSignerMethods: ['jwk'],
+    })
+
+    if (!result.isValid) {
+      throw new CredoError(`DIDComm v2 signed message signature verification failed for kid '${kid}'`)
+    }
+
+    const plaintext = JsonEncoder.fromBase64Url(signedMessage.payload) as DidCommV2PlaintextMessage
+    const signerDid = kid.split('#')[0]
+    if (plaintext.from && plaintext.from !== signerDid) {
+      throw new CredoError(`Plaintext 'from' (${plaintext.from}) does not match signer DID (${signerDid})`)
+    }
+
+    this.logger.debug('Verified DIDComm v2 signed message', { type: plaintext.type, kid, alg })
+
+    return { plaintext, signers: [{ kid, alg, jwk: signerJwk }] }
   }
 
   private parseAndValidateApu(protectedJson: Record<string, unknown>, skid: string): Uint8Array {

--- a/packages/didcomm/src/v2/__tests__/DidCommV2EnvelopeService.signed.test.ts
+++ b/packages/didcomm/src/v2/__tests__/DidCommV2EnvelopeService.signed.test.ts
@@ -207,4 +207,42 @@ describe('DidCommV2EnvelopeService (signed messages)', () => {
       ).rejects.toThrow()
     })
   })
+
+  describe('round-trip on Askar (all DIDComm v2.1 algorithms)', () => {
+    const cases: Array<{ alg: 'EdDSA' | 'ES256' | 'ES256K'; keyType: Kms.KmsCreateKeyType }> = [
+      { alg: 'EdDSA', keyType: { kty: 'OKP', crv: 'Ed25519' } },
+      { alg: 'ES256', keyType: { kty: 'EC', crv: 'P-256' } },
+      { alg: 'ES256K', keyType: { kty: 'EC', crv: 'secp256k1' } },
+    ]
+
+    it.each(cases)('signs and verifies with $alg', async ({ alg, keyType }) => {
+      const kms = agentContext.dependencyManager.resolve(Kms.KeyManagementApi)
+      const created = await kms.createKey({ type: keyType })
+      const jwk = Kms.PublicJwk.fromPublicJwk(created.publicJwk as Kms.KmsJwkPublicAsymmetric)
+      jwk.keyId = created.keyId
+      const kid = `did:example:alice#${alg.toLowerCase()}-key`
+      const localPlaintext: DidCommV2PlaintextMessage = {
+        id: `roundtrip-${alg}`,
+        type: 'https://example.com/protocols/test/1.0/ping',
+        from: 'did:example:alice',
+        to: ['did:example:bob'],
+        body: { alg },
+      }
+
+      const signed = await envelopeService.signPlaintext(agentContext, localPlaintext, {
+        keyId: jwk.keyId,
+        kid,
+        alg,
+      })
+
+      const { plaintext: verified, signers } = await envelopeService.verifySignedMessage(agentContext, signed, {
+        resolveSignerJwk: async (resolved) => (resolved === kid ? jwk : null),
+      })
+
+      expect(verified).toEqual(localPlaintext)
+      expect(signers).toHaveLength(1)
+      expect(signers[0].alg).toBe(alg)
+      expect(signers[0].jwk.fingerprint).toBe(jwk.fingerprint)
+    })
+  })
 })

--- a/packages/didcomm/src/v2/__tests__/DidCommV2EnvelopeService.signed.test.ts
+++ b/packages/didcomm/src/v2/__tests__/DidCommV2EnvelopeService.signed.test.ts
@@ -208,6 +208,69 @@ describe('DidCommV2EnvelopeService (signed messages)', () => {
     })
   })
 
+  describe('sign-then-encrypt round-trip', () => {
+    let recipientKey: Kms.PublicJwk<Kms.X25519PublicJwk>
+    let senderEcdhKey: Kms.PublicJwk<Kms.X25519PublicJwk>
+
+    beforeAll(async () => {
+      const kms = agentContext.dependencyManager.resolve(Kms.KeyManagementApi)
+      const recipient = await kms.createKey({ type: { kty: 'OKP', crv: 'X25519' } })
+      const senderEcdh = await kms.createKey({ type: { kty: 'OKP', crv: 'X25519' } })
+      recipientKey = Kms.PublicJwk.fromPublicJwk(recipient.publicJwk) as Kms.PublicJwk<Kms.X25519PublicJwk>
+      recipientKey.keyId = recipient.keyId
+      senderEcdhKey = Kms.PublicJwk.fromPublicJwk(senderEcdh.publicJwk) as Kms.PublicJwk<Kms.X25519PublicJwk>
+      senderEcdhKey.keyId = senderEcdh.keyId
+    })
+
+    it('signs then authcrypts; unpacks back to the JWS which verifies to the original plaintext', async () => {
+      const envelope = await envelopeService.packSignedAndEncrypted(
+        agentContext,
+        plaintext,
+        { keyId: signerJwk.keyId, kid: signerKid, alg: 'EdDSA' },
+        { senderKey: senderEcdhKey, recipientKey }
+      )
+
+      const matchedKid = envelope.recipients[0]?.header?.kid ?? recipientKey.keyId
+      const { plaintext: inner } = await envelopeService.unpack(agentContext, envelope, {
+        recipientKey: recipientKey as Kms.PublicJwk<Kms.X25519PublicJwk> & { keyId: string },
+        matchedKid,
+        resolveSenderKey: async (skid) => (skid === senderEcdhKey.keyId ? senderEcdhKey : null),
+      })
+
+      // The inner bytes are a JWS, not a JWM plaintext. Verify and recover the original.
+      const innerSigned = inner as unknown as DidCommV2SignedMessage
+      expect(innerSigned.payload).toBeDefined()
+      expect(innerSigned.signatures).toHaveLength(1)
+
+      const { plaintext: verified } = await envelopeService.verifySignedMessage(agentContext, innerSigned, {
+        resolveSignerJwk: async (kid) => (kid === signerKid ? signerJwk : null),
+      })
+      expect(verified).toEqual(plaintext)
+    })
+
+    it('signs then anoncrypts; unpacks back to the JWS which verifies to the original plaintext', async () => {
+      const envelope = await envelopeService.packSignedAndAnoncrypted(
+        agentContext,
+        plaintext,
+        { keyId: signerJwk.keyId, kid: signerKid, alg: 'EdDSA' },
+        { recipientKey }
+      )
+
+      const matchedKid = envelope.recipients[0]?.header?.kid ?? recipientKey.keyId
+      const { plaintext: inner } = await envelopeService.unpack(agentContext, envelope, {
+        recipientKey: recipientKey as Kms.PublicJwk<Kms.X25519PublicJwk> & { keyId: string },
+        matchedKid,
+        resolveSenderKey: async () => null,
+      })
+
+      const innerSigned = inner as unknown as DidCommV2SignedMessage
+      const { plaintext: verified } = await envelopeService.verifySignedMessage(agentContext, innerSigned, {
+        resolveSignerJwk: async (kid) => (kid === signerKid ? signerJwk : null),
+      })
+      expect(verified).toEqual(plaintext)
+    })
+  })
+
   describe('round-trip on Askar (all DIDComm v2.1 algorithms)', () => {
     const cases: Array<{ alg: 'EdDSA' | 'ES256' | 'ES256K'; keyType: Kms.KmsCreateKeyType }> = [
       { alg: 'EdDSA', keyType: { kty: 'OKP', crv: 'Ed25519' } },

--- a/packages/didcomm/src/v2/__tests__/DidCommV2EnvelopeService.signed.test.ts
+++ b/packages/didcomm/src/v2/__tests__/DidCommV2EnvelopeService.signed.test.ts
@@ -1,0 +1,210 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { InjectionSymbols, JsonEncoder, Kms } from '@credo-ts/core'
+import { askar } from '@openwallet-foundation/askar-nodejs'
+
+import { AskarModuleConfig, AskarMultiWalletDatabaseScheme } from '../../../../askar/src/AskarModuleConfig'
+import { AskarKeyManagementService } from '../../../../askar/src/kms/AskarKeyManagementService'
+import { getAgentConfig, getAgentContext } from '../../../../core/tests/helpers'
+import testLogger from '../../../../core/tests/logger'
+import { NodeFileSystem } from '../../../../node/src/NodeFileSystem'
+
+import { DidCommV2EnvelopeService } from '../DidCommV2EnvelopeService'
+import type { DidCommV2PlaintextMessage, DidCommV2SignedMessage } from '../types'
+import { DIDCOMM_V2_SIGNED_MIME_TYPE } from '../types'
+
+describe('DidCommV2EnvelopeService (signed messages)', () => {
+  const agentContext = getAgentContext({
+    contextCorrelationId: 'v2-envelope-signed',
+    agentConfig: getAgentConfig('V2EnvelopeSigned'),
+    kmsBackends: [new AskarKeyManagementService()],
+    registerInstances: [
+      [InjectionSymbols.Logger, testLogger],
+      [InjectionSymbols.FileSystem, new NodeFileSystem()],
+      [
+        AskarModuleConfig,
+        new AskarModuleConfig({
+          multiWalletDatabaseScheme: AskarMultiWalletDatabaseScheme.ProfilePerWallet,
+          askar,
+          store: {
+            id: 'v2-envelope-signed',
+            key: 'CwNJroKHTSSj3XvE7ZAnuKiTn2C4QkFvxEqfm5rzhNrb',
+            keyDerivationMethod: 'raw',
+            database: { type: 'sqlite', config: { inMemory: true } },
+          },
+        }),
+      ],
+    ],
+  })
+
+  let envelopeService: DidCommV2EnvelopeService
+  let signerJwk: Kms.PublicJwk<Kms.Ed25519PublicJwk>
+  const signerDid = 'did:example:alice'
+  const signerKid = `${signerDid}#key-1`
+
+  const plaintext: DidCommV2PlaintextMessage = {
+    id: 'signed-test-1',
+    type: 'https://example.com/protocols/test/1.0/ping',
+    from: signerDid,
+    to: ['did:example:bob'],
+    body: { ping: true },
+  }
+
+  beforeAll(async () => {
+    agentContext.dependencyManager.registerSingleton(DidCommV2EnvelopeService)
+    envelopeService = agentContext.dependencyManager.resolve(DidCommV2EnvelopeService)
+
+    const kms = agentContext.dependencyManager.resolve(Kms.KeyManagementApi)
+    const ed = await kms.createKey({ type: { kty: 'OKP', crv: 'Ed25519' } })
+    signerJwk = Kms.PublicJwk.fromPublicJwk(ed.publicJwk) as Kms.PublicJwk<Kms.Ed25519PublicJwk>
+    signerJwk.keyId = ed.keyId
+  })
+
+  describe('signPlaintext', () => {
+    it('produces a single-signer JWS with kid in the protected header (DIDComm v2.1 spec example)', async () => {
+      const signed = await envelopeService.signPlaintext(agentContext, plaintext, {
+        keyId: signerJwk.keyId,
+        kid: signerKid,
+        alg: 'EdDSA',
+      })
+
+      expect(signed.signatures).toHaveLength(1)
+      expect(signed.signatures[0].header).toBeUndefined()
+      expect(JsonEncoder.fromBase64Url(signed.signatures[0].protected)).toMatchObject({
+        typ: DIDCOMM_V2_SIGNED_MIME_TYPE,
+        alg: 'EdDSA',
+        kid: signerKid,
+      })
+      expect(JsonEncoder.fromBase64Url(signed.payload)).toEqual(plaintext)
+    })
+
+    it('rejects an algorithm outside the DIDComm v2.1 set', async () => {
+      await expect(
+        envelopeService.signPlaintext(agentContext, plaintext, {
+          keyId: signerJwk.keyId,
+          kid: signerKid,
+          // biome-ignore lint/suspicious/noExplicitAny: deliberately passing an out-of-set alg
+          alg: 'RS256' as any,
+        })
+      ).rejects.toThrow(/Unsupported DIDComm v2 signing algorithm/)
+    })
+
+    it('rejects when plaintext.from is set but does not match the signer DID', async () => {
+      await expect(
+        envelopeService.signPlaintext(
+          agentContext,
+          { ...plaintext, from: 'did:example:eve' },
+          { keyId: signerJwk.keyId, kid: signerKid, alg: 'EdDSA' }
+        )
+      ).rejects.toThrow(/does not match signer DID/)
+    })
+  })
+
+  describe('verifySignedMessage', () => {
+    let signedMessage: DidCommV2SignedMessage
+
+    beforeAll(async () => {
+      signedMessage = await envelopeService.signPlaintext(agentContext, plaintext, {
+        keyId: signerJwk.keyId,
+        kid: signerKid,
+        alg: 'EdDSA',
+      })
+    })
+
+    it('verifies a signed message and returns the inner plaintext + signer metadata', async () => {
+      const { plaintext: verifiedPlaintext, signers } = await envelopeService.verifySignedMessage(
+        agentContext,
+        signedMessage,
+        { resolveSignerJwk: async (kid) => (kid === signerKid ? signerJwk : null) }
+      )
+
+      expect(verifiedPlaintext).toEqual(plaintext)
+      expect(signers).toHaveLength(1)
+      expect(signers[0].kid).toBe(signerKid)
+      expect(signers[0].alg).toBe('EdDSA')
+      expect(signers[0].jwk.fingerprint).toBe(signerJwk.fingerprint)
+    })
+
+    it('verifies SICPA-style envelopes with kid in the unprotected header', async () => {
+      const fixture = JSON.parse(readFileSync(join(__dirname, '__fixtures__/sicpa/signed-eddsa.json'), 'utf-8')) as {
+        signedMessage: DidCommV2SignedMessage
+        signer: { kid: string; publicJwk: Kms.KmsJwkPublicAsymmetric }
+      }
+      const sicpaSignerJwk = Kms.PublicJwk.fromPublicJwk(fixture.signer.publicJwk)
+
+      const { signers } = await envelopeService.verifySignedMessage(agentContext, fixture.signedMessage, {
+        resolveSignerJwk: async (kid) => (kid === fixture.signer.kid ? sicpaSignerJwk : null),
+      })
+
+      expect(signers).toHaveLength(1)
+      expect(signers[0].kid).toBe(fixture.signer.kid)
+      expect(signers[0].alg).toBe('EdDSA')
+    })
+
+    it('rejects multi-signer envelopes', async () => {
+      const multiSig: DidCommV2SignedMessage = {
+        payload: signedMessage.payload,
+        signatures: [signedMessage.signatures[0], signedMessage.signatures[0]],
+      }
+      await expect(
+        envelopeService.verifySignedMessage(agentContext, multiSig, {
+          resolveSignerJwk: async () => signerJwk,
+        })
+      ).rejects.toThrow(/exactly one signature/)
+    })
+
+    it('rejects when the protected header typ is wrong', async () => {
+      const badTyp = JsonEncoder.toBase64Url({ typ: 'application/didcomm-plain+json', alg: 'EdDSA' })
+      const bad: DidCommV2SignedMessage = {
+        payload: signedMessage.payload,
+        signatures: [{ ...signedMessage.signatures[0], protected: badTyp }],
+      }
+      await expect(
+        envelopeService.verifySignedMessage(agentContext, bad, {
+          resolveSignerJwk: async () => signerJwk,
+        })
+      ).rejects.toThrow(/Invalid DIDComm v2 signed message typ/)
+    })
+
+    it('rejects when the protected alg is outside the DIDComm v2.1 set', async () => {
+      const badAlg = JsonEncoder.toBase64Url({ typ: DIDCOMM_V2_SIGNED_MIME_TYPE, alg: 'RS256' })
+      const bad: DidCommV2SignedMessage = {
+        payload: signedMessage.payload,
+        signatures: [{ ...signedMessage.signatures[0], protected: badAlg }],
+      }
+      await expect(
+        envelopeService.verifySignedMessage(agentContext, bad, {
+          resolveSignerJwk: async () => signerJwk,
+        })
+      ).rejects.toThrow(/Unsupported DIDComm v2 signing algorithm/)
+    })
+
+    it('rejects when the resolver returns null', async () => {
+      await expect(
+        envelopeService.verifySignedMessage(agentContext, signedMessage, {
+          resolveSignerJwk: async () => null,
+        })
+      ).rejects.toThrow(/Could not resolve DIDComm v2 signer JWK/)
+    })
+
+    it('rejects when the inner plaintext from does not match the signer DID', async () => {
+      const mismatched = await envelopeService.signPlaintext(
+        agentContext,
+        { ...plaintext, from: undefined },
+        { keyId: signerJwk.keyId, kid: signerKid, alg: 'EdDSA' }
+      )
+      const tamperedPayload = JsonEncoder.toBase64Url({ ...plaintext, from: 'did:example:eve' })
+      const tampered: DidCommV2SignedMessage = {
+        payload: tamperedPayload,
+        signatures: mismatched.signatures,
+      }
+      // The signature won't verify because the payload changed, so we get the verify failure first.
+      await expect(
+        envelopeService.verifySignedMessage(agentContext, tampered, {
+          resolveSignerJwk: async () => signerJwk,
+        })
+      ).rejects.toThrow()
+    })
+  })
+})

--- a/packages/didcomm/src/v2/__tests__/DidCommV2EnvelopeService.signed.test.ts
+++ b/packages/didcomm/src/v2/__tests__/DidCommV2EnvelopeService.signed.test.ts
@@ -62,7 +62,7 @@ describe('DidCommV2EnvelopeService (signed messages)', () => {
   })
 
   describe('signPlaintext', () => {
-    it('produces a single-signer JWS with kid in the protected header (DIDComm v2.1 spec example)', async () => {
+    it('produces a single-signer JWS with kid in the unprotected header (SICPA interop)', async () => {
       const signed = await envelopeService.signPlaintext(agentContext, plaintext, {
         keyId: signerJwk.keyId,
         kid: signerKid,
@@ -70,11 +70,10 @@ describe('DidCommV2EnvelopeService (signed messages)', () => {
       })
 
       expect(signed.signatures).toHaveLength(1)
-      expect(signed.signatures[0].header).toBeUndefined()
-      expect(JsonEncoder.fromBase64Url(signed.signatures[0].protected)).toMatchObject({
+      expect(signed.signatures[0].header).toEqual({ kid: signerKid })
+      expect(JsonEncoder.fromBase64Url(signed.signatures[0].protected)).toEqual({
         typ: DIDCOMM_V2_SIGNED_MIME_TYPE,
         alg: 'EdDSA',
-        kid: signerKid,
       })
       expect(JsonEncoder.fromBase64Url(signed.payload)).toEqual(plaintext)
     })

--- a/packages/didcomm/src/v2/__tests__/__fixtures__/sicpa/signed-eddsa.json
+++ b/packages/didcomm/src/v2/__tests__/__fixtures__/sicpa/signed-eddsa.json
@@ -1,0 +1,34 @@
+{
+  "$description": "SICPA didcomm-rust SIGNED_MSG_ALICE_KEY_1: DIDComm v2 signed message with EdDSA over Ed25519. Alice signs a lets_do_lunch proposal for Bob.",
+  "$source": "https://github.com/sicpa-dlab/didcomm-rust/blob/main/src/test_vectors/signed.rs",
+  "$license": "Apache-2.0",
+  "signedMessage": {
+    "payload": "eyJpZCI6IjEyMzQ1Njc4OTAiLCJ0eXAiOiJhcHBsaWNhdGlvbi9kaWRjb21tLXBsYWluK2pzb24iLCJ0eXBlIjoiaHR0cDovL2V4YW1wbGUuY29tL3Byb3RvY29scy9sZXRzX2RvX2x1bmNoLzEuMC9wcm9wb3NhbCIsImZyb20iOiJkaWQ6ZXhhbXBsZTphbGljZSIsInRvIjpbImRpZDpleGFtcGxlOmJvYiJdLCJjcmVhdGVkX3RpbWUiOjE1MTYyNjkwMjIsImV4cGlyZXNfdGltZSI6MTUxNjM4NTkzMSwiYm9keSI6eyJtZXNzYWdlc3BlY2lmaWNhdHRyaWJ1dGUiOiJhbmQgaXRzIHZhbHVlIn19",
+    "signatures": [
+      {
+        "protected": "eyJ0eXAiOiJhcHBsaWNhdGlvbi9kaWRjb21tLXNpZ25lZCtqc29uIiwiYWxnIjoiRWREU0EifQ",
+        "signature": "FW33NnvOHV0Ted9-F7GZbkia-vYAfBKtH4oBxbrttWAhBZ6UFJMxcGjL3lwOl4YohI3kyyd08LHPWNMgP2EVCQ",
+        "header": { "kid": "did:example:alice#key-1" }
+      }
+    ]
+  },
+  "expectedPlaintext": {
+    "id": "1234567890",
+    "typ": "application/didcomm-plain+json",
+    "type": "http://example.com/protocols/lets_do_lunch/1.0/proposal",
+    "from": "did:example:alice",
+    "to": ["did:example:bob"],
+    "created_time": 1516269022,
+    "expires_time": 1516385931,
+    "body": { "messagespecificattribute": "and its value" }
+  },
+  "signer": {
+    "kid": "did:example:alice#key-1",
+    "alg": "EdDSA",
+    "publicJwk": {
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "x": "G-boxFB6vOZBu-wXkm-9Lh79I8nf9Z50cILaOgKKGww"
+    }
+  }
+}

--- a/packages/didcomm/src/v2/__tests__/__fixtures__/sicpa/signed-es256.json
+++ b/packages/didcomm/src/v2/__tests__/__fixtures__/sicpa/signed-es256.json
@@ -1,0 +1,35 @@
+{
+  "$description": "SICPA didcomm-rust SIGNED_MSG_ALICE_KEY_2: DIDComm v2 signed message with ES256 over P-256. Alice signs a lets_do_lunch proposal for Bob.",
+  "$source": "https://github.com/sicpa-dlab/didcomm-rust/blob/main/src/test_vectors/signed.rs",
+  "$license": "Apache-2.0",
+  "signedMessage": {
+    "payload": "eyJpZCI6IjEyMzQ1Njc4OTAiLCJ0eXAiOiJhcHBsaWNhdGlvbi9kaWRjb21tLXBsYWluK2pzb24iLCJ0eXBlIjoiaHR0cDovL2V4YW1wbGUuY29tL3Byb3RvY29scy9sZXRzX2RvX2x1bmNoLzEuMC9wcm9wb3NhbCIsImZyb20iOiJkaWQ6ZXhhbXBsZTphbGljZSIsInRvIjpbImRpZDpleGFtcGxlOmJvYiJdLCJjcmVhdGVkX3RpbWUiOjE1MTYyNjkwMjIsImV4cGlyZXNfdGltZSI6MTUxNjM4NTkzMSwiYm9keSI6eyJtZXNzYWdlc3BlY2lmaWNhdHRyaWJ1dGUiOiJhbmQgaXRzIHZhbHVlIn19",
+    "signatures": [
+      {
+        "protected": "eyJ0eXAiOiJhcHBsaWNhdGlvbi9kaWRjb21tLXNpZ25lZCtqc29uIiwiYWxnIjoiRVMyNTYifQ",
+        "signature": "gcW3lVifhyR48mLHbbpnGZQuziskR5-wXf6IoBlpa9SzERfSG9I7oQ9pssmHZwbvJvyMvxskpH5oudw1W3X5Qg",
+        "header": { "kid": "did:example:alice#key-2" }
+      }
+    ]
+  },
+  "expectedPlaintext": {
+    "id": "1234567890",
+    "typ": "application/didcomm-plain+json",
+    "type": "http://example.com/protocols/lets_do_lunch/1.0/proposal",
+    "from": "did:example:alice",
+    "to": ["did:example:bob"],
+    "created_time": 1516269022,
+    "expires_time": 1516385931,
+    "body": { "messagespecificattribute": "and its value" }
+  },
+  "signer": {
+    "kid": "did:example:alice#key-2",
+    "alg": "ES256",
+    "publicJwk": {
+      "kty": "EC",
+      "crv": "P-256",
+      "x": "2syLh57B-dGpa0F8p1JrO6JU7UUSF6j7qL-vfk1eOoY",
+      "y": "BgsGtI7UPsObMRjdElxLOrgAO9JggNMjOcfzEPox18w"
+    }
+  }
+}

--- a/packages/didcomm/src/v2/__tests__/__fixtures__/sicpa/signed-es256k.json
+++ b/packages/didcomm/src/v2/__tests__/__fixtures__/sicpa/signed-es256k.json
@@ -1,0 +1,35 @@
+{
+  "$description": "SICPA didcomm-rust SIGNED_MSG_ALICE_KEY_3: DIDComm v2 signed message with ES256K over secp256k1. Alice signs a lets_do_lunch proposal for Bob.",
+  "$source": "https://github.com/sicpa-dlab/didcomm-rust/blob/main/src/test_vectors/signed.rs",
+  "$license": "Apache-2.0",
+  "signedMessage": {
+    "payload": "eyJpZCI6IjEyMzQ1Njc4OTAiLCJ0eXAiOiJhcHBsaWNhdGlvbi9kaWRjb21tLXBsYWluK2pzb24iLCJ0eXBlIjoiaHR0cDovL2V4YW1wbGUuY29tL3Byb3RvY29scy9sZXRzX2RvX2x1bmNoLzEuMC9wcm9wb3NhbCIsImZyb20iOiJkaWQ6ZXhhbXBsZTphbGljZSIsInRvIjpbImRpZDpleGFtcGxlOmJvYiJdLCJjcmVhdGVkX3RpbWUiOjE1MTYyNjkwMjIsImV4cGlyZXNfdGltZSI6MTUxNjM4NTkzMSwiYm9keSI6eyJtZXNzYWdlc3BlY2lmaWNhdHRyaWJ1dGUiOiJhbmQgaXRzIHZhbHVlIn19",
+    "signatures": [
+      {
+        "protected": "eyJ0eXAiOiJhcHBsaWNhdGlvbi9kaWRjb21tLXNpZ25lZCtqc29uIiwiYWxnIjoiRVMyNTZLIn0",
+        "signature": "EGjhIcts6tqiJgqtxaTiTY3EUvL-_rLjn9lxaZ4eRUwa1-CS1nknZoyJWbyY5NQnUafWh5nvCtQpdpMyzH3blw",
+        "header": { "kid": "did:example:alice#key-3" }
+      }
+    ]
+  },
+  "expectedPlaintext": {
+    "id": "1234567890",
+    "typ": "application/didcomm-plain+json",
+    "type": "http://example.com/protocols/lets_do_lunch/1.0/proposal",
+    "from": "did:example:alice",
+    "to": ["did:example:bob"],
+    "created_time": 1516269022,
+    "expires_time": 1516385931,
+    "body": { "messagespecificattribute": "and its value" }
+  },
+  "signer": {
+    "kid": "did:example:alice#key-3",
+    "alg": "ES256K",
+    "publicJwk": {
+      "kty": "EC",
+      "crv": "secp256k1",
+      "x": "aToW5EaTq5mlAf8C5ECYDSkqsJycrW-e1SQ6_GJcAOk",
+      "y": "JAGX94caA21WKreXwYUaOCYTBMrqaX4KWIlsQZTHWCk"
+    }
+  }
+}

--- a/packages/didcomm/src/v2/__tests__/interop/sicpaSignedInterop.test.ts
+++ b/packages/didcomm/src/v2/__tests__/interop/sicpaSignedInterop.test.ts
@@ -1,0 +1,84 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+import { InjectionSymbols, JsonEncoder, JwsService, Kms } from '@credo-ts/core'
+import { askar } from '@openwallet-foundation/askar-nodejs'
+
+import { AskarModuleConfig, AskarMultiWalletDatabaseScheme } from '../../../../../askar/src/AskarModuleConfig'
+import { AskarKeyManagementService } from '../../../../../askar/src/kms/AskarKeyManagementService'
+import { getAgentConfig, getAgentContext } from '../../../../../core/tests/helpers'
+import testLogger from '../../../../../core/tests/logger'
+import { NodeFileSystem } from '../../../../../node/src/NodeFileSystem'
+
+import type { JwsFlattenedFormat } from '@credo-ts/core'
+
+interface SicpaSignedFixture {
+  signedMessage: {
+    payload: string
+    signatures: Array<{ protected: string; signature: string; header: { kid: string } }>
+  }
+  expectedPlaintext: Record<string, unknown>
+  signer: { kid: string; alg: string; publicJwk: Kms.KmsJwkPublicAsymmetric }
+}
+
+const fixturesDir = path.join(__dirname, '../__fixtures__/sicpa')
+const fixtures: Array<{ name: string; file: string }> = [
+  { name: 'EdDSA / Ed25519', file: 'signed-eddsa.json' },
+  { name: 'ES256 / P-256', file: 'signed-es256.json' },
+  { name: 'ES256K / secp256k1', file: 'signed-es256k.json' },
+]
+
+describe('SICPA DIDComm v2 signed message interop', () => {
+  const agentContext = getAgentContext({
+    contextCorrelationId: 'sicpa-signed-interop',
+    agentConfig: getAgentConfig('SicpaSignedInterop'),
+    kmsBackends: [new AskarKeyManagementService()],
+    registerInstances: [
+      [InjectionSymbols.Logger, testLogger],
+      [InjectionSymbols.FileSystem, new NodeFileSystem()],
+      [
+        AskarModuleConfig,
+        new AskarModuleConfig({
+          multiWalletDatabaseScheme: AskarMultiWalletDatabaseScheme.ProfilePerWallet,
+          askar,
+          store: {
+            id: 'sicpa-signed-interop',
+            key: 'CwNJroKHTSSj3XvE7ZAnuKiTn2C4QkFvxEqfm5rzhNrb',
+            keyDerivationMethod: 'raw',
+            database: { type: 'sqlite', config: { inMemory: true } },
+          },
+        }),
+      ],
+    ],
+  })
+
+  let jwsService: JwsService
+
+  beforeAll(async () => {
+    agentContext.dependencyManager.registerSingleton(JwsService)
+    jwsService = agentContext.dependencyManager.resolve(JwsService)
+  })
+
+  it.each(fixtures)('verifies SICPA signed envelope $name', async ({ file }) => {
+    const fixture = JSON.parse(readFileSync(path.join(fixturesDir, file), 'utf-8')) as SicpaSignedFixture
+    const jwk = Kms.PublicJwk.fromPublicJwk(fixture.signer.publicJwk)
+
+    const protectedJson = JsonEncoder.fromBase64Url(fixture.signedMessage.signatures[0].protected)
+    expect(protectedJson).toMatchObject({
+      typ: 'application/didcomm-signed+json',
+      alg: fixture.signer.alg,
+    })
+
+    const result = await jwsService.verifyJws(agentContext, {
+      jws: fixture.signedMessage satisfies JwsFlattenedFormat,
+      jwsSigner: { method: 'jwk', jwk },
+      allowedJwsSignerMethods: ['jwk'],
+    })
+
+    expect(result.isValid).toBe(true)
+    expect(result.jwsSigners[0].jwk.fingerprint).toBe(jwk.fingerprint)
+
+    const decodedPayload = JsonEncoder.fromBase64Url(fixture.signedMessage.payload)
+    expect(decodedPayload).toEqual(fixture.expectedPlaintext)
+  })
+})

--- a/packages/didcomm/src/v2/__tests__/interop/sicpaSignedInterop.test.ts
+++ b/packages/didcomm/src/v2/__tests__/interop/sicpaSignedInterop.test.ts
@@ -1,16 +1,13 @@
 import { readFileSync } from 'node:fs'
 import path from 'node:path'
-
+import type { JwsFlattenedFormat } from '@credo-ts/core'
 import { InjectionSymbols, JsonEncoder, JwsService, Kms } from '@credo-ts/core'
 import { askar } from '@openwallet-foundation/askar-nodejs'
-
 import { AskarModuleConfig, AskarMultiWalletDatabaseScheme } from '../../../../../askar/src/AskarModuleConfig'
 import { AskarKeyManagementService } from '../../../../../askar/src/kms/AskarKeyManagementService'
 import { getAgentConfig, getAgentContext } from '../../../../../core/tests/helpers'
 import testLogger from '../../../../../core/tests/logger'
 import { NodeFileSystem } from '../../../../../node/src/NodeFileSystem'
-
-import type { JwsFlattenedFormat } from '@credo-ts/core'
 
 interface SicpaSignedFixture {
   signedMessage: {

--- a/packages/didcomm/src/v2/index.ts
+++ b/packages/didcomm/src/v2/index.ts
@@ -2,6 +2,8 @@ export {
   type DidCommV2AnoncryptKeys,
   type DidCommV2EnvelopeKeys,
   DidCommV2EnvelopeService,
+  type DidCommV2Signer,
+  type DidCommV2VerifiedSigner,
 } from './DidCommV2EnvelopeService'
 export { normalizeV2PlaintextToV1 } from './normalize'
 export { buildV2PlaintextFromMessage } from './plaintextBuilder'
@@ -9,6 +11,11 @@ export { DidCommV2KeyResolver } from './resolveV2Keys'
 export {
   DIDCOMM_V2_ENCRYPTED_MIME_TYPE,
   DIDCOMM_V2_PLAIN_MIME_TYPE,
+  DIDCOMM_V2_SIGNED_MIME_TYPE,
+  DIDCOMM_V2_SIGNING_ALGORITHMS,
   type DidCommV2EncryptedMessage,
+  type DidCommV2JwsSignature,
   type DidCommV2PlaintextMessage,
+  type DidCommV2SignedMessage,
+  type DidCommV2SigningAlgorithm,
 } from './types'

--- a/packages/didcomm/src/v2/types.ts
+++ b/packages/didcomm/src/v2/types.ts
@@ -66,14 +66,19 @@ export interface DidCommV2EncryptedMessage {
 export interface DidCommV2JwsSignature {
   protected: string
   signature: string
-  header: { kid: string }
+  // Optional: spec puts kid in `protected`, SICPA fixtures put it here. Verifiers accept either.
+  header?: { kid?: string }
 }
 
 /**
  * DIDComm v2 signed message (JWS in JSON General Serialization, typ application/didcomm-signed+json).
- * `payload` is the base64url-encoded plaintext bytes; per-signature `kid` lives in the unprotected header.
+ * `payload` is the base64url-encoded plaintext bytes.
  */
 export interface DidCommV2SignedMessage {
   payload: string
   signatures: DidCommV2JwsSignature[]
 }
+
+/** Algorithms required by DIDComm v2.1: verify all three, sign at least one. */
+export const DIDCOMM_V2_SIGNING_ALGORITHMS = ['EdDSA', 'ES256', 'ES256K'] as const
+export type DidCommV2SigningAlgorithm = (typeof DIDCOMM_V2_SIGNING_ALGORITHMS)[number]

--- a/packages/didcomm/src/v2/types.ts
+++ b/packages/didcomm/src/v2/types.ts
@@ -41,6 +41,7 @@ export interface DidCommV2Attachment {
 
 export const DIDCOMM_V2_PLAIN_MIME_TYPE = 'application/didcomm-plain+json'
 export const DIDCOMM_V2_ENCRYPTED_MIME_TYPE = 'application/didcomm-encrypted+json'
+export const DIDCOMM_V2_SIGNED_MIME_TYPE = 'application/didcomm-signed+json'
 
 export type DidCommV2ContentEncryptionAlgorithm = 'A256GCM' | 'A256CBC-HS512'
 
@@ -60,4 +61,19 @@ export interface DidCommV2EncryptedMessage {
   iv: string
   ciphertext: string
   tag: string
+}
+
+export interface DidCommV2JwsSignature {
+  protected: string
+  signature: string
+  header: { kid: string }
+}
+
+/**
+ * DIDComm v2 signed message (JWS in JSON General Serialization, typ application/didcomm-signed+json).
+ * `payload` is the base64url-encoded plaintext bytes; per-signature `kid` lives in the unprotected header.
+ */
+export interface DidCommV2SignedMessage {
+  payload: string
+  signatures: DidCommV2JwsSignature[]
 }


### PR DESCRIPTION
Adds DIDComm v2.1 signed messages (typ application/didcomm-signed+json) plus sign-then-encrypt and sign-then-anoncrypt convenience methods on the envelope service. Supports the three algorithms the v2.1 spec mandates for verification: EdDSA, ES256, and ES256K.

Two notable decisions worth flagging:

1. First, kid lives in the unprotected per-signature header on emit. The spec example shows it in the protected header, but SICPA's didcomm-python and didcomm-rust both reject anything else in their validate_jws path. Verify accepts kid in either location, so we interop with both styles. 

**Update on 1st pointer**: 
After testing interop with affinidi, there's divergence. Affinidi reads kid only from the protected header. So interop with Affinidi fails here. Any suggestions here? @TimoGlastra @genaris [**FIXED** from Affinidi]

2. Second, single-signer only. The spec says "only the message sender's signature is valid", multi-sig has no defined semantics anywhere in v2.1, and no reference impl produces multi-sig envelopes. Multi-sig is rejected on verify with an explicit error so the limit is loud rather than hidden.

Round-trip tested on Askar for all three algorithms. Three SICPA fixtures from didcomm-rust are committed as known-good inputs. Cross-impl interop verified locally against didcomm-python in both directions.