### PR TITLE
fix(core): normalize did fragment when authenticating credential subject

### DIFF
--- a/.changeset/wild-mangos-rest.md
+++ b/.changeset/wild-mangos-rest.md
@@ -1,0 +1,5 @@
+---
+"@credo-ts/core": patch
+---
+
+Normalize DID identifiers when authenticating the credential subject of a verifiable presentation. A credential subject id that references a specific verification method (e.g. `did:example:123#0`) now matches the bare DID controller (`did:example:123`), as both refer to the same DID subject. Non-DID identifiers are still compared as-is.

--- a/packages/core/src/modules/vc/__tests__/util.test.ts
+++ b/packages/core/src/modules/vc/__tests__/util.test.ts
@@ -1,0 +1,56 @@
+import { validateCredentialSubjectAuthentication, w3cDate } from '../util'
+
+describe('w3cDate', () => {
+  test('formats a date without milliseconds', () => {
+    expect(w3cDate('2020-01-01T00:00:00.123Z')).toBe('2020-01-01T00:00:00Z')
+  })
+})
+
+describe('validateCredentialSubjectAuthentication', () => {
+  // The did:jwk from the reported issue: subject id has a `#0` fragment while the
+  // verification method controller is the bare did.
+  const did =
+    'did:jwk:eyJrdHkiOiJFQyIsImNydiI6IlAtMjU2IiwieCI6IkVRRG5SRDdvcU1sTkxFRElNOFpjVTF0QTZDaWw2NG5lb3NHYUxMRTRibVUiLCJ5Ijoibkl2Wlc5TElMLXlUSllwcTVva0VvSGozMFhoU0tHM1hCZ2Nfd2U4cUdzZyJ9'
+
+  test('matches a did credential subject id that has a fragment against the bare did controller', () => {
+    expect(validateCredentialSubjectAuthentication([`${did}#0`], did)).toEqual({ isValid: true })
+  })
+
+  test('matches a did credential subject id without a fragment against the bare did controller', () => {
+    expect(validateCredentialSubjectAuthentication([did], did)).toEqual({ isValid: true })
+  })
+
+  test('strips the fragment from the controller as well', () => {
+    expect(validateCredentialSubjectAuthentication([did], `${did}#0`)).toEqual({ isValid: true })
+  })
+
+  test('does not match a different did', () => {
+    const result = validateCredentialSubjectAuthentication([`${did}#0`], 'did:example:other')
+    expect(result.isValid).toBe(false)
+    expect(result.error).toBeInstanceOf(Error)
+  })
+
+  test('matches when at least one of multiple subject ids matches', () => {
+    expect(validateCredentialSubjectAuthentication(['did:example:other#1', `${did}#0`], did)).toEqual({ isValid: true })
+  })
+
+  test('passes by default when there are no subject ids to authenticate', () => {
+    expect(validateCredentialSubjectAuthentication([], did)).toEqual({ isValid: true })
+  })
+
+  // Non-did identifiers (UUIDs, HTTP URLs) are only normalized for dids, so they are
+  // compared as-is. A fragment difference on a non-did identifier is therefore significant.
+  test('compares non-did identifiers exactly (matching)', () => {
+    const subject = 'urn:uuid:0c07c1ce-57cb-41af-bef2-1b932b986873'
+    expect(validateCredentialSubjectAuthentication([subject], subject)).toEqual({ isValid: true })
+  })
+
+  test('does not strip the fragment from non-did http url identifiers', () => {
+    const result = validateCredentialSubjectAuthentication(
+      ['https://id.example/things#123'],
+      'https://id.example/things'
+    )
+    expect(result.isValid).toBe(false)
+    expect(result.error).toBeInstanceOf(Error)
+  })
+})

--- a/packages/core/src/modules/vc/jwt-vc/W3cJwtCredentialService.ts
+++ b/packages/core/src/modules/vc/jwt-vc/W3cJwtCredentialService.ts
@@ -12,7 +12,8 @@ import {
 } from '../../dids/domain/key-type/keyDidMapping'
 import { type KnownJwaSignatureAlgorithm, PublicJwk } from '../../kms'
 import { W3cJsonLdVerifiableCredential } from '../data-integrity/models/W3cJsonLdVerifiableCredential'
-import type { SingleValidationResult, W3cVerifyCredentialResult, W3cVerifyPresentationResult } from '../models'
+import type { W3cVerifyCredentialResult, W3cVerifyPresentationResult } from '../models'
+import { validateCredentialSubjectAuthentication } from '../util'
 import type {
   W3cJwtSignCredentialOptions,
   W3cJwtSignPresentationOptions,
@@ -382,32 +383,10 @@ export class W3cJwtCredentialService {
             verifyCredentialStatus: options.verifyCredentialStatus,
           })
 
