### PR TITLE
fix(mdoc): accept status lists signed by the credential's issuance chain during presentation verification

### DIFF
--- a/.changeset/mdoc-presentation-status-fallback.md
+++ b/.changeset/mdoc-presentation-status-fallback.md
@@ -1,0 +1,7 @@
+---
+"@credo-ts/core": patch
+---
+
+fix(mdoc): accept status lists signed by the credential's issuance chain during presentation (device response) verification
+
+The mdoc presentation verification path (`MdocDeviceResponse.verify`, used by OpenID4VP) did not fall back to the issuance certificates when a trusted issuer was configured without dedicated `status` certificates (`status: undefined`). As a result, an mdoc carrying a token status list signed by the same certificate as the credential failed presentation verification, while the equivalent SD-JWT VC and standalone `Mdoc.verify` cases succeeded. The fallback (and the chain-equality safeguard that prevents it from widening the trust set) is now shared between `Mdoc.verify` and `MdocDeviceResponse.verify`.

--- a/packages/core/src/modules/mdoc/Mdoc.ts
+++ b/packages/core/src/modules/mdoc/Mdoc.ts
@@ -6,11 +6,15 @@ import { type KnownJwaSignatureAlgorithm, PublicJwk } from '../kms'
 import { isKnownJwaSignatureAlgorithm } from '../kms/jwk/jwa'
 import { ClaimFormat } from '../vc/index'
 import { X509Certificate } from '../x509'
-import { convertLegacyTrustedCertificates } from '../x509/utils/convertLegacyTrustedCertificates'
 import { X509ModuleConfig } from '../x509/X509ModuleConfig'
 import { MdocError } from './MdocError'
 import type { MdocNameSpaces, MdocSignOptions, MdocVerifyOptions } from './MdocOptions'
 import { isMdocSupportedSignatureAlgorithm, mdocSupportedSignatureAlgorithms } from './mdocSupportedAlgs'
