### PR TITLE
feat(openid4vc): improved key attestation level hierarchy

### DIFF
--- a/.changeset/key-attestation-level-hierarchy.md
+++ b/.changeset/key-attestation-level-hierarchy.md
@@ -1,0 +1,5 @@
+---
+"@credo-ts/openid4vc": patch
+---
+
+feat: interpret key attestation ISO 18045 levels hierarchically on the issuer, so a stronger attested level (e.g. `iso_18045_high`) satisfies a weaker required level (e.g. `iso_18045_moderate`). Also adds the `OpenId4VciKeyAttestationLevel` enum and `keyAttestationLevelSatisfies` helper.

--- a/packages/openid4vc/src/openid4vc-holder/OpenId4VciHolderServiceOptions.ts
+++ b/packages/openid4vc/src/openid4vc-holder/OpenId4VciHolderServiceOptions.ts
@@ -13,6 +13,7 @@ import type {
   OpenId4VciAccessTokenResponse,
   OpenId4VciCredentialConfigurationSupportedWithFormats,
   OpenId4VciCredentialConfigurationsSupportedWithFormats,
+  OpenId4VciKeyAttestationLevel,
   OpenId4VciMetadata,
 } from '../shared'
 import { OpenId4VciCredentialFormatProfile } from '../shared/models/OpenId4VciCredentialFormatProfile'
@@ -118,7 +119,7 @@ export type OpenId4VciResolvedAuthorizationRequest =
       codeVerifier?: string
 
       /**
-       * DPoP request options if DPoP was used for the pushed authorization reuqest
+       * DPoP request options if DPoP was used for the pushed authorization request
        */
       dpop?: OpenId4VciDpopRequestOptions
     }
