### PR TITLE
fix(openid4vc): resolve JWS signer method 'did' verification failure

### DIFF
--- a/packages/openid4vc/src/shared/callbacks.ts
+++ b/packages/openid4vc/src/shared/callbacks.ts
@@ -192,25 +192,27 @@ export function getOid4vcJwtVerifyCallback(
       throw new CredoError(`Unsupported jwa signatre algorithm '${alg}'`)
     }
 
-    const jwsSigner: JwsSignerWithJwk | undefined =
-      signer.method === 'did'
-        ? {
-            method: 'did',
-            didUrl: signer.didUrl,
-            jwk: await getPublicJwkFromDid(agentContext, signer.didUrl),
-          }
-        : signer.method === 'jwk'
-          ? {
-              method: 'jwk',
-              jwk: Kms.PublicJwk.fromUnknown(signer.publicJwk),
-            }
-          : signer.method === 'x5c'
-            ? {
-                method: 'x5c',
-                x5c: signer.x5c,
-                jwk: X509Certificate.fromEncodedCertificate(signer.x5c[0]).publicJwk,
-              }
-            : undefined
+    let jwsSigner: JwsSignerWithJwk | undefined
+
+    if (signer.method === 'did') {
+      const didPublicJwk = await getPublicJwkFromDid(agentContext, signer.didUrl)
+      jwsSigner = {
+        method: 'did',
+        didUrl: signer.didUrl,
+        jwk: didPublicJwk,
+      }
+    } else if (signer.method === 'jwk') {
+      jwsSigner = {
+        method: 'jwk',
+        jwk: Kms.PublicJwk.fromUnknown(signer.publicJwk),
+      }
+    } else if (signer.method === 'x5c') {
+      jwsSigner = {
+        method: 'x5c',
+        x5c: signer.x5c,
+        jwk: X509Certificate.fromEncodedCertificate(signer.x5c[0]).publicJwk,
+      }
+    }
 
     if (!jwsSigner) {
       throw new CredoError(`Unable to verify jws with unsupported jws signer method '${signer.method}'`)


### PR DESCRIPTION
This PR fixes a bug encountered when verifying `did:webvh` presentations where the wallet would incorrectly throw the following error:

> `Unable to verify jws with unsupported jws signer method 'did'`

### What changed?

In `@credo-ts/openid4vc`, the logic to extract the `jwsSigner` inside `getOid4vcJwtVerifyCallback` was using a nested ternary operator containing an `await` statement. This structure appeared to cause unexpected transpilation/runtime issues (potentially a quirk with Hermes in React Native), leading to the `did` method being skipped or mishandled.

I've refactored the ternary assignment into a standard `if/else` block. The behavior remains identical, but this avoids the nested `await` issue and successfully resolves the verification failure for `did:webvh` presentations.