### PR TITLE
feat(openid4vc): add delete APIs for issuance and verification sessions

### DIFF
--- a/.changeset/openid4vc-delete-session-apis.md
+++ b/.changeset/openid4vc-delete-session-apis.md
@@ -1,0 +1,5 @@
+---
+"@credo-ts/openid4vc": patch
+---
+
+feat: add `deleteIssuanceSessionById` and `deleteVerificationSessionById` public APIs to allow cleanup of stored OpenID4VC session records.

--- a/packages/openid4vc/src/openid4vc-issuer/OpenId4VcIssuerApi.ts
+++ b/packages/openid4vc/src/openid4vc-issuer/OpenId4VcIssuerApi.ts
@@ -137,4 +137,11 @@ export class OpenId4VcIssuerApi {
   public async getIssuanceSessionById(issuanceSessionId: string) {
     return this.openId4VcIssuerService.getIssuanceSessionById(this.agentContext, issuanceSessionId)
   }
+
+  /**
+   * Delete an issuance session record by id.
+   */
+  public async deleteIssuanceSessionById(issuanceSessionId: string) {
+    return this.openId4VcIssuerService.deleteIssuanceSessionById(this.agentContext, issuanceSessionId)
+  }
 }

--- a/packages/openid4vc/src/openid4vc-issuer/OpenId4VcIssuerService.ts
+++ b/packages/openid4vc/src/openid4vc-issuer/OpenId4VcIssuerService.ts
@@ -1222,6 +1222,10 @@ export class OpenId4VcIssuerService {
     return this.openId4VcIssuanceSessionRepository.getById(agentContext, issuanceSessionId)
   }
 
+  public async deleteIssuanceSessionById(agentContext: AgentContext, issuanceSessionId: string) {
+    await this.openId4VcIssuanceSessionRepository.deleteById(agentContext, issuanceSessionId)
+  }
+
   public async getAllIssuers(agentContext: AgentContext) {
     return this.openId4VcIssuerRepository.getAll(agentContext)
   }

--- a/packages/openid4vc/src/openid4vc-issuer/__tests__/openid4vc-issuer.test.ts
+++ b/packages/openid4vc/src/openid4vc-issuer/__tests__/openid4vc-issuer.test.ts
@@ -16,6 +16,7 @@ import {
   JsonTransformer,
   JwsService,
   JwtPayload,
+  RecordNotFoundError,
   SdJwtVcApi,
   TypedArrayEncoder,
   utils,
@@ -1107,5 +1108,27 @@ describe('OpenId4VcIssuer', () => {
     })
 
     expect(issuanceSession.expiresAt).toEqual(utils.addSecondsToDate(issuanceSession.createdAt, 60 * 60))
+  })
+
+  it('deletes an issuance session by id', async () => {
+    const { issuanceSession } = await issuer.openid4vc.issuer.createCredentialOffer({
+      credentialConfigurationIds: [openBadgeCredential.id],
+      issuerId: openId4VcIssuer.issuerId,
+      preAuthorizedCodeFlowConfig: {
+        preAuthorizedCode: '1234567890',
+      },
+    })
+
+    await issuer.openid4vc.issuer.deleteIssuanceSessionById(issuanceSession.id)
+
+    await expect(issuer.openid4vc.issuer.getIssuanceSessionById(issuanceSession.id)).rejects.toThrow(
+      RecordNotFoundError
+    )
+  })
+
+  it('throws an error when deleting a non-existent issuance session', async () => {
+    await expect(issuer.openid4vc.issuer.deleteIssuanceSessionById('non-existent-id')).rejects.toThrow(
+      RecordNotFoundError
+    )
   })
 })

--- a/packages/openid4vc/src/openid4vc-verifier/OpenId4VcVerifierApi.ts
+++ b/packages/openid4vc/src/openid4vc-verifier/OpenId4VcVerifierApi.ts
@@ -65,6 +65,13 @@ export class OpenId4VcVerifierApi {
   }
 
   /**
+   * Delete a verification session record by id.
+   */
+  public async deleteVerificationSessionById(verificationSessionId: string) {
+    return this.openId4VpVerifierService.deleteVerificationSessionById(this.agentContext, verificationSessionId)
+  }
+
+  /**
    * Create an OpenID4VP authorization request, acting as a Relying Party (RP).
    *
    * See {@link OpenId4VpCreateAuthorizationRequestOptions} for detailed documentation on the options.

--- a/packages/openid4vc/src/openid4vc-verifier/OpenId4VpVerifierService.ts
+++ b/packages/openid4vc/src/openid4vc-verifier/OpenId4VpVerifierService.ts
@@ -937,6 +937,10 @@ export class OpenId4VpVerifierService {
     return this.openId4VcVerificationSessionRepository.getById(agentContext, verificationSessionId)
   }
 
+  public async deleteVerificationSessionById(agentContext: AgentContext, verificationSessionId: string) {
+    await this.openId4VcVerificationSessionRepository.deleteById(agentContext, verificationSessionId)
+  }
+
   private async getClientMetadata(
     agentContext: AgentContext,
     options: {

--- a/packages/openid4vc/src/openid4vc-verifier/__tests__/openid4vc-verifier.test.ts
+++ b/packages/openid4vc/src/openid4vc-verifier/__tests__/openid4vc-verifier.test.ts
@@ -1,4 +1,4 @@
-import { Jwt, utils } from '@credo-ts/core'
+import { Jwt, RecordNotFoundError, utils } from '@credo-ts/core'
 import { InMemoryWalletModule } from '../../../../../tests/InMemoryWalletModule'
 import { type AgentType, createAgentFromModules } from '../../../tests/utils'
 import { openBadgeDcqlQuery, universityDegreePresentationDefinition } from '../../../tests/utilsVp'
@@ -81,6 +81,32 @@ describe('OpenId4VcVerifier', () => {
       })
 
       expect(verificationSession.expiresAt).toEqual(utils.addSecondsToDate(verificationSession.createdAt, 60 * 60))
+    })
+
+    it('deletes a verification session by id', async () => {
+      const openIdVerifier = await verifier.agent.openid4vc.verifier.createVerifier()
+      const { verificationSession } = await verifier.agent.openid4vc.verifier.createAuthorizationRequest({
+        requestSigner: {
+          method: 'did',
+          didUrl: verifier.kid,
+        },
+        verifierId: openIdVerifier.verifierId,
+        dcql: {
+          query: openBadgeDcqlQuery,
+        },
+      })
+
+      await verifier.agent.openid4vc.verifier.deleteVerificationSessionById(verificationSession.id)
+
+      await expect(
+        verifier.agent.openid4vc.verifier.getVerificationSessionById(verificationSession.id)
+      ).rejects.toThrow(RecordNotFoundError)
+    })
+
+    it('throws an error when deleting a non-existent verification session', async () => {
+      await expect(verifier.agent.openid4vc.verifier.deleteVerificationSessionById('non-existent-id')).rejects.toThrow(
+        RecordNotFoundError
+      )
     })
   })
 })


### PR DESCRIPTION
Expose _deleteIssuanceSessionById_ on the openid4vc issuer API and _deleteVerificationSessionById_ on the openid4vc verifier API to allow cleanup of stored OpenID4VC session records.