### PR TITLE
fix(askar): use NativeAskar.instance instead of the deprecated askar export

### DIFF
--- a/.changeset/askar-native-instance.md
+++ b/.changeset/askar-native-instance.md
@@ -1,0 +1,7 @@
+---
+'@credo-ts/askar': minor
+---
+
+Read the askar native binding via `NativeAskar.instance` instead of the deprecated mutable `askar` export in the KMS (key management and ECDH key derivation). The deprecated binding is populated only when the platform package's side-effect import runs, so an ESM consumer that loads the KMS first snapshots it as `undefined` and key operations fail with `Cannot read properties of undefined (reading 'keyGetJwkSecret')`. `NativeAskar.instance` resolves the binding on each access, so registration order no longer matters. See #2597, #2607.
+
+This raises the minimum required `@openwallet-foundation/askar-shared` to 0.6.0, where `NativeAskar` was introduced, so the peer dependency range is narrowed to `^0.6.0`.

--- a/packages/askar/package.json
+++ b/packages/askar/package.json
@@ -45,6 +45,6 @@
     "typescript": "catalog:"
   },
   "peerDependencies": {
-    "@openwallet-foundation/askar-shared": "^0.4.3 || ^0.5.0 || ^0.6.0"
+    "@openwallet-foundation/askar-shared": "^0.6.0"
   }
 }

--- a/packages/askar/src/kms/AskarKeyManagementService.ts
+++ b/packages/askar/src/kms/AskarKeyManagementService.ts
@@ -1,12 +1,12 @@
 import { type AgentContext, JsonEncoder, Kms, TypedArrayEncoder, utils } from '@credo-ts/core'
 import type { JwkProps, KeyEntryObject, Session } from '@openwallet-foundation/askar-shared'
 import {
-  askar,
   CryptoBox,
   Jwk,
   Key,
   KeyAlgorithm,
   KeyEntryList,
+  NativeAskar,
   SignatureAlgorithm,
 } from '@openwallet-foundation/askar-shared'
 