-          let credentialSubjectAuthentication: SingleValidationResult
-
-          // Check whether any of the credentialSubjectIds for each credential is the same as the controller of the verificationMethod
-          // This authenticates the presentation creator controls one of the credentialSubject ids.
-          // NOTE: this doesn't take into account the case where the credentialSubject is no the holder. In the
-          // future we can add support for other flows, but for now this is the most common use case.
-          // TODO: should this be handled on a higher level? I don't really see it being handled in the jsonld lib
-          // or in the did-jwt-vc lib (it seems they don't even verify the credentials itself), but we probably need some
-          // more experience on the use cases before we loosen the restrictions (as it means we need to handle it on a higher layer).
-          const credentialSubjectIds = credential.credentialSubjectIds
-          const presentationAuthenticatesCredentialSubject = credentialSubjectIds.some(
-            (subjectId) => proverVerificationMethod.controller === subjectId
+          const credentialSubjectAuthentication = validateCredentialSubjectAuthentication(
+            credential.credentialSubjectIds,
+            proverVerificationMethod.controller
           )
-
-          if (credentialSubjectIds.length > 0 && !presentationAuthenticatesCredentialSubject) {
-            credentialSubjectAuthentication = {
-              isValid: false,
-              error: new CredoError(
-                'Credential has one or more credentialSubject ids, but presentation does not authenticate credential subject'
-              ),
-            }
-          } else {
-            credentialSubjectAuthentication = {
-              isValid: true,
-            }
-          }
 
           return {
             ...credentialResult,

--- a/packages/core/src/modules/vc/jwt-vc/W3cV2JwtCredentialService.ts
+++ b/packages/core/src/modules/vc/jwt-vc/W3cV2JwtCredentialService.ts
@@ -6,7 +6,8 @@ import { injectable } from '../../../plugins'
 import { asArray, JsonTransformer, MessageValidator, nowInSeconds } from '../../../utils'
 import { getPublicJwkFromVerificationMethod } from '../../dids/domain/key-type/keyDidMapping'
 import { extractKeyFromHolderBinding } from '../../sd-jwt-vc/utils'
-import type { SingleValidationResult, W3cV2VerifyCredentialResult, W3cV2VerifyPresentationResult } from '../models'
+import type { W3cV2VerifyCredentialResult, W3cV2VerifyPresentationResult } from '../models'
+import { validateCredentialSubjectAuthentication } from '../util'
 import {
   extractHolderFromPresentationCredentials,
   getVerificationMethodForJwt,
@@ -361,32 +362,10 @@ export class W3cV2JwtCredentialService {
             credential: credential.envelopedCredential,
           })
 
-          let credentialSubjectAuthentication: SingleValidationResult
-
-          // Check whether any of the credentialSubjectIds for each credential is the same as the controller of the verificationMethod
-          // This authenticates the presentation creator controls one of the credentialSubject ids.
-          // NOTE: this doesn't take into account the case where the credentialSubject is no the holder. In the
-          // future we can add support for other flows, but for now this is the most common use case.
-          // TODO: should this be handled on a higher level? I don't really see it being handled in the jsonld lib
-          // or in the did-jwt-vc lib (it seems they don't even verify the credentials itself), but we probably need some
-          // more experience on the use cases before we loosen the restrictions (as it means we need to handle it on a higher layer).
-          const credentialSubjectIds = credential.resolvedCredential.credentialSubjectIds
-          const presentationAuthenticatesCredentialSubject = credentialSubjectIds.some(
-            (subjectId) => proverVerificationMethod.controller === subjectId
+          const credentialSubjectAuthentication = validateCredentialSubjectAuthentication(
+            credential.resolvedCredential.credentialSubjectIds,
+            proverVerificationMethod.controller
           )
-
-          if (credentialSubjectIds.length > 0 && !presentationAuthenticatesCredentialSubject) {
-            credentialSubjectAuthentication = {
-              isValid: false,
-              error: new CredoError(
-                'Credential has one or more credentialSubject ids, but presentation does not authenticate credential subject'
-              ),
-            }
-          } else {
-            credentialSubjectAuthentication = {
-              isValid: true,
-            }
-          }
 
           return {
             ...credentialResult,

--- a/packages/core/src/modules/vc/sd-jwt-vc/W3cV2SdJwtCredentialService.ts
+++ b/packages/core/src/modules/vc/sd-jwt-vc/W3cV2SdJwtCredentialService.ts
@@ -14,12 +14,12 @@ import {
   parseHolderBindingFromCredential,
 } from '../../sd-jwt-vc/utils'
 import type {
-  SingleValidationResult,
   W3cV2JsonCredential,
   W3cV2JsonPresentation,
   W3cV2VerifyCredentialResult,
   W3cV2VerifyPresentationResult,
 } from '../models'
+import { validateCredentialSubjectAuthentication } from '../util'
 import {
   extractHolderFromPresentationCredentials,
   getVerificationMethodForJwt,
@@ -356,32 +356,10 @@ export class W3cV2SdJwtCredentialService {
             credential: credential.envelopedCredential,
           })
 
-          let credentialSubjectAuthentication: SingleValidationResult
-
-          // Check whether any of the credentialSubjectIds for each credential is the same as the controller of the verificationMethod
-          // This authenticates the presentation creator controls one of the credentialSubject ids.
-          // NOTE: this doesn't take into account the case where the credentialSubject is no the holder. In the
-          // future we can add support for other flows, but for now this is the most common use case.
-          // TODO: should this be handled on a higher level? I don't really see it being handled in the jsonld lib
-          // or in the did-jwt-vc lib (it seems they don't even verify the credentials itself), but we probably need some
-          // more experience on the use cases before we loosen the restrictions (as it means we need to handle it on a higher layer).
-          const credentialSubjectIds = credential.resolvedCredential.credentialSubjectIds
-          const presentationAuthenticatesCredentialSubject = credentialSubjectIds.some(
-            (subjectId) => proverVerificationMethod.controller === subjectId
+          const credentialSubjectAuthentication = validateCredentialSubjectAuthentication(
+            credential.resolvedCredential.credentialSubjectIds,
+            proverVerificationMethod.controller
           )
-
-          if (credentialSubjectIds.length > 0 && !presentationAuthenticatesCredentialSubject) {
-            credentialSubjectAuthentication = {
-              isValid: false,
-              error: new CredoError(
-                'Credential has one or more credentialSubject ids, but presentation does not authenticate credential subject'
-              ),
-            }
-          } else {
-            credentialSubjectAuthentication = {
-              isValid: true,
-            }
-          }
 
           return {
             ...credentialResult,

--- a/packages/core/src/modules/vc/util.ts
+++ b/packages/core/src/modules/vc/util.ts
@@ -1,3 +1,7 @@
+import { CredoError } from '../../error'
+import { tryParseDid } from '../dids/domain/parse'
+import type { SingleValidationResult } from './models'
+
 /**
  * Formats an input date to w3c standard date format
  * @param date {number|string} Optional if not defined current date is returned
@@ -11,4 +15,53 @@ export const w3cDate = (date?: number | string): string => {
   }
   const str = result.toISOString()
   return `${str.substr(0, str.length - 5)}Z`
+}
+
+/**
+ * Returns the bare DID for a DID URL, stripping any fragment, query and path.
+ * Returns the input unchanged if it is not a (parseable) DID.
+ */
+function normalizeDidIdentifier(identifier: string): string {
+  return tryParseDid(identifier)?.did ?? identifier
+}
+
+/**
+ * Validates whether the given `controller` (e.g. the controller of a verification method)
+ * authenticates one of the provided `credentialSubjectIds`. This authenticates that the
+ * presentation creator controls one of the credential subject ids.
+ *
+ * A credential subject id may reference a specific verification method (e.g.
+ * `did:example:123#0`), while a verification method controller is always the bare DID
+ * (`did:example:123`). Both refer to the same DID subject, so for DIDs the fragment (and
+ * any DID URL parameters/path) is stripped before comparison. Non-DID identifiers (e.g.
+ * UUIDs or HTTP URLs) are compared as-is.
+ *
+ * If the credential has no credential subject ids, the validation passes by default as
+ * there is no subject to authenticate.
+ *
+ * NOTE: this doesn't take into account the case where the credentialSubject is not the
+ * holder. In the future we can add support for other flows, but for now this is the most
+ * common use case.
+ */
+export function validateCredentialSubjectAuthentication(
+  credentialSubjectIds: string[],
+  controller: string
+): SingleValidationResult {
+  const normalizedController = normalizeDidIdentifier(controller)
+  const authenticatesCredentialSubject = credentialSubjectIds.some(
+    (subjectId) => normalizeDidIdentifier(subjectId) === normalizedController
+  )
+
+  if (credentialSubjectIds.length > 0 && !authenticatesCredentialSubject) {
+    return {
+      isValid: false,
+      error: new CredoError(
+        'Credential has one or more credentialSubject ids, but presentation does not authenticate credential subject'
+      ),
+    }
+  }
+
+  return {
+    isValid: true,
+  }
 }


### PR DESCRIPTION
A credential subject id that references a specific verification method (e.g. did:example:123#0) now matches the bare DID controller (did:example:123), as both refer to the same DID subject. The shared validation logic is moved into a `validateCredentialSubjectAuthentication` helper reused by the v1 JWT, v2 JWT and v2 SD-JWT credential services.

This allows for more flexibility when the issuer has used the DID referencing the key and not the subject itself.