+import {
+  assertMdocStatusListChainsMatchIssuanceChain,
+  convertMdocTrustedCertificates,
+  mdocTrustedCertificatesToRaw,
+} from './mdocUtil'
 
 /**
  * This class represents a IssuerSigned Mdoc Document,
@@ -203,26 +207,12 @@ export class Mdoc {
     })
 
     try {
-      // The underlying mdoc library requires `status` certificates to validate status/identifier lists.
-      // When the user has not configured a `status` field at all (undefined) for a trusted entry, fall
-      // back to that entry's `issuance` certs — chain equality between the status/identifier and issuance
-      // chains is then enforced below so the fallback can't widen the trust set unintentionally. An
-      // explicitly-empty `status: []` is treated as a deliberate user choice and passed through unchanged.
-      const convertedTrustedCertificates = convertLegacyTrustedCertificates(trustedCertificates).map(
-        ({ issuance, status }) => ({
-          issuance,
-          status: status ?? issuance,
-          hasDedicatedStatusCertificates: status !== undefined,
-        })
-      )
+      const convertedTrustedCertificates = convertMdocTrustedCertificates(trustedCertificates)
 
       const { trustedIssuanceChain, trustedStatusListChain, trustedIdentifierListChain } =
         await Holder.verifyIssuerSigned(
           {
-            trustedCertificates: convertedTrustedCertificates.map(({ issuance, status }) => ({
-              issuance: issuance.map((cert) => X509Certificate.fromEncodedCertificate(cert).rawCertificate),
-              status: status.map((cert) => X509Certificate.fromEncodedCertificate(cert).rawCertificate),
-            })),
+            trustedCertificates: mdocTrustedCertificatesToRaw(convertedTrustedCertificates),
             issuerSigned: this.issuerSigned,
             disableCertificateChainValidation: false,
             disableStatusValidation: false,
@@ -230,9 +220,6 @@ export class Mdoc {
           },
           mdocContext
         )
-
-      const x509ChainsAreEqual = (a: X509Certificate[], b: X509Certificate[]) =>
-        a.length === b.length && a.every((cert, i) => cert.equal(b[i]))
 
       const issuanceChain = trustedIssuanceChain.map((c) => X509Certificate.fromRawCertificate(c))
 
@@ -245,37 +232,11 @@ export class Mdoc {
         throw new MdocError('Certificate chain does not match the trusted issuance chain')
       }
 
-      const issuanceTrustAnchor = issuanceChain[issuanceChain.length - 1]
-      const matchedTrustedCertificates = convertedTrustedCertificates.find(({ issuance }) =>
-        issuance.some((cert) => X509Certificate.fromEncodedCertificate(cert).equal(issuanceTrustAnchor))
-      )
-      const hasDedicatedStatusCertificates = matchedTrustedCertificates?.hasDedicatedStatusCertificates ?? false
-
-      if (!hasDedicatedStatusCertificates) {
-        if (
-          trustedIdentifierListChain &&
-          !x509ChainsAreEqual(
-            trustedIdentifierListChain.map((c) => X509Certificate.fromRawCertificate(c)),
-            issuanceChain
-          )
-        ) {
-          throw new MdocError(
-            'Trusted identifier list chain does not match the trusted issuance chain, and no trusted status certificates were provided for the trusted issuance certificate'
-          )
-        }
-
-        if (
-          trustedStatusListChain &&
-          !x509ChainsAreEqual(
-            trustedStatusListChain.map((c) => X509Certificate.fromRawCertificate(c)),
-            issuanceChain
-          )
-        ) {
-          throw new MdocError(
-            'Trusted status list chain does not match the trusted issuance chain, and no trusted status certificates were provided for the trusted issuance certificate'
-          )
-        }
-      }
+      assertMdocStatusListChainsMatchIssuanceChain(convertedTrustedCertificates, {
+        trustedIssuanceChain,
+        trustedStatusListChain,
+        trustedIdentifierListChain,
+      })
 
       return { isValid: true }
     } catch (error) {

--- a/packages/core/src/modules/mdoc/MdocDeviceResponse.ts
+++ b/packages/core/src/modules/mdoc/MdocDeviceResponse.ts
@@ -25,8 +25,6 @@ import { getMdocContext } from '../../crypto/contexts/mdocContext'
 import { TypedArrayEncoder } from './../../utils'
 import { PublicJwk } from '../kms'
 import { ClaimFormat } from '../vc'
-import { convertLegacyTrustedCertificates } from '../x509/utils/convertLegacyTrustedCertificates'
-import { X509Certificate } from '../x509/X509Certificate'
 import type { Mdoc } from './Mdoc'
 import { MdocError } from './MdocError'
 import type {
@@ -37,7 +35,12 @@ import type {
   MdocSessionTranscriptOptions,
 } from './MdocOptions'
 import { isMdocSupportedSignatureAlgorithm, mdocSupportedSignatureAlgorithms } from './mdocSupportedAlgs'
-import { nameSpacesRecordToMap } from './mdocUtil'
+import {
+  assertMdocStatusListChainsMatchIssuanceChain,
+  convertMdocTrustedCertificates,
+  mdocTrustedCertificatesToRaw,
+  nameSpacesRecordToMap,
+} from './mdocUtil'
 import { convertDocumentRequest } from './utils/convertDocumentRequest'
 
 export type DeviceAndIssuerClaims = {
@@ -300,15 +303,12 @@ export class MdocDeviceResponse {
       category: 'DOCUMENT_FORMAT',
     })
 
-    const trustedCertificates = convertLegacyTrustedCertificates(options.trustedCertificates ?? [])
+    const trustedCertificates = convertMdocTrustedCertificates(options.trustedCertificates ?? [])
 
-    await this.deviceResponse
+    const verificationResults = await this.deviceResponse
       .verify(
         {
-          trustedCertificates: trustedCertificates.map(({ issuance, status }) => ({
-            issuance: issuance.map((cert) => X509Certificate.fromEncodedCertificate(cert).rawCertificate),
-            status: status?.map((cert) => X509Certificate.fromEncodedCertificate(cert).rawCertificate),
-          })),
+          trustedCertificates: mdocTrustedCertificatesToRaw(trustedCertificates),
           disableCertificateChainValidation: false,
           now: options.now,
           skewSeconds: agentContext.config.validitySkewSeconds,
@@ -324,6 +324,16 @@ export class MdocDeviceResponse {
           cause: error,
         })
       })
+
+    for (const { trustedIssuanceChain, trustedStatusListChain, trustedIdentifierListChain } of verificationResults) {
+      if (!trustedIssuanceChain) continue
+
+      assertMdocStatusListChainsMatchIssuanceChain(trustedCertificates, {
+        trustedIssuanceChain,
+        trustedStatusListChain,
+        trustedIdentifierListChain,
+      })
+    }
   }
 
   private static async calculateSessionTranscriptBytes(

--- a/packages/core/src/modules/mdoc/__tests__/mdocDeviceResponseStatus.test.ts
+++ b/packages/core/src/modules/mdoc/__tests__/mdocDeviceResponseStatus.test.ts
@@ -1,0 +1,221 @@
+import { Buffer } from 'node:buffer'
+import { MediaTypes } from '@owf/token-status-list'
+import type { DcqlQuery } from 'dcql'
+import nock from 'nock'
+import { getAgentOptions } from '../../../../tests'
+import { Agent } from '../../../agent/Agent'
+import { KnownJwaSignatureAlgorithms, PublicJwk } from '../../kms'
+import { TokenStatusListApi } from '../../token-status-list'
+import { ClaimFormat } from '../../vc'
+import { X509Certificate, X509Service } from '../../x509'
+import { Mdoc } from '../Mdoc'
+import { MdocDeviceResponse } from '../MdocDeviceResponse'
+
+// Regression tests for the mdoc *presentation* (device response) verification path. The standalone
+// `Mdoc.verify` path is covered in `mdocServer.test.ts`; these cases ensure `MdocDeviceResponse.verify`
+// applies the same `status ?? issuance` fallback and chain-equality safeguard. The leaf-under-root +
+// same-signer status list with `status: undefined` is the Paradym repro that previously failed.
+
+const docType = 'org.iso.18013.5.1.mDL'
+const namespace = 'org.iso.18013.5.1'
+
+const verifierGeneratedNonce = 'abcdefg'
+const mdocGeneratedNonce = '123456'
+const clientId = 'Cq1anPb8vZU5j5C0d7hcsbuJLBpIawUJIDQRi2Ebwb4'
+const responseUri = 'http://localhost:4000/api/presentation_request/dc8999df-d6ea-4c84-9985-37a8b81a82ec/callback'
+
+const dcqlQuery = {
+  credentials: [
+    {
+      id: 'mdl-status-test',
+      format: ClaimFormat.MsoMdoc,
+      multiple: false,
+      require_cryptographic_holder_binding: true,
+      meta: { doctype_value: docType },
+      claims: [{ path: [namespace, 'family_name'] }],
+    },
+  ],
+} satisfies DcqlQuery
+
+const sessionTranscriptOptions = {
+  type: 'openId4VpDraft18',
+  clientId,
+  responseUri,
+  verifierGeneratedNonce,
+  mdocGeneratedNonce,
+} as const
+
+describe('mdoc device-response status list verification', () => {
+  const agent = new Agent(getAgentOptions('mdoc-device-response-status', {}))
+
+  let currentDate: Date
+  let nextDay: Date
+
+  beforeAll(async () => {
+    await agent.initialize()
+
+    currentDate = new Date()
+    currentDate.setDate(currentDate.getDate() - 1)
+    nextDay = new Date(currentDate)
+    nextDay.setDate(currentDate.getDate() + 2)
+  })
+
+  afterAll(async () => {
+    nock.cleanAll()
+    await agent.shutdown()
+  })
+
+  const createRootAndLeaf = async (name: string) => {
+    const rootKey = await agent.kms.createKey({ type: { kty: 'EC', crv: 'P-256' } })
+    const leafKey = await agent.kms.createKey({ type: { kty: 'EC', crv: 'P-256' } })
+
+    const rootCertificate = await X509Service.createCertificate(agent.context, {
+      authorityKey: PublicJwk.fromPublicJwk(rootKey.publicJwk),
+      validity: { notBefore: currentDate, notAfter: nextDay },
+      issuer: `C=DE,CN=${name}Root`,
+      extensions: { basicConstraints: { ca: true } },
+    })
+    rootCertificate.keyId = rootKey.keyId
+
+    const leafCertificate = await X509Service.createCertificate(agent.context, {
+      authorityKey: PublicJwk.fromPublicJwk(rootKey.publicJwk),
+      subjectPublicKey: PublicJwk.fromPublicJwk(leafKey.publicJwk),
+      validity: { notBefore: currentDate, notAfter: nextDay },
+      issuer: `C=DE,CN=${name}Root`,
+      subject: `C=DE,CN=${name}Leaf`,
+    })
+    leafCertificate.keyId = leafKey.keyId
+
+    return { rootCertificate, leafCertificate }
+  }
+
+  const createStatusList = async (path: string, x5c: X509Certificate[]) => {
+    const tokenStatusList = agent.context.resolve(TokenStatusListApi)
+    const statusListUri = `https://example.org/token-status-list/${path}`
+    const { statusList } = await tokenStatusList.createTokenStatusList({
+      format: 'cwt',
+      signer: { method: 'x5c', x5c },
+      alg: KnownJwaSignatureAlgorithms.ES256,
+      statusList: { statusListLength: 10, bitsPerStatus: 1 },
+      statusListUri,
+    })
+
+    nock('https://example.org')
+      .persist()
+      .get(`/token-status-list/${path}`)
+      .reply(200, Buffer.from(statusList as Uint8Array), { 'Content-Type': MediaTypes.StatusListCwt })
+
+    return statusListUri
+  }
+
+  const createDeviceResponse = async (mdoc: Mdoc) => {
+    const { encoded } = await MdocDeviceResponse.createDeviceResponseWithDcqlQuery(agent.context, {
+      mdocs: [mdoc],
+      dcqlQuery,
+      sessionTranscriptOptions,
+    })
+
+    return MdocDeviceResponse.fromBase64Url(encoded)
+  }
+
+  const signMdoc = async (leafCertificate: X509Certificate, statusListUri: string) => {
+    const holderKey = await agent.kms.createKey({ type: { kty: 'EC', crv: 'P-256' } })
+    return Mdoc.sign(agent.context, {
+      docType,
+      holderKey: PublicJwk.fromPublicJwk(holderKey.publicJwk),
+      namespaces: { [namespace]: { family_name: 'Jones' } },
+      issuerCertificate: leafCertificate,
+      validityInfo: { validUntil: nextDay },
+      statusInfo: { index: 1, uri: statusListUri },
+    })
+  }
+
+  test('verify succeeds when status list shares the issuance leaf and only the root is trusted', async () => {
+    const { rootCertificate, leafCertificate } = await createRootAndLeaf('Shared')
+    const statusListUri = await createStatusList('device-shared', [leafCertificate])
+    const mdoc = await signMdoc(leafCertificate, statusListUri)
+    const deviceResponse = await createDeviceResponse(mdoc)
+
+    await expect(
+      deviceResponse.verify(agent.context, {
+        trustedCertificates: [{ issuance: [rootCertificate.toString('base64')] }],
+        sessionTranscriptOptions,
+      })
+    ).resolves.toBeUndefined()
+  })
+
+  test('verify fails when status list is anchored to a different root and no status certificates are configured', async () => {
+    const { rootCertificate, leafCertificate } = await createRootAndLeaf('Issuance')
+    const { leafCertificate: statusLeaf } = await createRootAndLeaf('Status')
+    const statusListUri = await createStatusList('device-different', [statusLeaf])
+    const mdoc = await signMdoc(leafCertificate, statusListUri)
+    const deviceResponse = await createDeviceResponse(mdoc)
+
+    await expect(
+      deviceResponse.verify(agent.context, {
+        trustedCertificates: [{ issuance: [rootCertificate.toString('base64')] }],
+        sessionTranscriptOptions,
+      })
+    ).rejects.toThrow(`Mdoc with doctype ${docType} is not valid`)
+  })
+
+  test('verify fails when status list is signed by a different leaf under the same trusted root', async () => {
+    const rootKey = await agent.kms.createKey({ type: { kty: 'EC', crv: 'P-256' } })
+    const issuanceLeafKey = await agent.kms.createKey({ type: { kty: 'EC', crv: 'P-256' } })
+    const statusLeafKey = await agent.kms.createKey({ type: { kty: 'EC', crv: 'P-256' } })
+
+    const rootCertificate = await X509Service.createCertificate(agent.context, {
+      authorityKey: PublicJwk.fromPublicJwk(rootKey.publicJwk),
+      validity: { notBefore: currentDate, notAfter: nextDay },
+      issuer: 'C=DE,CN=SiblingRoot',
+      extensions: { basicConstraints: { ca: true } },
+    })
+    rootCertificate.keyId = rootKey.keyId
+
+    const createLeaf = async (leafKey: typeof issuanceLeafKey, commonName: string) => {
+      const leaf = await X509Service.createCertificate(agent.context, {
+        authorityKey: PublicJwk.fromPublicJwk(rootKey.publicJwk),
+        subjectPublicKey: PublicJwk.fromPublicJwk(leafKey.publicJwk),
+        validity: { notBefore: currentDate, notAfter: nextDay },
+        issuer: 'C=DE,CN=SiblingRoot',
+        subject: `C=DE,CN=${commonName}`,
+      })
+      leaf.keyId = leafKey.keyId
+      return leaf
+    }
+
+    const issuanceLeaf = await createLeaf(issuanceLeafKey, 'IssuanceLeaf')
+    const statusLeaf = await createLeaf(statusLeafKey, 'StatusLeaf')
+
+    const statusListUri = await createStatusList('device-sibling', [statusLeaf])
+    const mdoc = await signMdoc(issuanceLeaf, statusListUri)
+    const deviceResponse = await createDeviceResponse(mdoc)
+
+    await expect(
+      deviceResponse.verify(agent.context, {
+        trustedCertificates: [{ issuance: [rootCertificate.toString('base64')] }],
+        sessionTranscriptOptions,
+      })
+    ).rejects.toThrow('Trusted status list chain does not match the trusted issuance chain')
+  })
+
+  test('verify succeeds when dedicated status certificates are configured for a different-root status list', async () => {
+    const { rootCertificate, leafCertificate } = await createRootAndLeaf('DedicatedIssuance')
+    const { rootCertificate: statusRoot, leafCertificate: statusLeaf } = await createRootAndLeaf('DedicatedStatus')
+    const statusListUri = await createStatusList('device-dedicated', [statusLeaf])
+    const mdoc = await signMdoc(leafCertificate, statusListUri)
+    const deviceResponse = await createDeviceResponse(mdoc)
+
+    await expect(
+      deviceResponse.verify(agent.context, {
+        trustedCertificates: [
+          {
+            issuance: [rootCertificate.toString('base64')],
+            status: [statusRoot.toString('base64')],
+          },
+        ],
+        sessionTranscriptOptions,
+      })
+    ).resolves.toBeUndefined()
+  })
+})

--- a/packages/core/src/modules/mdoc/mdocUtil.ts
+++ b/packages/core/src/modules/mdoc/mdocUtil.ts
@@ -1,3 +1,81 @@
+import { convertLegacyTrustedCertificates } from '../x509/utils/convertLegacyTrustedCertificates'
+import { X509Certificate } from '../x509/X509Certificate'
+import type { X509VerificationTrustedCertificates } from '../x509/X509ModuleConfig'
+import { MdocError } from './MdocError'
+
+export interface MdocTrustedCertificate {
+  issuance: string[]
+  status: string[]
+  hasDedicatedStatusCertificates: boolean
+}
+
+/**
+ * Falls back to the `issuance` certs when no `status` certs are configured (`status: undefined`); an
+ * explicit `status: []` is passed through. {@link assertMdocStatusListChainsMatchIssuanceChain} then
+ * keeps the fallback from widening the trust set.
+ */
+export function convertMdocTrustedCertificates(
+  trustedCertificates: string[] | X509VerificationTrustedCertificates[]
+): MdocTrustedCertificate[] {
+  return convertLegacyTrustedCertificates(trustedCertificates).map(({ issuance, status }) => ({
+    issuance,
+    status: status ?? issuance,
+    hasDedicatedStatusCertificates: status !== undefined,
+  }))
+}
+
+/**
+ * Maps the converted trusted certificates to the raw representation the `@owf/mdoc` library expects.
+ */
+export function mdocTrustedCertificatesToRaw(trustedCertificates: MdocTrustedCertificate[]) {
+  return trustedCertificates.map(({ issuance, status }) => ({
+    issuance: issuance.map((cert) => X509Certificate.fromEncodedCertificate(cert).rawCertificate),
+    status: status.map((cert) => X509Certificate.fromEncodedCertificate(cert).rawCertificate),
+  }))
+}
+
+/**
+ * Without dedicated status certs, requires the status/identifier list chains to equal the issuance
+ * chain, so the fallback can't accept a list signed by a different chain under the same trust anchor.
+ */
+export function assertMdocStatusListChainsMatchIssuanceChain(
+  trustedCertificates: MdocTrustedCertificate[],
+  chains: {
+    trustedIssuanceChain: Uint8Array[]
+    trustedStatusListChain?: Uint8Array[]
+    trustedIdentifierListChain?: Uint8Array[]
+  }
+) {
+  const issuanceChain = chains.trustedIssuanceChain.map((cert) => X509Certificate.fromRawCertificate(cert))
+  const issuanceTrustAnchor = issuanceChain[issuanceChain.length - 1]
+
+  const matchedTrustedCertificate = trustedCertificates.find(({ issuance }) =>
+    issuance.some((cert) => X509Certificate.fromEncodedCertificate(cert).equal(issuanceTrustAnchor))
+  )
+
+  // With dedicated status certs the library already validated the lists against them.
+  if (matchedTrustedCertificate?.hasDedicatedStatusCertificates) return
+
+  const chainMatchesIssuanceChain = (chain: Uint8Array[]) => {
+    const resolvedChain = chain.map((cert) => X509Certificate.fromRawCertificate(cert))
+    return (
+      resolvedChain.length === issuanceChain.length && resolvedChain.every((cert, i) => cert.equal(issuanceChain[i]))
+    )
+  }
+
+  if (chains.trustedIdentifierListChain && !chainMatchesIssuanceChain(chains.trustedIdentifierListChain)) {
+    throw new MdocError(
+      'Trusted identifier list chain does not match the trusted issuance chain, and no trusted status certificates were provided for the trusted issuance certificate'
+    )
+  }
+
+  if (chains.trustedStatusListChain && !chainMatchesIssuanceChain(chains.trustedStatusListChain)) {
+    throw new MdocError(
+      'Trusted status list chain does not match the trusted issuance chain, and no trusted status certificates were provided for the trusted issuance certificate'
+    )
+  }
+}
+
 export function nameSpacesRecordToMap<
   NamespaceValue,
   NameSpaces extends Record<string, Record<string, NamespaceValue>>,