@@ -681,7 +681,7 @@ export class AskarKeyManagementService implements Kms.KeyManagementService {
 
   private keyFromJwk(jwk: Kms.KmsJwkPrivate | Kms.KmsJwkPublic) {
     const key = new Key(
-      askar.keyFromJwk({
+      NativeAskar.instance.keyFromJwk({
         // TODO: the JWK class in JS Askar wrapper is too limiting
         // so we use this method directly. should update it
         jwk: new Uint8Array(JsonEncoder.toUint8Array(jwk)) as unknown as Jwk,
@@ -717,7 +717,7 @@ export class AskarKeyManagementService implements Kms.KeyManagementService {
     // so we use this method directly. should update it
     // We extract alg, as Askar doesn't always use the same algs
     const { alg, ...jwkSecret } = JsonEncoder.fromUint8Array(
-      askar.keyGetJwkSecret({
+      NativeAskar.instance.keyGetJwkSecret({
         localKeyHandle: key.handle,
       })
     )
@@ -733,7 +733,11 @@ export class AskarKeyManagementService implements Kms.KeyManagementService {
       if (!session.handle) throw Error('Cannot fetch a key with a closed session')
 
       // Fetch the key from the session
-      const handle = await askar.sessionFetchKey({ forUpdate: false, name: keyId, sessionHandle: session.handle })
+      const handle = await NativeAskar.instance.sessionFetchKey({
+        forUpdate: false,
+        name: keyId,
+        sessionHandle: session.handle,
+      })
       if (!handle) return null
 
       // Get the key entry

--- a/packages/askar/src/kms/__tests__/AskarKeyManagementService.test.ts
+++ b/packages/askar/src/kms/__tests__/AskarKeyManagementService.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from 'node:fs'
 import path from 'node:path'
 import { InjectionSymbols, JsonEncoder, Kms, TypedArrayEncoder } from '@credo-ts/core'
-import { AskarError, askar } from '@openwallet-foundation/askar-shared'
+import { AskarError, NativeAskar } from '@openwallet-foundation/askar-shared'
 import { getAgentConfig, getAgentContext } from '../../../../core/tests'
 import { NodeFileSystem } from '../../../../node/src/NodeFileSystem'
 import { AskarModuleConfig, AskarMultiWalletDatabaseScheme } from '../../AskarModuleConfig'
@@ -17,7 +17,7 @@ const agentContext = getAgentContext({
       AskarModuleConfig,
       new AskarModuleConfig({
         multiWalletDatabaseScheme: AskarMultiWalletDatabaseScheme.ProfilePerWallet,
-        askar,
+        askar: NativeAskar.instance,
         store: {
           id: 'default',
           key: 'CwNJroKHTSSj3XvE7ZAnuKiTn2C4QkFvxEqfm5rzhNrb',

--- a/packages/askar/src/kms/crypto/deriveKey.ts
+++ b/packages/askar/src/kms/crypto/deriveKey.ts
@@ -1,5 +1,5 @@
 import { Kms, TypedArrayEncoder } from '@credo-ts/core'
-import { askar, Key } from '@openwallet-foundation/askar-shared'
+import { Key, NativeAskar } from '@openwallet-foundation/askar-shared'
 import { jwkEncToAskarAlg } from '../../utils'
 
 export const askarSupportedKeyAgreementAlgorithms = [
@@ -47,7 +47,7 @@ export function deriveEncryptionKey(options: {
       : undefined
 
   const derivedKey = new Key(
-    askar.keyDeriveEcdhEs({
+    NativeAskar.instance.keyDeriveEcdhEs({
       algId: TypedArrayEncoder.fromUtf8String(
         keyAgreement.algorithm === 'ECDH-ES' ? encryption.algorithm : keyAgreement.algorithm
       ),
@@ -130,7 +130,7 @@ export function deriveDecryptionKey(options: {
       : undefined
 
   const derivedKey = new Key(
-    askar.keyDeriveEcdhEs({
+    NativeAskar.instance.keyDeriveEcdhEs({
       algId: TypedArrayEncoder.fromUtf8String(
         keyAgreement.algorithm === 'ECDH-ES' ? decryption.algorithm : keyAgreement.algorithm
       ),

--- a/packages/askar/src/storage/__tests__/AskarStorageService.test.ts
+++ b/packages/askar/src/storage/__tests__/AskarStorageService.test.ts
@@ -1,7 +1,7 @@
 import type { AgentContext, TagsBase } from '@credo-ts/core'
 
 import { RecordDuplicateError, RecordNotFoundError, TypedArrayEncoder } from '@credo-ts/core'
-import { askar } from '@openwallet-foundation/askar-nodejs'
+import { NativeAskar } from '@openwallet-foundation/askar-nodejs'
 
 import { TestRecord } from '../../../../core/src/storage/__tests__/TestRecord'
 import { getAgentConfig, getAgentContext, getAskarStoreConfig } from '../../../../core/tests/helpers'
@@ -27,7 +27,7 @@ describe('AskarStorageService', () => {
     storeManager = new AskarStoreManager(
       new NodeFileSystem(),
       new AskarModuleConfig({
-        askar,
+        askar: NativeAskar.instance,
         store: getAskarStoreConfig('AskarStorageServiceTest', {
           inMemory: true,
         }),
@@ -70,7 +70,7 @@ describe('AskarStorageService', () => {
       })
 
       const retrieveRecord = await storeManager.withSession(agentContext, (session) =>
-        askar.sessionFetch({
+        NativeAskar.instance.sessionFetch({
           category: record.type,
           name: record.id,
           // biome-ignore lint/style/noNonNullAssertion: no explanation
@@ -96,7 +96,7 @@ describe('AskarStorageService', () => {
       await storeManager.withSession(
         agentContext,
         async (session) =>
-          await askar.sessionUpdate({
+          await NativeAskar.instance.sessionUpdate({
             category: TestRecord.type,
             name: 'some-id',
             // biome-ignore lint/style/noNonNullAssertion: no explanation


### PR DESCRIPTION
The KMS reads the askar binding through the deprecated `askar` export from `askar-shared`. That binding is only set as a side effect of importing `askar-nodejs`, so if anything loads the KMS first (ESM, bundlers, test runners) it's still `undefined` and key ops throw `Cannot read properties of undefined (reading 'keyGetJwkSecret')`.

This switches `AskarKeyManagementService` and the ECDH derive helpers (plus the two tests that used it) to `NativeAskar.instance`, the getter added in askar 0.6.0 ([openwallet-foundation/askar-wrapper-javascript#77](https://github.com/openwallet-foundation/askar-wrapper-javascript/issues/77) / [#78](https://github.com/openwallet-foundation/askar-wrapper-javascript/pull/78)), which resolves the binding on each call so import order stops mattering.

`NativeAskar` only exists from 0.6.0, so the `askar-shared` peer is narrowed to `^0.6.0` and the changeset is `minor`. Flagging that this drops pre-0.6.0 support, in case anyone still pins an older askar.

Relates to #2597, #2607.