@@ -349,7 +350,7 @@ export interface OpenId4VciAuthCodeFlowOptions {
    * The wallet attestation to send to the issuer. This will only be used
    * if client attestations and PAR are supported by the issuer.
    *
-   * A Proof of Possesion will be created based on the wallet attestation,
+   * A Proof of Possession will be created based on the wallet attestation,
    * so the key bound to the wallet attestation must be in the wallet.
    */
   walletAttestationJwt?: string
@@ -363,7 +364,7 @@ export interface OpenId4VciCredentialBindingOptions {
 
   /**
    * The OpenID4VCI metadata, consisting of the draft version used,
-   * the issuer metadatan and the authorization server metadata
+   * the issuer metadata and the authorization server metadata
    */
   metadata: OpenId4VciMetadata
 
@@ -384,9 +385,9 @@ export interface OpenId4VciCredentialBindingOptions {
    * by credo. Currently `jwt` and `attestation` are supported.
    *
    * Each proof type will list the supported algorithms, key types
-   * and whether key attesations are required
+   * and whether key attestations are required
    */
-  proofTypes: OpenId4VciProofOfPressionProofTypes
+  proofTypes: OpenId4VciProofOfPossessionProofTypes
 
   /**
    * The id of the credential configuration that will be requested from the issuer.
@@ -457,7 +458,12 @@ export type OpenId4VciCredentialBindingResolver = (
   options: OpenId4VciCredentialBindingOptions
 ) => Promise<OpenId4VcCredentialHolderBinding> | OpenId4VcCredentialHolderBinding
 
-export type OpenId4VciProofOfPressionProofTypes = Record<
+/**
+ * @deprecated use {@link OpenId4VciProofOfPossessionProofTypes} instead.
+ */
+export type OpenId4VciProofOfPressionProofTypes = OpenId4VciProofOfPossessionProofTypes
+
+export type OpenId4VciProofOfPossessionProofTypes = Record<
   'jwt' | 'attestation',
   | {
       /**
@@ -483,8 +489,8 @@ export type OpenId4VciProofOfPressionProofTypes = Record<
        *  by the `keyStorage` and `userAuthentication` values.
        */
       keyAttestationsRequired?: {
-        keyStorage?: string[]
-        userAuthentication?: string[]
+        keyStorage?: (OpenId4VciKeyAttestationLevel | string)[]
+        userAuthentication?: (OpenId4VciKeyAttestationLevel | string)[]
       }
     }
   | undefined
@@ -494,7 +500,7 @@ export type OpenId4VciProofOfPressionProofTypes = Record<
  * @internal
  */
 export interface OpenId4VciProofOfPossessionRequirements {
-  proofTypes: OpenId4VciProofOfPressionProofTypes
+  proofTypes: OpenId4VciProofOfPossessionProofTypes
   supportedDidMethods?: string[]
   supportsAllDidMethods: boolean
   supportsJwk: boolean

--- a/packages/openid4vc/src/openid4vc-holder/OpenId4VciHolderServiceOptions.ts
+++ b/packages/openid4vc/src/openid4vc-holder/OpenId4VciHolderServiceOptions.ts
@@ -489,8 +489,8 @@ export type OpenId4VciProofOfPossessionProofTypes = Record<
        *  by the `keyStorage` and `userAuthentication` values.
        */
       keyAttestationsRequired?: {
-        keyStorage?: (OpenId4VciKeyAttestationLevel | string)[]
-        userAuthentication?: (OpenId4VciKeyAttestationLevel | string)[]
+        keyStorage?: (OpenId4VciKeyAttestationLevel | (string & {}))[]
+        userAuthentication?: (OpenId4VciKeyAttestationLevel | (string & {}))[]
       }
     }
   | undefined

--- a/packages/openid4vc/src/openid4vc-issuer/OpenId4VcIssuerService.ts
+++ b/packages/openid4vc/src/openid4vc-issuer/OpenId4VcIssuerService.ts
@@ -60,7 +60,7 @@ import type {
   OpenId4VcJwtIssuer,
   VerifiedOpenId4VcCredentialHolderBinding,
 } from '../shared'
-import { OpenId4VciCredentialFormatProfile } from '../shared'
+import { keyAttestationLevelSatisfies, OpenId4VciCredentialFormatProfile } from '../shared'
 import { dynamicOid4vciClientAuthentication, getOid4vcCallbacks } from '../shared/callbacks'
 import { getCredentialConfigurationsSupportedForScopes, getOfferedCredentials } from '../shared/issuerMetadataUtils'
 import { storeActorIdForContextCorrelationId } from '../shared/router'
@@ -967,7 +967,7 @@ export class OpenId4VcIssuerService {
 
         if (
           expectedKeyStorage &&
-          !expectedKeyStorage.some((keyStorage) => keyAttestation.payload.key_storage?.includes(keyStorage))
+          !keyAttestationLevelSatisfies(expectedKeyStorage, keyAttestation.payload.key_storage)
         ) {
           throw new Oauth2ServerErrorResponseError({
             error: Oauth2ErrorCodes.InvalidProof,
@@ -977,9 +977,7 @@ export class OpenId4VcIssuerService {
 
         if (
           expectedUserAuthentication &&
-          !expectedUserAuthentication.some((userAuthentication) =>
-            keyAttestation.payload.user_authentication?.includes(userAuthentication)
-          )
+          !keyAttestationLevelSatisfies(expectedUserAuthentication, keyAttestation.payload.user_authentication)
         ) {
           throw new Oauth2ServerErrorResponseError({
             error: Oauth2ErrorCodes.InvalidProof,
@@ -1082,7 +1080,7 @@ export class OpenId4VcIssuerService {
 
           if (
             expectedKeyStorage &&
-            !expectedKeyStorage.some((keyStorage) => keyAttestation.payload.key_storage?.includes(keyStorage))
+            !keyAttestationLevelSatisfies(expectedKeyStorage, keyAttestation.payload.key_storage)
           ) {
             throw new Oauth2ServerErrorResponseError({
               error: Oauth2ErrorCodes.InvalidProof,
@@ -1092,9 +1090,7 @@ export class OpenId4VcIssuerService {
 
           if (
             expectedUserAuthentication &&
-            !expectedUserAuthentication.some((userAuthentication) =>
-              keyAttestation.payload.user_authentication?.includes(userAuthentication)
-            )
+            !keyAttestationLevelSatisfies(expectedUserAuthentication, keyAttestation.payload.user_authentication)
           ) {
             throw new Oauth2ServerErrorResponseError({
               error: Oauth2ErrorCodes.InvalidProof,

--- a/packages/openid4vc/src/shared/models/OpenId4VciKeyAttestationLevel.ts
+++ b/packages/openid4vc/src/shared/models/OpenId4VciKeyAttestationLevel.ts
@@ -1,0 +1,54 @@
+/**
+ * Key attestation levels for the `key_storage` and `user_authentication` values.
+ *
+ * Currently only the ISO 18045 attack potential resistance levels defined by OpenID4VCI are
+ * included.
+ *
+ * @see https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#appendix-D.2
+ */
+export enum OpenId4VciKeyAttestationLevel {
+  Basic = 'iso_18045_basic',
+  EnhancedBasic = 'iso_18045_enhanced-basic',
+  Moderate = 'iso_18045_moderate',
+  High = 'iso_18045_high',
+}
+
+/**
+ * The ISO 18045 levels ordered from weakest to strongest. The array index represents the
+ * level rank and is used to compare levels hierarchically.
+ */
+const orderedIso18045Levels = [
+  OpenId4VciKeyAttestationLevel.Basic,
+  OpenId4VciKeyAttestationLevel.EnhancedBasic,
+  OpenId4VciKeyAttestationLevel.Moderate,
+  OpenId4VciKeyAttestationLevel.High,
+]
+
+/**
+ * Whether an attested set of key attestation levels (`key_storage` or `user_authentication`)
+ * satisfies a required set of levels.
+ *
+ * Both `required` and `attested` are treated with OR semantics: the requirement is satisfied
+ * if any attested value meets-or-exceeds any required value.
+ *
+ * Known ISO 18045 values are compared by rank, so a stronger attested level (e.g.
+ * `iso_18045_high`) satisfies a weaker required level (e.g. `iso_18045_moderate`). Any custom
+ * (non-ISO) string is only matched exactly, so we never loosen a requirement we don't understand.
+ */
+export function keyAttestationLevelSatisfies(required: string[], attested: string[] | undefined): boolean {
+  if (!attested) return false
+
+  return required.some((requiredLevel) =>
+    attested.some((attestedLevel) => {
+      if (attestedLevel === requiredLevel) return true
+
+      const requiredRank = orderedIso18045Levels.indexOf(requiredLevel as OpenId4VciKeyAttestationLevel)
+      const attestedRank = orderedIso18045Levels.indexOf(attestedLevel as OpenId4VciKeyAttestationLevel)
+
+      // Only compare by rank when both values are known ISO 18045 levels
+      if (requiredRank === -1 || attestedRank === -1) return false
+
+      return attestedRank >= requiredRank
+    })
+  )
+}

--- a/packages/openid4vc/src/shared/models/__tests__/OpenId4VciKeyAttestationLevel.test.ts
+++ b/packages/openid4vc/src/shared/models/__tests__/OpenId4VciKeyAttestationLevel.test.ts
@@ -1,0 +1,34 @@
+import { keyAttestationLevelSatisfies } from '../OpenId4VciKeyAttestationLevel'
+
+describe('keyAttestationLevelSatisfies', () => {
+  test('a stronger attested level satisfies a weaker required level', () => {
+    expect(keyAttestationLevelSatisfies(['iso_18045_moderate'], ['iso_18045_high'])).toBe(true)
+    expect(keyAttestationLevelSatisfies(['iso_18045_basic'], ['iso_18045_enhanced-basic'])).toBe(true)
+  })
+
+  test('an equal attested level satisfies the required level', () => {
+    expect(keyAttestationLevelSatisfies(['iso_18045_high'], ['iso_18045_high'])).toBe(true)
+  })
+
+  test('a weaker attested level does not satisfy a stronger required level', () => {
+    expect(keyAttestationLevelSatisfies(['iso_18045_high'], ['iso_18045_moderate'])).toBe(false)
+  })
+
+  test('is satisfied if any attested value meets or exceeds any required value', () => {
+    // required includes `basic`, attested `moderate` exceeds it
+    expect(keyAttestationLevelSatisfies(['iso_18045_high', 'iso_18045_basic'], ['iso_18045_moderate'])).toBe(true)
+    // attested includes `high` which satisfies the required `moderate`
+    expect(keyAttestationLevelSatisfies(['iso_18045_moderate'], ['iso_18045_basic', 'iso_18045_high'])).toBe(true)
+  })
+
+  test('returns false when no attested levels are provided', () => {
+    expect(keyAttestationLevelSatisfies(['iso_18045_basic'], undefined)).toBe(false)
+    expect(keyAttestationLevelSatisfies(['iso_18045_basic'], [])).toBe(false)
+  })
+
+  test('custom (non-ISO) values are only matched exactly', () => {
+    expect(keyAttestationLevelSatisfies(['custom_level'], ['custom_level'])).toBe(true)
+    expect(keyAttestationLevelSatisfies(['custom_level'], ['iso_18045_high'])).toBe(false)
+    expect(keyAttestationLevelSatisfies(['iso_18045_basic'], ['custom_level'])).toBe(false)
+  })
+})

--- a/packages/openid4vc/src/shared/models/index.ts
+++ b/packages/openid4vc/src/shared/models/index.ts
@@ -57,4 +57,5 @@ export type OpenId4VpAuthorizationResponsePayload = Openid4vpAuthorizationRespon
 export * from './CredentialHolderBinding'
 export * from './OpenId4VciAuthorizationServerConfig'
 export * from './OpenId4VciCredentialFormatProfile'
+export * from './OpenId4VciKeyAttestationLevel'
 export * from './OpenId4VcJwtIssuer'

--- a/packages/openid4vc/tests/openid4vc-wallet-key-attestation.e2e.test.ts
+++ b/packages/openid4vc/tests/openid4vc-wallet-key-attestation.e2e.test.ts
@@ -11,12 +11,16 @@ import {
   OpenId4VcIssuerService,
   type OpenId4VciCredentialConfigurationSupportedWithFormats,
   OpenId4VciCredentialFormatProfile,
+  OpenId4VciKeyAttestationLevel,
   OpenId4VcModule,
   type OpenId4VcVerifierModuleConfigOptions,
 } from '../src'
 import { getOid4vcCallbacks } from '../src/shared/callbacks'
 import type { AgentType } from './utils'
 import { createAgentFromModules, waitForCredentialIssuanceSessionRecordSubject } from './utils'
+
+const highLevels = [OpenId4VciKeyAttestationLevel.High]
+const moderateLevels = [OpenId4VciKeyAttestationLevel.Moderate]
 
 const universityDegreeCredentialConfigurationSupportedMdoc = {
   format: OpenId4VciCredentialFormatProfile.MsoMdoc,
@@ -26,17 +30,40 @@ const universityDegreeCredentialConfigurationSupportedMdoc = {
     jwt: {
       proof_signing_alg_values_supported: ['ES256', 'EdDSA'],
       key_attestations_required: {
-        // TODO: enum for iso enum values
-        key_storage: ['iso_18045_high'],
-        user_authentication: ['iso_18045_high'],
+        key_storage: highLevels,
+        user_authentication: highLevels,
       },
     },
     attestation: {
       proof_signing_alg_values_supported: ['ES256', 'EdDSA'],
       key_attestations_required: {
-        // TODO: enum for iso enum values
-        key_storage: ['iso_18045_high'],
-        user_authentication: ['iso_18045_high'],
+        key_storage: highLevels,
+        user_authentication: highLevels,
+      },
+    },
+  },
+  cryptographic_binding_methods_supported: ['jwk'],
+} satisfies OpenId4VciCredentialConfigurationSupportedWithFormats
+
+// Only requires the `moderate` level, used to verify that a stronger attested level (`high`)
+// satisfies a weaker required level.
+const universityDegreeModerateCredentialConfigurationSupportedMdoc = {
+  format: OpenId4VciCredentialFormatProfile.MsoMdoc,
+  scope: 'UniversityDegreeCredentialModerate',
+  doctype: 'UniversityDegreeCredential',
+  proof_types_supported: {
+    jwt: {
+      proof_signing_alg_values_supported: ['ES256', 'EdDSA'],
+      key_attestations_required: {
+        key_storage: moderateLevels,
+        user_authentication: moderateLevels,
+      },
+    },
+    attestation: {
+      proof_signing_alg_values_supported: ['ES256', 'EdDSA'],
+      key_attestations_required: {
+        key_storage: moderateLevels,
+        user_authentication: moderateLevels,
       },
     },
   },
@@ -46,7 +73,13 @@ const universityDegreeCredentialConfigurationSupportedMdoc = {
 const baseUrl = 'http://localhost:3991'
 const issuerBaseUrl = `${baseUrl}/oid4vci`
 const verifierBaseUrl = `${baseUrl}/oid4vp`
-let generateKeyAttestation: (nonce?: string) => Promise<string>
+let generateKeyAttestation: (
+  nonce?: string,
+  levels?: {
+    keyStorage: OpenId4VciKeyAttestationLevel[]
+    userAuthentication: OpenId4VciKeyAttestationLevel[]
+  }
+) => Promise<string>
 
 describe('OpenId4Vc Wallet and Key Attestations', () => {
   let expressApp: Express
@@ -227,7 +260,7 @@ describe('OpenId4Vc Wallet and Key Attestations', () => {
         )
     )
 
-    generateKeyAttestation = (nonce?: string) =>
+    generateKeyAttestation = (nonce?: string, levels = { keyStorage: highLevels, userAuthentication: highLevels }) =>
       walletProvider.createKeyAttestationJwt({
         attestedKeys: attestedKeys.map((key) => key.toJson() as Jwk),
         signer: {
@@ -237,8 +270,8 @@ describe('OpenId4Vc Wallet and Key Attestations', () => {
           kid: walletProviderCertificate.publicJwk.keyId,
         },
         use: 'proof_type.jwt',
-        keyStorage: ['iso_18045_high'],
-        userAuthentication: ['iso_18045_high'],
+        keyStorage: levels.keyStorage,
+        userAuthentication: levels.userAuthentication,
         // 5 minutes
         expiresAt: utils.addSecondsToDate(new Date(), 300),
         nonce,
@@ -304,6 +337,7 @@ describe('OpenId4Vc Wallet and Key Attestations', () => {
       },
       credentialConfigurationsSupported: {
         universityDegree: universityDegreeCredentialConfigurationSupportedMdoc,
+        universityDegreeModerate: universityDegreeModerateCredentialConfigurationSupportedMdoc,
       },
     })
 
@@ -373,6 +407,82 @@ describe('OpenId4Vc Wallet and Key Attestations', () => {
         attestedKeys[credentialIndex].fingerprint
       )
     })
+  })
+
+  it('issues when the attested level is stronger than the required level (high satisfies moderate)', async () => {
+    // Offer only requires the `moderate` level
+    const { issuanceSession, credentialOffer } = await issuer.agent.openid4vc.issuer.createCredentialOffer({
+      issuerId: issuerRecord.issuerId,
+      credentialConfigurationIds: ['universityDegreeModerate'],
+      preAuthorizedCodeFlowConfig: {},
+      authorization: {
+        requireDpop: true,
+        requireWalletAttestation: true,
+      },
+    })
+
+    const resolvedCredentialOffer = await holder.agent.openid4vc.holder.resolveCredentialOffer(credentialOffer)
+    const tokenResponse = await holder.agent.openid4vc.holder.requestToken({
+      resolvedCredentialOffer,
+      walletAttestationJwt,
+      clientId: 'wallet',
+    })
+
+    // Wallet attests the stronger `high` level, which should satisfy the required `moderate` level
+    const credentialResponse = await holder.agent.openid4vc.holder.requestCredentials({
+      resolvedCredentialOffer,
+      ...tokenResponse,
+      credentialBindingResolver: async () => ({
+        method: 'attestation',
+        keyAttestationJwt: await generateKeyAttestation(undefined, {
+          keyStorage: highLevels,
+          userAuthentication: highLevels,
+        }),
+      }),
+    })
+
+    await waitForCredentialIssuanceSessionRecordSubject(issuer.replaySubject, {
+      state: OpenId4VcIssuanceSessionState.Completed,
+      issuanceSessionId: issuanceSession.id,
+    })
+
+    expect(credentialResponse.credentials).toHaveLength(1)
+    expect(credentialResponse.credentials[0].record.credentialInstances).toHaveLength(10)
+  })
+
+  it('throws error when the attested level is weaker than the required level (moderate does not satisfy high)', async () => {
+    // Offer requires the `high` level
+    const { credentialOffer } = await issuer.agent.openid4vc.issuer.createCredentialOffer({
+      issuerId: issuerRecord.issuerId,
+      credentialConfigurationIds: ['universityDegree'],
+      preAuthorizedCodeFlowConfig: {},
+      authorization: {
+        requireDpop: true,
+        requireWalletAttestation: true,
+      },
+    })
+
+    const resolvedCredentialOffer = await holder.agent.openid4vc.holder.resolveCredentialOffer(credentialOffer)
+    const tokenResponse = await holder.agent.openid4vc.holder.requestToken({
+      resolvedCredentialOffer,
+      walletAttestationJwt,
+      clientId: 'wallet',
+    })
+
+    // Wallet only attests the weaker `moderate` level, which does not satisfy the required `high` level
+    await expect(
+      holder.agent.openid4vc.holder.requestCredentials({
+        resolvedCredentialOffer,
+        ...tokenResponse,
+        credentialBindingResolver: async () => ({
+          method: 'attestation',
+          keyAttestationJwt: await generateKeyAttestation(undefined, {
+            keyStorage: moderateLevels,
+            userAuthentication: moderateLevels,
+          }),
+        }),
+      })
+    ).rejects.toThrow('Insufficient key_storage for key attestation')
   })
 
   it('e2e flow issuing a batch of mdoc based on wallet and nonce-bound key attestation', async () => {


### PR DESCRIPTION
Interpret key attestation ISO 18045 levels hierarchically on the issuer, so a stronger attested level (e.g. `iso_18045_high`) satisfies a weaker required level (e.g. `iso_18045_moderate`). Also adds the `OpenId4VciKeyAttestationLevel` enum and `keyAttestationLevelSatisfies` helper.