--- a/packages/core/src/modules/sd-jwt-vc/__tests__/SdJwtVcService.test.ts
+++ b/packages/core/src/modules/sd-jwt-vc/__tests__/SdJwtVcService.test.ts
@@ -1668,6 +1668,43 @@ describe('SdJwtVcService', () => {
       expect(verificationResult.isValid).toBe(true)
     })
 
+    test('x509: falls back to issuance certs for a leaf-under-root chain when no status certs are configured', async () => {
+      const rootKey = PublicJwk.fromPublicJwk(
+        (await agent.kms.createKey({ type: { kty: 'EC', crv: 'P-256' } })).publicJwk
+      )
+      const leafKey = PublicJwk.fromPublicJwk(
+        (await agent.kms.createKey({ type: { kty: 'EC', crv: 'P-256' } })).publicJwk
+      )
+
+      const rootCertificate = await X509Service.createCertificate(agent.context, {
+        authorityKey: rootKey,
+        issuer: { commonName: 'Root' },
+        validity: { notBefore: new Date('2020-01-01'), notAfter: new Date('2035-01-01') },
+        extensions: { basicConstraints: { ca: true } },
+      })
+      rootCertificate.keyId = rootKey.keyId
+
+      const leafCertificate = await X509Service.createCertificate(agent.context, {
+        authorityKey: rootKey,
+        subjectPublicKey: leafKey,
+        issuer: { commonName: 'Root' },
+        subject: { commonName: 'Leaf' },
+        validity: { notBefore: new Date('2020-01-01'), notAfter: new Date('2035-01-01') },
+      })
+      leafCertificate.keyId = leafKey.keyId
+
+      const presentation = await signX509CredentialWithStatus(leafCertificate)
+      // Status list is signed by the same leaf as the credential.
+      mockStatusList(await generateX509StatusList(agent.context, leafKey, leafCertificate, 24, []))
+
+      const verificationResult = await sdJwtVcService.verify(agent.context, {
+        compactSdJwtVc: presentation,
+        trustedIssuers: [{ method: 'x509', issuance: [rootCertificate.toString('base64')] }],
+      })
+
+      expect(verificationResult.isValid).toBe(true)
+    })
+
     test('x509: an empty status certificates array rejects any status list', async () => {
       const issuance = await createSigningCertificate('Issuance')
 


### PR DESCRIPTION
This fixes the different behavior between verifying a Mdoc on itself and verifying a presentation.