### PR TITLE
feat(core): improved x509 crl caching mechanism

### DIFF
--- a/packages/core/src/modules/x509/X509CertificateRevocationList.ts
+++ b/packages/core/src/modules/x509/X509CertificateRevocationList.ts
@@ -17,6 +17,7 @@ import {
   X509CrlExtensionIdentifier,
   x509SignatureAlgorithmToJwa,
 } from './utils'
+import { normalizeSerialNumber } from './utils/serialNumber'
 import { X509Certificate, X509KeyUsage } from './X509Certificate'
 import type { X509RevocationReason } from './X509CrlDistributionPoint'
 import { X509Error } from './X509Error'
@@ -61,14 +62,6 @@ export interface X509IssuingDistributionPoint {
   indirectCRL: boolean
   /** Whether the CRL only covers attribute certificates. */
   onlyContainsAttributeCerts: boolean
-}
-
-/**
- * Normalize a hexadecimal serial number for comparison by lowercasing and stripping leading
- * zeros, so that e.g. `0A1B2C` and `0a1b2c` are treated as equal.
- */
-function normalizeSerialNumber(serialNumber: string): string {
-  return serialNumber.toLowerCase().replace(/^0+/, '') || '0'
 }
 
 /**
@@ -309,6 +302,13 @@ export class X509CertificateRevocationList {
   }
 
   /**
+   * The object identifiers of all critical extensions on this CRL.
+   */
+  public get criticalExtensionIds(): string[] {
+    return this.crl.extensions.filter((extension) => extension.critical).map((extension) => extension.type)
+  }
+
+  /**
    * Whether the extension with the given id is marked critical. Throws if the extension is absent.
    */
   public isExtensionCritical(id: X509CrlExtensionIdentifier | string): boolean {
@@ -322,6 +322,10 @@ export class X509CertificateRevocationList {
 
   /**
    * Verify this CRL with the issuer's certificate.
+   *
+   * NOTE: the CRL summary cache fast path in `X509RevocationService` reproduces the
+   * issuer-certificate-dependent checks below (public key, subject name, cRLSign key usage). If a
+   * new check depending on the issuer certificate is added here, update that gate in tandem.
    */
   public async verify(
     {

--- a/packages/core/src/modules/x509/X509RevocationService.ts
+++ b/packages/core/src/modules/x509/X509RevocationService.ts
@@ -1,10 +1,16 @@
-import * as x509 from '@peculiar/x509'
 import type { AgentContext } from '../../agent'
 import { CredoWebCrypto } from '../../crypto/webcrypto'
 import { injectable } from '../../plugins'
-import { validateCriticalCrlExtensions } from './utils/criticalExtensions'
-import { fetchCrl, getCachedCrl, setCachedCrl } from './utils/crlFetcher'
-import { X509Certificate } from './X509Certificate'
+import { validateCriticalCrlExtensionIds } from './utils/criticalExtensions'
+import { fetchCrl, getCachedCrlSummary, setCachedCrlSummary } from './utils/crlFetcher'
+import {
+  buildCrlSummary,
+  CrlSummaryVerifiedCrl,
+  computeIssuerNameSha256,
+  computeIssuerPublicJwkThumbprint,
+  type VerifiedCrl,
+} from './utils/crlSummary'
+import { X509Certificate, X509KeyUsage } from './X509Certificate'
 import { X509CertificateRevocationList, type X509CertificateRevocationListEntry } from './X509CertificateRevocationList'
 import { ALL_REVOCATION_REASONS_MASK, X509RevocationReason } from './X509CrlDistributionPoint'
 import { X509CrlUnavailableError, X509Error } from './X509Error'
@@ -177,7 +183,7 @@ export class X509RevocationService {
       : X509RevocationService.calculateAllReasonsInDPs(distributionPoints)
 
     let coveredReasons = 0 // Bitmask of covered reason codes
-    const coveredCrls: X509CertificateRevocationList[] = []
+    const coveredCrls: VerifiedCrl[] = []
     const fetchedDPs: string[] = []
     const fetchErrors: string[] = [] // Track errors for DPs we couldn't fetch
     const unsupportedDPs: Array<{ reasons: number; feature: string }> = [] // Track DPs we can't process
@@ -436,12 +442,12 @@ export class X509RevocationService {
    * CRL covering this certificate. Returns a human-readable reason when the CRL must be rejected.
    */
   private static checkCrlApplicability(
-    crl: X509CertificateRevocationList,
+    crl: VerifiedCrl,
     certificate: X509Certificate
   ): { usable: true } | { usable: false; reason: string } {
     // RFC 5280 §6.3.3: a CRL bearing a critical extension we do not recognize MUST NOT be used, as
     // that extension may change the CRL's meaning (e.g. its scope) in ways we cannot account for.
-    const criticalExtensions = validateCriticalCrlExtensions(new x509.X509Crl(crl.rawCertificateRevocationList))
+    const criticalExtensions = validateCriticalCrlExtensionIds(crl.criticalExtensionIds)
     if (!criticalExtensions.isValid) {
       return {
         usable: false,
@@ -502,8 +508,7 @@ export class X509RevocationService {
     verificationDate: Date,
     options: X509RevocationCheckOptions
   ): Promise<
-    | { success: true; crl: X509CertificateRevocationList; usedUrl: string }
-    | { success: false; error: string; reachable: boolean }
+    { success: true; crl: VerifiedCrl; usedUrl: string } | { success: false; error: string; reachable: boolean }
   > {
     let lastError: string | undefined
 
@@ -548,9 +553,61 @@ export class X509RevocationService {
   }
 
   /**
-   * Download a single CRL (optionally from the cache), parse it, and verify it against the issuer.
+   * Obtain a verified CRL for a URL, preferring the cached verified summary.
+   *
+   * A summary is only used when the provided issuer certificate carries the same subject name and
+   * public key the summary was verified against, its key usage (when present) permits cRLSign, and
+   * the summary's validity window covers `verificationDate` — together these reproduce exactly the
+   * issuer-dependent checks of {@link X509CertificateRevocationList.verify}, so a renewed or
+   * cross-certified issuer certificate (same name and key) reuses the summary directly. The summary
+   * is then trusted from the (application-controlled) cache without re-parsing or re-verifying the
+   * CRL bytes.
+   *
+   * Anything else — a different key or subject name, a key usage without cRLSign, an out-of-window,
+   * missing or malformed summary — falls through to the full fetch-parse-verify path, which
+   * produces all failure results (an unreachable host is then an availability failure like any
+   * other fetch). On success the full path overwrites the summary with the new issuer binding.
    */
   private static async fetchVerifyAndCacheCrl(
+    agentContext: AgentContext,
+    fetchOptions: {
+      url: string
+      issuerCertificate: X509Certificate
+      verificationDate: Date
+      options: { timeoutMs?: number; maxCrlSizeBytes?: number; crlCacheExpirySeconds?: number }
+      useCache: boolean
+    },
+    webCrypto: CredoWebCrypto
+  ): Promise<{ success: true; crl: VerifiedCrl } | { success: false; error: string; reachable: boolean }> {
+    const { url, issuerCertificate, verificationDate, useCache } = fetchOptions
+
+    if (useCache) {
+      const summary = await getCachedCrlSummary(agentContext, url)
+      const verificationTime = verificationDate.getTime()
+      const issuerKeyUsage = issuerCertificate.keyUsage
+      if (
+        summary &&
+        summary.issuerNameSha256 === computeIssuerNameSha256(issuerCertificate) &&
+        summary.issuerPublicJwkThumbprint === computeIssuerPublicJwkThumbprint(issuerCertificate) &&
+        // Mirror verify()'s cRLSign check: key usage, when present and non-empty, must include cRLSign
+        !(issuerKeyUsage && issuerKeyUsage.length > 0 && !issuerKeyUsage.includes(X509KeyUsage.CrlSign)) &&
+        // Mirror verify()'s validity window checks (isNotYetValid/isExpired use strict comparisons)
+        verificationTime >= summary.thisUpdate &&
+        (summary.nextUpdate === undefined || verificationTime <= summary.nextUpdate)
+      ) {
+        return { success: true, crl: new CrlSummaryVerifiedCrl(summary) }
+      }
+    }
+
+    return X509RevocationService.fetchParseVerifyAndCacheCrl(agentContext, fetchOptions, webCrypto)
+  }
+
+  /**
+   * Download a single CRL, parse it, and verify it against the issuer. When `useCache` is enabled,
+   * a successful verification also caches a derived summary so subsequent checks can skip the
+   * download and the (potentially very expensive) parse via {@link fetchVerifyAndCacheCrl}.
+   */
+  private static async fetchParseVerifyAndCacheCrl(
     agentContext: AgentContext,
     {
       url,
@@ -569,15 +626,16 @@ export class X509RevocationService {
   ): Promise<
     { success: true; crl: X509CertificateRevocationList } | { success: false; error: string; reachable: boolean }
   > {
-    // Whether we obtained the CRL bytes (from cache or a successful download).
+    // Whether the CRL bytes were downloaded successfully.
     let reachable = false
 
     try {
-      // Use a cached (previously verified) CRL if available, otherwise fetch it.
-      const cachedData = useCache ? await getCachedCrl(agentContext, url) : null
-      const crlData =
-        cachedData ??
-        (await fetchCrl({ url, timeoutMs: options.timeoutMs, maxSizeBytes: options.maxCrlSizeBytes, agentContext }))
+      const crlData = await fetchCrl({
+        url,
+        timeoutMs: options.timeoutMs,
+        maxSizeBytes: options.maxCrlSizeBytes,
+        agentContext,
+      })
 
       reachable = true
 
@@ -589,15 +647,26 @@ export class X509RevocationService {
         return { success: false, error: verifyResult.error?.message ?? 'CRL verification failed', reachable }
       }
 
-      // Cache only freshly-fetched, fully-verified CRLs, with a TTL bounded by nextUpdate so an
-      // expired CRL is never served from the cache.
-      if (useCache && !cachedData) {
+      if (useCache) {
+        // TTL bounded by nextUpdate so an expired CRL is never served from the cache. The globally
+        // configured expiry applies even when per-call revocation options omit it; the hardcoded
+        // default only kicks in when neither is set.
         const ttlSeconds = X509RevocationService.computeCacheTtlSeconds(
           crl,
           verificationDate,
-          options.crlCacheExpirySeconds
+          options.crlCacheExpirySeconds ??
+            agentContext.dependencyManager.resolve(X509ModuleConfig).revocationCheck?.crlCacheExpirySeconds
         )
-        await setCachedCrl(agentContext, url, crlData, ttlSeconds)
+
+        // Cache the derived summary of every successfully verified CRL (fresh fetch or
+        // re-verification against a different issuer certificate). Best-effort: a malformed CRL
+        // (e.g. duplicate extensions) throws while deriving the summary; skip caching it so such
+        // CRLs keep surfacing that error at applicability time.
+        try {
+          await setCachedCrlSummary(agentContext, url, buildCrlSummary(crl, issuerCertificate), ttlSeconds)
+        } catch {
+          // the summary cache is an optimization only
+        }
       }
 
       return { success: true, crl }
@@ -684,7 +753,7 @@ export class X509RevocationService {
         ? issuerCertificate
         : X509Certificate.fromEncodedCertificate(issuerCertificate)
 
-    const result = await X509RevocationService.fetchVerifyAndCacheCrl(
+    const result = await X509RevocationService.fetchParseVerifyAndCacheCrl(
       agentContext,
       {
         url,

--- a/packages/core/src/modules/x509/X509ValidationOptions.ts
+++ b/packages/core/src/modules/x509/X509ValidationOptions.ts
@@ -57,7 +57,11 @@ export interface X509RevocationCheckOptions {
   maxCrlSizeBytes?: number
 
   /**
-   * Cache expiry time in seconds for CRL data
+   * How long (in seconds) a verified CRL may be served from the cache before it is fetched and
+   * verified again. The effective TTL is additionally bounded by the CRL's own `nextUpdate`, so an
+   * expired CRL is never served from the cache. When unset in per-call revocation options, the
+   * value configured on the X509 module's `revocationCheck` applies.
+   *
    * @default 3600 (1 hour)
    */
   crlCacheExpirySeconds?: number

--- a/packages/core/src/modules/x509/__tests__/X509CertificateRevocationList.test.ts
+++ b/packages/core/src/modules/x509/__tests__/X509CertificateRevocationList.test.ts
@@ -261,5 +261,23 @@ describe('X509CertificateRevocationList', () => {
       const crl = X509CertificateRevocationList.fromRaw(crlBytes)
       expect(() => crl.isExtensionCritical(X509CrlExtensionIdentifier.CrlNumber)).toThrow(X509Error)
     })
+
+    it('exposes the ids of critical extensions only', async () => {
+      const criticalCrl = await X509Service.createCertificateRevocationList(agentContext, {
+        authorityKey: issuerKey,
+        issuer: issuerCertificate.subject,
+        validity: { thisUpdate: lastMonth, nextUpdate: nextMonth },
+        extensions: { crlNumber: { value: 1, markAsCritical: true } },
+      })
+      expect(criticalCrl.criticalExtensionIds).toContain(X509CrlExtensionIdentifier.CrlNumber)
+
+      const nonCriticalCrl = await X509Service.createCertificateRevocationList(agentContext, {
+        authorityKey: issuerKey,
+        issuer: issuerCertificate.subject,
+        validity: { thisUpdate: lastMonth, nextUpdate: nextMonth },
+        extensions: { crlNumber: { value: 1 } },
+      })
+      expect(nonCriticalCrl.criticalExtensionIds).not.toContain(X509CrlExtensionIdentifier.CrlNumber)
+    })
   })
 })

--- a/packages/core/src/modules/x509/__tests__/X509RevocationService.test.ts
+++ b/packages/core/src/modules/x509/__tests__/X509RevocationService.test.ts
@@ -1,13 +1,18 @@
 import nock from 'nock'
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest'
 
 import type { Agent } from '../../../agent/Agent'
 import type { AgentContext } from '../../../agent/context'
 import type { InMemoryLruCache } from '../../cache'
 import type { KeyManagementApi, PublicJwk } from '../../kms'
+import { getCachedCrlSummary } from '../utils/crlFetcher'
 import { X509Certificate, X509KeyUsage } from '../X509Certificate'
-import { X509CertificateRevocationListEntryReason } from '../X509CertificateRevocationList'
+import {
+  X509CertificateRevocationList,
+  X509CertificateRevocationListEntryReason,
+} from '../X509CertificateRevocationList'
 import { X509RevocationReason } from '../X509CrlDistributionPoint'
+import { X509ModuleConfig } from '../X509ModuleConfig'
 import { X509RevocationService } from '../X509RevocationService'
 import { X509Service } from '../X509Service'
 import type { X509CreateCertificateRevocationListOptions } from '../X509ServiceOptions'
@@ -162,7 +167,7 @@ describe('X509RevocationService', () => {
 
   it('detects a revoked certificate and fails in both SoftFail and Require modes', async () => {
     const leaf = await createLeaf({ serialNumber: '1004', crlDistributionPoints: { urls: [FULL_URL] } })
-    // The CRL bytes are cached after the first fetch, so a single interceptor covers both checks.
+    // A verified summary is cached after the first check, so a single interceptor covers both checks.
     mockCrl(
       FULL_URL,
       await crlBytes({
@@ -590,14 +595,8 @@ describe('X509RevocationService', () => {
       const leaf = await createLeaf({ serialNumber: '4008', crlDistributionPoints: { urls: [FULL_URL] } })
       // A CRL Number marked critical violates RFC 5280 §5.2.3 (it MUST be non-critical) and is a
       // critical extension the engine must treat as unrecognized-for-criticality, so the CRL is
-      // unusable. A failed-to-verify CRL is not cached, so both checks fetch.
-      mockCrl(
-        FULL_URL,
-        await crlBytes({ entries: [], extensions: { crlNumber: { value: 1, markAsCritical: true } } }),
-        {
-          times: 2,
-        }
-      )
+      // unusable. The CRL itself verifies, so it is cached and the second check reuses it.
+      mockCrl(FULL_URL, await crlBytes({ entries: [], extensions: { crlNumber: { value: 1, markAsCritical: true } } }))
 
       const required = await checkRevocation(leaf, issuerCertificate, { mode: X509RevocationCheckMode.Require })
       expect(required.isValid).toBe(false)
@@ -648,6 +647,285 @@ describe('X509RevocationService', () => {
       const result = await checkRevocation(leaf, issuerWithCrlSign, { mode: X509RevocationCheckMode.Require })
       expect(result.isValid).toBe(true)
       expect(result.isRevoked).toBe(false)
+    })
+  })
+
+  describe('verified CRL summary cache', () => {
+    let fromRawSpy: MockInstance
+
+    beforeEach(() => {
+      fromRawSpy = vi.spyOn(X509CertificateRevocationList, 'fromRaw')
+    })
+
+    afterEach(() => {
+      fromRawSpy.mockRestore()
+    })
+
+    it('reuses the cached summary without fetching or parsing', async () => {
+      const leaf = await createLeaf({ serialNumber: '5001', crlDistributionPoints: { urls: [FULL_URL] } })
+      // A single interceptor: the second check must not fetch.
+      mockCrl(FULL_URL, await crlBytes({ entries: [{ serialNumber: 'dead' }] }))
+
+      const first = await checkRevocation(leaf, issuerCertificate, { mode: X509RevocationCheckMode.Require })
+      expect(first.isValid).toBe(true)
+      expect(fromRawSpy).toHaveBeenCalledTimes(1)
+
+      const second = await checkRevocation(leaf, issuerCertificate, { mode: X509RevocationCheckMode.Require })
+      expect(second).toEqual(first)
+      // No additional parse: the check ran entirely from the cached summary.
+      expect(fromRawSpy).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not reuse a summary for an issuer certificate lacking cRLSign', async () => {
+      // Same subject and key as the issuer that produced the summary, but a key usage without
+      // cRLSign: the fast-path gate re-evaluates the cRLSign check on the provided certificate, so
+      // the check falls back to a fresh fetch and full verification, failing on the missing cRLSign
+      // key usage.
+      const issuerWithCrlSign = await X509Service.createCertificate(agentContext, {
+        serialNumber: '0d',
+        issuer: { commonName: 'Issuer CA' },
+        authorityKey: issuerKey,
+        validity: { notBefore: lastMonth, notAfter: nextMonth },
+        extensions: {
+          basicConstraints: { ca: true },
+          keyUsage: { usages: [X509KeyUsage.KeyCertSign, X509KeyUsage.CrlSign] },
+        },
+      })
+      const issuerWithoutCrlSign = await X509Service.createCertificate(agentContext, {
+        serialNumber: '0e',
+        issuer: { commonName: 'Issuer CA' },
+        authorityKey: issuerKey,
+        validity: { notBefore: lastMonth, notAfter: nextMonth },
+        extensions: { basicConstraints: { ca: true }, keyUsage: { usages: [X509KeyUsage.KeyCertSign] } },
+      })
+      const leaf = await createLeaf({ serialNumber: '5003', crlDistributionPoints: { urls: [FULL_URL] } })
+      // The gate miss refetches, so both checks fetch.
+      mockCrl(FULL_URL, await crlBytes({ entries: [] }), { times: 2 })
+
+      const first = await checkRevocation(leaf, issuerWithCrlSign, { mode: X509RevocationCheckMode.Require })
+      expect(first.isValid).toBe(true)
+
+      const second = await checkRevocation(leaf, issuerWithoutCrlSign, { mode: X509RevocationCheckMode.SoftFail })
+      expect(second.isValid).toBe(false)
+      expect(second.error?.message).toContain('cRLSign')
+    })
+
+    it('reuses the summary for a rotated issuer certificate with the same subject and key', async () => {
+      // The summary binds the issuer's subject name and public key — the inputs CRL verification
+      // actually depends on — so a renewed CA certificate (same name and key, new serial/validity)
+      // hits the summary directly without re-parsing.
+      const rotatedIssuer = await X509Service.createCertificate(agentContext, {
+        serialNumber: '0f',
+        issuer: { commonName: 'Issuer CA' },
+        authorityKey: issuerKey,
+        validity: { notBefore: twoMonthsAgo, notAfter: nextMonth },
+        extensions: { basicConstraints: { ca: true } },
+      })
+      const leaf = await createLeaf({ serialNumber: '5004', crlDistributionPoints: { urls: [FULL_URL] } })
+      mockCrl(FULL_URL, await crlBytes({ entries: [] }))
+
+      const first = await checkRevocation(leaf, issuerCertificate, { mode: X509RevocationCheckMode.Require })
+      expect(first.isValid).toBe(true)
+      expect(fromRawSpy).toHaveBeenCalledTimes(1)
+
+      const second = await checkRevocation(leaf, rotatedIssuer, { mode: X509RevocationCheckMode.Require })
+      expect(second.isValid).toBe(true)
+      expect(fromRawSpy).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not reuse a summary for an issuer certificate with the same name but a different key', async () => {
+      const sameNameDifferentKeyIssuer = await X509Service.createCertificate(agentContext, {
+        serialNumber: '10',
+        issuer: { commonName: 'Issuer CA' },
+        authorityKey: otherIssuerKey,
+        validity: { notBefore: lastMonth, notAfter: nextMonth },
+        extensions: { basicConstraints: { ca: true } },
+      })
+      const leaf = await createLeaf({ serialNumber: '500c', crlDistributionPoints: { urls: [FULL_URL] } })
+      // The gate miss refetches, so both checks fetch.
+      mockCrl(FULL_URL, await crlBytes({ entries: [] }), { times: 2 })
+
+      const first = await checkRevocation(leaf, issuerCertificate, { mode: X509RevocationCheckMode.Require })
+      expect(first.isValid).toBe(true)
+
+      // Key thumbprint mismatch: the full re-verification fails on the signature.
+      const second = await checkRevocation(leaf, sameNameDifferentKeyIssuer, {
+        mode: X509RevocationCheckMode.SoftFail,
+      })
+      expect(second.isValid).toBe(false)
+      expect(second.error?.message).toContain('signature')
+    })
+
+    it('falls back to full verification when the summary window does not cover the verification date', async () => {
+      const leaf = await createLeaf({ serialNumber: '5005', crlDistributionPoints: { urls: [FULL_URL] } })
+      const inWindow = new Date(twoMonthsAgo.getTime() + 24 * 60 * 60 * 1000)
+      // Valid at `inWindow` but expired now. Each gate miss refetches, so all three checks fetch.
+      mockCrl(FULL_URL, await crlBytes({ entries: [], thisUpdate: twoMonthsAgo, nextUpdate: lastMonth }), { times: 3 })
+
+      const first = await checkRevocation(leaf, issuerCertificate, {
+        mode: X509RevocationCheckMode.Require,
+        verificationDate: inWindow,
+      })
+      expect(first.isValid).toBe(true)
+
+      // The summary window check rejects the hit; the full path refetches and reproduces the expiry
+      // failure, in both Require and SoftFail (integrity, not availability).
+      const required = await checkRevocation(leaf, issuerCertificate, { mode: X509RevocationCheckMode.Require })
+      expect(required.isValid).toBe(false)
+      expect(required.error?.message).toContain('expired')
+
+      const soft = await checkRevocation(leaf, issuerCertificate, { mode: X509RevocationCheckMode.SoftFail })
+      expect(soft.isValid).toBe(false)
+    })
+
+    it('falls back to full verification for a verification date before thisUpdate', async () => {
+      const leaf = await createLeaf({ serialNumber: '5006', crlDistributionPoints: { urls: [FULL_URL] } })
+      // The gate miss refetches, so both checks fetch.
+      mockCrl(FULL_URL, await crlBytes({ entries: [] }), { times: 2 })
+
+      const first = await checkRevocation(leaf, issuerCertificate, { mode: X509RevocationCheckMode.Require })
+      expect(first.isValid).toBe(true)
+
+      const result = await checkRevocation(leaf, issuerCertificate, {
+        mode: X509RevocationCheckMode.Require,
+        verificationDate: twoMonthsAgo,
+      })
+      expect(result.isValid).toBe(false)
+      expect(result.error?.message).toContain('not yet valid')
+    })
+
+    it('reports a revoked certificate identically from the summary, including serial normalization', async () => {
+      const leaf = await createLeaf({ serialNumber: '00bd', crlDistributionPoints: { urls: [FULL_URL] } })
+      // CRL entry 'bd' matches certificate serial '00bd' via normalization.
+      mockCrl(
+        FULL_URL,
+        await crlBytes({
+          entries: [{ serialNumber: 'bd', reason: X509CertificateRevocationListEntryReason.KeyCompromise }],
+        })
+      )
+
+      const first = await checkRevocation(leaf, issuerCertificate, { mode: X509RevocationCheckMode.Require })
+      expect(first.isValid).toBe(false)
+      expect(first.isRevoked).toBe(true)
+
+      const second = await checkRevocation(leaf, issuerCertificate, { mode: X509RevocationCheckMode.Require })
+      expect(fromRawSpy).toHaveBeenCalledTimes(1)
+      expect(second.isRevoked).toBe(true)
+      expect(second.error?.message).toEqual(first.error?.message)
+      expect(second.details).toEqual(first.details)
+    })
+
+    it('rejects an unusable CRL identically from the summary', async () => {
+      const cases = [
+        { serial: '5007', extensions: { deltaCrlIndicator: { value: 1 } }, message: 'delta CRL' },
+        {
+          serial: '5008',
+          extensions: { crlNumber: { value: 1, markAsCritical: true } },
+          message: 'unrecognized critical extension',
+        },
+        {
+          serial: '5009',
+          extensions: { issuingDistributionPoint: { onlyContainsUserCerts: true } },
+          message: 'end-entity certificates',
+          ca: true,
+        },
+      ] as const
+
+      for (const { serial, extensions, message, ...rest } of cases) {
+        const url = `https://crl.example/${serial}.crl`
+        const leaf = await createLeaf({
+          serialNumber: serial,
+          crlDistributionPoints: { urls: [url] },
+          ca: 'ca' in rest ? rest.ca : undefined,
+        })
+        mockCrl(url, await crlBytes({ entries: [], extensions }))
+
+        const first = await checkRevocation(leaf, issuerCertificate, { mode: X509RevocationCheckMode.SoftFail })
+        expect(first.isValid).toBe(false)
+        expect(first.error?.message).toContain(message)
+
+        const parseCount = fromRawSpy.mock.calls.length
+        const second = await checkRevocation(leaf, issuerCertificate, { mode: X509RevocationCheckMode.SoftFail })
+        expect(second.isValid).toBe(false)
+        expect(second.error?.message).toEqual(first.error?.message)
+        expect(fromRawSpy.mock.calls.length).toBe(parseCount)
+      }
+    })
+
+    it('treats a malformed cached summary as a miss', async () => {
+      const leaf = await createLeaf({ serialNumber: '500a', crlDistributionPoints: { urls: [FULL_URL] } })
+      await cache.set(agentContext, `x509:crl-summary:v1:${FULL_URL}`, { some: 'garbage' }, 3600)
+      // Single interceptor: the malformed summary causes one fetch, then the rewritten summary is used.
+      mockCrl(FULL_URL, await crlBytes({ entries: [] }))
+
+      const first = await checkRevocation(leaf, issuerCertificate, { mode: X509RevocationCheckMode.Require })
+      expect(first.isValid).toBe(true)
+      expect(fromRawSpy).toHaveBeenCalledTimes(1)
+      // The malformed summary was overwritten with a valid one.
+      expect(await getCachedCrlSummary(agentContext, FULL_URL)).not.toBeNull()
+
+      const second = await checkRevocation(leaf, issuerCertificate, { mode: X509RevocationCheckMode.Require })
+      expect(second.isValid).toBe(true)
+      expect(fromRawSpy).toHaveBeenCalledTimes(1)
+    })
+
+    it('lets a second agent sharing the cache verify without fetching or parsing', async () => {
+      const { agent: agentB, agentContext: agentContextB } = await setupCrlAgent({ cache })
+      try {
+        const leaf = await createLeaf({ serialNumber: '500b', crlDistributionPoints: { urls: [FULL_URL] } })
+        const scope = mockCrl(FULL_URL, await crlBytes({ entries: [] }))
+
+        const first = await checkRevocation(leaf, issuerCertificate, { mode: X509RevocationCheckMode.Require })
+        expect(first.isValid).toBe(true)
+        expect(scope.isDone()).toBe(true)
+
+        const parseCount = fromRawSpy.mock.calls.length
+        const second = await X509RevocationService.checkCertificateRevocation(agentContextB, {
+          certificate: leaf,
+          issuerCertificate,
+          revocationCheckOptions: { mode: X509RevocationCheckMode.Require },
+        })
+        expect(second.isValid).toBe(true)
+        expect(fromRawSpy.mock.calls.length).toBe(parseCount)
+      } finally {
+        await agentB.shutdown()
+      }
+    })
+
+    it('caches the summary with the configured crlCacheExpirySeconds', async () => {
+      const leaf = await createLeaf({ serialNumber: '500d', crlDistributionPoints: { urls: [FULL_URL] } })
+      mockCrl(FULL_URL, await crlBytes({ entries: [] }))
+      const setSpy = vi.spyOn(cache, 'set')
+
+      try {
+        // The CRL's nextUpdate is ~a month away, so the configured expiry is the effective TTL.
+        const result = await checkRevocation(leaf, issuerCertificate, {
+          mode: X509RevocationCheckMode.Require,
+          crlCacheExpirySeconds: 123,
+        })
+        expect(result.isValid).toBe(true)
+        expect(setSpy).toHaveBeenCalledWith(agentContext, `x509:crl-summary:v1:${FULL_URL}`, expect.anything(), 123)
+      } finally {
+        setSpy.mockRestore()
+      }
+    })
+
+    it('falls back to the module-config crlCacheExpirySeconds when per-call options omit it', async () => {
+      const config = agentContext.dependencyManager.resolve(X509ModuleConfig)
+      const leaf = await createLeaf({ serialNumber: '500e', crlDistributionPoints: { urls: [FULL_URL] } })
+      mockCrl(FULL_URL, await crlBytes({ entries: [] }))
+      const setSpy = vi.spyOn(cache, 'set')
+
+      try {
+        config.setRevocationCheck({ mode: X509RevocationCheckMode.Require, crlCacheExpirySeconds: 77 })
+
+        const result = await checkRevocation(leaf, issuerCertificate, { mode: X509RevocationCheckMode.Require })
+        expect(result.isValid).toBe(true)
+        expect(setSpy).toHaveBeenCalledWith(agentContext, `x509:crl-summary:v1:${FULL_URL}`, expect.anything(), 77)
+      } finally {
+        config.setRevocationCheck(undefined)
+        setSpy.mockRestore()
+      }
     })
   })
 })

--- a/packages/core/src/modules/x509/__tests__/crlFetcher.test.ts
+++ b/packages/core/src/modules/x509/__tests__/crlFetcher.test.ts
@@ -3,14 +3,24 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } 
 
 import type { Agent } from '../../../agent/Agent'
 import type { AgentContext } from '../../../agent/context'
-import { TypedArrayEncoder } from '../../../utils'
 import type { InMemoryLruCache } from '../../cache'
-import { fetchCrl, getCachedCrl, setCachedCrl } from '../utils/crlFetcher'
+import { fetchCrl, getCachedCrlSummary, setCachedCrlSummary } from '../utils/crlFetcher'
+import type { X509CrlSummary } from '../utils/crlSummary'
 import { X509Error } from '../X509Error'
 import { mockCrl, mockCrlHttpError, mockCrlNetworkError, setupCrlAgent } from './x509CrlTestUtils'
 
 const URL_A = 'https://crl.example/a.crl'
-const crlData = new Uint8Array([0x30, 0x01, 0x02, 0x03, 0x04, 0x05])
+
+const crlSummary: X509CrlSummary = {
+  issuerNameSha256: 'ab'.repeat(32),
+  issuerPublicJwkThumbprint: 'cd'.repeat(32),
+  thisUpdate: 1700000000000,
+  nextUpdate: 1700003600000,
+  criticalExtensionIds: [],
+  serialNumbers: ['0a'],
+  revocationDates: [1700000000000],
+  reasons: [null],
+}
 
 describe('fetchCrl', () => {
   let agent: Agent
@@ -52,7 +62,7 @@ describe('fetchCrl', () => {
   })
 })
 
-describe('CRL cache helpers', () => {
+describe('CRL summary cache helpers', () => {
   let agent: Agent
   let agentContext: AgentContext
   let cache: InMemoryLruCache
@@ -69,32 +79,45 @@ describe('CRL cache helpers', () => {
     cache.clear()
   })
 
-  it('round-trips cached bytes and returns null on a miss', async () => {
-    expect(await getCachedCrl(agentContext, URL_A)).toBeNull()
+  it('round-trips a cached summary and returns null on a miss', async () => {
+    expect(await getCachedCrlSummary(agentContext, URL_A)).toBeNull()
 
-    await setCachedCrl(agentContext, URL_A, crlData, 3600)
+    await setCachedCrlSummary(agentContext, URL_A, crlSummary, 3600)
 
-    const cached = await getCachedCrl(agentContext, URL_A)
-    expect(cached).not.toBeNull()
-    expect(Array.from(cached as Uint8Array)).toEqual(Array.from(crlData))
+    expect(await getCachedCrlSummary(agentContext, URL_A)).toEqual(crlSummary)
   })
 
-  it('stores the cache entry with the provided expiry', async () => {
+  it('stores the summary under a versioned key with the provided expiry', async () => {
     const setSpy = vi.spyOn(cache, 'set')
 
-    await setCachedCrl(agentContext, URL_A, crlData, 1234)
+    await setCachedCrlSummary(agentContext, URL_A, crlSummary, 1234)
 
-    expect(setSpy).toHaveBeenCalledWith(agentContext, `x509:crl:${URL_A}`, TypedArrayEncoder.toBase64(crlData), 1234)
+    expect(setSpy).toHaveBeenCalledWith(agentContext, `x509:crl-summary:v1:${URL_A}`, crlSummary, 1234)
     setSpy.mockRestore()
   })
 
-  it('does not cache when the TTL is zero or negative', async () => {
+  it('does not cache a summary when the TTL is zero or negative', async () => {
     const setSpy = vi.spyOn(cache, 'set')
 
-    await setCachedCrl(agentContext, URL_A, crlData, 0)
+    await setCachedCrlSummary(agentContext, URL_A, crlSummary, 0)
 
     expect(setSpy).not.toHaveBeenCalled()
-    expect(await getCachedCrl(agentContext, URL_A)).toBeNull()
+    expect(await getCachedCrlSummary(agentContext, URL_A)).toBeNull()
     setSpy.mockRestore()
+  })
+
+  it('treats a cached value that is not a valid summary as a miss', async () => {
+    await cache.set(agentContext, `x509:crl-summary:v1:${URL_A}`, 'not a summary', 3600)
+    expect(await getCachedCrlSummary(agentContext, URL_A)).toBeNull()
+
+    await cache.set(agentContext, `x509:crl-summary:v1:${URL_A}`, { ...crlSummary, serialNumbers: ['0a', '0b'] }, 3600)
+    expect(await getCachedCrlSummary(agentContext, URL_A)).toBeNull()
+  })
+
+  it('treats a throwing cache as a miss', async () => {
+    const getSpy = vi.spyOn(cache, 'get').mockRejectedValueOnce(new Error('cache unavailable'))
+
+    expect(await getCachedCrlSummary(agentContext, URL_A)).toBeNull()
+    getSpy.mockRestore()
   })
 })

--- a/packages/core/src/modules/x509/__tests__/crlSummary.test.ts
+++ b/packages/core/src/modules/x509/__tests__/crlSummary.test.ts
@@ -1,0 +1,182 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import type { Agent } from '../../../agent/Agent'
+import type { AgentContext } from '../../../agent/context'
+import type { KeyManagementApi, PublicJwk } from '../../kms'
+import { buildCrlSummary, CrlSummaryVerifiedCrl, isX509CrlSummary } from '../utils/crlSummary'
+import type { X509Certificate } from '../X509Certificate'
+import {
+  type X509CertificateRevocationList,
+  X509CertificateRevocationListEntryReason,
+} from '../X509CertificateRevocationList'
+import { X509RevocationReason } from '../X509CrlDistributionPoint'
+import { X509Service } from '../X509Service'
+import type { X509CreateCertificateRevocationListOptions } from '../X509ServiceOptions'
+import { createP256Key, setupCrlAgent } from './x509CrlTestUtils'
+
+const lastMonth = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000)
+const nextMonth = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000)
+const twoMonthsAgo = new Date(Date.now() - 60 * 24 * 60 * 60 * 1000)
+
+describe('crlSummary', () => {
+  let agent: Agent
+  let agentContext: AgentContext
+  let kmsApi: KeyManagementApi
+
+  let issuerKey: PublicJwk
+  let issuerCertificate: X509Certificate
+
+  beforeAll(async () => {
+    ;({ agent, agentContext, kmsApi } = await setupCrlAgent())
+
+    issuerKey = await createP256Key(kmsApi)
+    issuerCertificate = await X509Service.createCertificate(agentContext, {
+      serialNumber: '01',
+      issuer: { commonName: 'Issuer CA' },
+      authorityKey: issuerKey,
+      validity: { notBefore: lastMonth, notAfter: nextMonth },
+      extensions: { basicConstraints: { ca: true } },
+    })
+  })
+
+  afterAll(async () => {
+    await agent.shutdown()
+  })
+
+  async function createCrl(options: {
+    entries?: X509CreateCertificateRevocationListOptions['entries']
+    extensions?: X509CreateCertificateRevocationListOptions['extensions']
+    nextUpdate?: Date
+  }): Promise<X509CertificateRevocationList> {
+    return X509Service.createCertificateRevocationList(agentContext, {
+      authorityKey: issuerKey,
+      issuer: issuerCertificate.subject,
+      validity: { thisUpdate: lastMonth, nextUpdate: options.nextUpdate ?? nextMonth },
+      entries: options.entries,
+      extensions: options.extensions,
+    })
+  }
+
+  async function createLeaf(serialNumber: string): Promise<X509Certificate> {
+    return X509Service.createCertificate(agentContext, {
+      serialNumber,
+      issuer: issuerCertificate.subject,
+      authorityKey: issuerKey,
+      subject: { commonName: `Leaf ${serialNumber}` },
+      subjectPublicKey: await createP256Key(kmsApi),
+      validity: { notBefore: lastMonth, notAfter: nextMonth },
+    })
+  }
+
+  function summaryFor(crl: X509CertificateRevocationList) {
+    return buildCrlSummary(crl, issuerCertificate)
+  }
+
+  it('builds a summary that survives a JSON round-trip', async () => {
+    const crl = await createCrl({
+      entries: [
+        {
+          serialNumber: 'a1',
+          revocationDate: twoMonthsAgo,
+          reason: X509CertificateRevocationListEntryReason.KeyCompromise,
+        },
+        { serialNumber: 'b2', revocationDate: lastMonth },
+      ],
+      extensions: {
+        issuingDistributionPoint: {
+          fullName: ['https://crl.example/scoped.crl'],
+          onlyContainsUserCerts: true,
+          onlySomeReasons: [X509RevocationReason.KeyCompromise, X509RevocationReason.Superseded],
+        },
+      },
+    })
+
+    const summary = summaryFor(crl)
+    expect(JSON.parse(JSON.stringify(summary))).toEqual(summary)
+  })
+
+  describe('CrlSummaryVerifiedCrl', () => {
+    it('matches findRevoked of the parsed CRL, including serial normalization', async () => {
+      const crl = await createCrl({
+        entries: [
+          {
+            serialNumber: 'ab',
+            revocationDate: twoMonthsAgo,
+            reason: X509CertificateRevocationListEntryReason.KeyCompromise,
+          },
+          { serialNumber: 'c3', revocationDate: lastMonth },
+        ],
+      })
+      const view = new CrlSummaryVerifiedCrl(summaryFor(crl))
+
+      // Certificate serial '00ab' matches CRL entry 'ab' via normalization
+      for (const serialNumber of ['00ab', 'c3', 'dead']) {
+        const certificate = await createLeaf(serialNumber)
+        expect(view.findRevoked(certificate)).toEqual(crl.findRevoked(certificate))
+      }
+    })
+
+    it('returns the first matching entry for duplicate serials, like the linear scan of the parsed CRL', async () => {
+      // The CRL generator rejects duplicate serials, so exercise the lookup index directly with a
+      // hand-built summary containing entries that normalize to the same serial.
+      const view = new CrlSummaryVerifiedCrl({
+        issuerNameSha256: 'ab'.repeat(32),
+        issuerPublicJwkThumbprint: 'cd'.repeat(32),
+        thisUpdate: lastMonth.getTime(),
+        criticalExtensionIds: [],
+        serialNumbers: ['00C3', 'c3'],
+        revocationDates: [twoMonthsAgo.getTime(), lastMonth.getTime()],
+        reasons: [X509CertificateRevocationListEntryReason.KeyCompromise, null],
+      })
+
+      expect(view.findRevoked(await createLeaf('c3'))).toEqual({
+        serialNumber: '00C3',
+        revocationDate: new Date(twoMonthsAgo.getTime()),
+        reason: X509CertificateRevocationListEntryReason.KeyCompromise,
+      })
+    })
+
+    it('exposes the same applicability data as the parsed CRL', async () => {
+      const deltaCrl = await createCrl({ extensions: { deltaCrlIndicator: { value: 5 } } })
+      const idpCrl = await createCrl({
+        extensions: {
+          issuingDistributionPoint: { fullName: ['https://crl.example/full.crl'], onlyContainsCACerts: true },
+        },
+      })
+      const criticalCrlNumberCrl = await createCrl({ extensions: { crlNumber: { value: 1, markAsCritical: true } } })
+
+      for (const crl of [deltaCrl, idpCrl, criticalCrlNumberCrl]) {
+        const view = new CrlSummaryVerifiedCrl(summaryFor(crl))
+        expect(view.deltaCrlIndicator).toEqual(crl.deltaCrlIndicator)
+        expect(view.issuingDistributionPoint).toEqual(crl.issuingDistributionPoint)
+        expect(view.criticalExtensionIds).toEqual(crl.criticalExtensionIds)
+      }
+    })
+  })
+
+  describe('isX509CrlSummary', () => {
+    it('accepts summaries built from a CRL', async () => {
+      const plainCrl = await createCrl({ entries: [{ serialNumber: 'a1', revocationDate: lastMonth }] })
+      expect(isX509CrlSummary(summaryFor(plainCrl))).toBe(true)
+
+      const richCrl = await createCrl({
+        extensions: { issuingDistributionPoint: { indirectCRL: true } },
+      })
+      // Also after a serialization round-trip, as returned by persistent caches
+      expect(isX509CrlSummary(JSON.parse(JSON.stringify(summaryFor(richCrl))))).toBe(true)
+    })
+
+    it('rejects values that are not a valid summary', async () => {
+      const crl = await createCrl({ entries: [{ serialNumber: 'a1', revocationDate: lastMonth }] })
+      const summary = summaryFor(crl)
+
+      expect(isX509CrlSummary(null)).toBe(false)
+      expect(isX509CrlSummary('garbage')).toBe(false)
+      expect(isX509CrlSummary({})).toBe(false)
+      expect(isX509CrlSummary({ ...summary, thisUpdate: 'not a number' })).toBe(false)
+      expect(isX509CrlSummary({ ...summary, serialNumbers: [1] })).toBe(false)
+      // Mismatched parallel array lengths
+      expect(isX509CrlSummary({ ...summary, revocationDates: [] })).toBe(false)
+    })
+  })
+})

--- a/packages/core/src/modules/x509/__tests__/x509CrlTestUtils.ts
+++ b/packages/core/src/modules/x509/__tests__/x509CrlTestUtils.ts
@@ -33,9 +33,13 @@ export interface CrlTestAgent {
  * Remember to `await agent.shutdown()` in `afterAll`.
  *
  * @param options.revocationCheck optional revocation configuration for the X509 module
+ * @param options.cache optional cache instance, e.g. to share a cache between two agents
  */
-export async function setupCrlAgent(options?: { revocationCheck?: X509RevocationCheckOptions }): Promise<CrlTestAgent> {
-  const cache = new InMemoryLruCache({ limit: 100 })
+export async function setupCrlAgent(options?: {
+  revocationCheck?: X509RevocationCheckOptions
+  cache?: InMemoryLruCache
+}): Promise<CrlTestAgent> {
+  const cache = options?.cache ?? new InMemoryLruCache({ limit: 100 })
 
   const { config, modules, dependencies } = getAgentOptions(
     'X509 CRL',

--- a/packages/core/src/modules/x509/utils/criticalExtensions.ts
+++ b/packages/core/src/modules/x509/utils/criticalExtensions.ts
@@ -90,13 +90,17 @@ export function validateCriticalExtensionsForChain(
  * cannot be processed) MUST NOT be used, as it may change the CRL's meaning (e.g. its scope).
  */
 export function validateCriticalCrlExtensions(crl: x509.X509Crl): CriticalExtensionValidationResult {
-  const unknownCriticalExtensions: string[] = []
+  return validateCriticalCrlExtensionIds(crl.extensions.filter((e) => e.critical).map((e) => e.type))
+}
 
-  for (const extension of crl.extensions) {
-    if (extension.critical && !knownCriticalCrlExtensions.includes(extension.type as X509CrlExtensionIdentifier)) {
-      unknownCriticalExtensions.push(extension.type)
-    }
-  }
+/**
+ * Validates a list of critical CRL extension ids against the extensions Credo understands.
+ * See {@link validateCriticalCrlExtensions}.
+ */
+export function validateCriticalCrlExtensionIds(criticalExtensionIds: string[]): CriticalExtensionValidationResult {
+  const unknownCriticalExtensions = criticalExtensionIds.filter(
+    (id) => !knownCriticalCrlExtensions.includes(id as X509CrlExtensionIdentifier)
+  )
 
   if (unknownCriticalExtensions.length > 0) {
     return {

--- a/packages/core/src/modules/x509/utils/crlFetcher.ts
+++ b/packages/core/src/modules/x509/utils/crlFetcher.ts
@@ -1,8 +1,8 @@
 import type { AgentContext } from '../../../agent'
-import { TypedArrayEncoder } from '../../../utils'
 import { fetchWithTimeout } from '../../../utils/fetch'
 import { CacheModuleConfig } from '../../cache'
 import { X509Error } from '../X509Error'
+import { isX509CrlSummary, type X509CrlSummary } from './crlSummary'
 
 export interface CrlFetchOptions {
   url: string
@@ -33,16 +33,19 @@ const DEFAULT_MAX_CRL_SIZE_BYTES = 10 * 1024 * 1024 // 10 MB
  */
 const DEFAULT_TIMEOUT_MILLISECONDS = 5000
 
-function crlCacheKey(url: string): string {
-  return `x509:crl:${url}`
+// Versioned so future summary shape changes can bump the key. Distinct from the legacy
+// `x509:crl:${url}` raw-bytes key, which this version no longer reads or writes but which older
+// Credo versions sharing the cache may still use.
+function crlSummaryCacheKey(url: string): string {
+  return `x509:crl-summary:v1:${url}`
 }
 
 /**
  * Fetches a CRL from a given URL with size limit and timeout enforcement.
  *
  * This does NOT cache: caching is the responsibility of the caller, which should only cache a CRL
- * after it has been verified (see {@link setCachedCrl}), so unverified or expired CRLs are never
- * persisted.
+ * after it has been verified (see {@link setCachedCrlSummary}), so unverified or expired CRLs are
+ * never persisted.
  *
  * @throws {X509Error} If the fetch fails, returns a non-OK status, or exceeds the size limit
  */
@@ -76,28 +79,29 @@ export async function fetchCrl(options: CrlFetchOptions): Promise<Uint8Array> {
 }
 
 /**
- * Return the cached (and previously verified) CRL bytes for a URL, or `null` if not cached.
+ * Return the cached verified CRL summary for a URL, or `null` if not cached. Values that do not
+ * match the expected summary shape are treated as a cache miss, never as an error.
  */
-export async function getCachedCrl(agentContext: AgentContext, url: string): Promise<Uint8Array | null> {
+export async function getCachedCrlSummary(agentContext: AgentContext, url: string): Promise<X509CrlSummary | null> {
   const cache = agentContext.resolve(CacheModuleConfig).cache
-  const cached = await cache.get<string>(agentContext, crlCacheKey(url)).catch(() => null)
-  return cached ? TypedArrayEncoder.fromBase64(cached) : null
+  const cached = await cache.get<unknown>(agentContext, crlSummaryCacheKey(url)).catch(() => null)
+  return isX509CrlSummary(cached) ? cached : null
 }
 
 /**
- * Cache verified CRL bytes for a URL.
+ * Cache the summary of a verified CRL for a URL.
  *
- * Callers must only cache CRLs that have passed verification (signature, issuer, validity window),
- * and should derive `expiresInSeconds` from the CRL's `nextUpdate` so an expired CRL is never
- * served from the cache.
+ * Callers must only cache summaries derived from CRLs that have passed verification, and should
+ * derive `expiresInSeconds` from the CRL's `nextUpdate` so an expired CRL is never served from the
+ * cache.
  */
-export async function setCachedCrl(
+export async function setCachedCrlSummary(
   agentContext: AgentContext,
   url: string,
-  data: Uint8Array,
+  summary: X509CrlSummary,
   expiresInSeconds: number
 ): Promise<void> {
   if (expiresInSeconds <= 0) return
   const cache = agentContext.resolve(CacheModuleConfig).cache
-  await cache.set(agentContext, crlCacheKey(url), TypedArrayEncoder.toBase64(data), expiresInSeconds).catch(() => null)
+  await cache.set(agentContext, crlSummaryCacheKey(url), summary, expiresInSeconds).catch(() => null)
 }

--- a/packages/core/src/modules/x509/utils/crlSummary.ts
+++ b/packages/core/src/modules/x509/utils/crlSummary.ts
@@ -1,0 +1,196 @@
+import { z } from 'zod'
+import { Hasher } from '../../../crypto/hashes/Hasher'
+import { TypedArrayEncoder } from '../../../utils'
+import type { X509Certificate } from '../X509Certificate'
+import type {
+  X509CertificateRevocationList,
+  X509CertificateRevocationListEntry,
+  X509CertificateRevocationListEntryReason,
+  X509IssuingDistributionPoint,
+} from '../X509CertificateRevocationList'
+import { normalizeSerialNumber } from './serialNumber'
+
+/**
+ * The subset of a verified CRL that the revocation engine consumes.
+ *
+ * Satisfied both by a freshly parsed and verified {@link X509CertificateRevocationList} and by a
+ * cached {@link X509CrlSummary} (via {@link CrlSummaryVerifiedCrl}), so a cache hit does not need
+ * to re-parse the CRL.
+ */
+export interface VerifiedCrl {
+  readonly deltaCrlIndicator: number | undefined
+  readonly issuingDistributionPoint: X509IssuingDistributionPoint | undefined
+  readonly criticalExtensionIds: string[]
+  findRevoked(certificate: X509Certificate): X509CertificateRevocationListEntry | null
+}
+
+/**
+ * Plain-JSON summary of a verified CRL, cached so that subsequent revocation checks do not need to
+ * re-parse the (potentially multi-MB) CRL. Must remain JSON-serializable so it survives
+ * storage-backed cache implementations.
+ */
+const zX509CrlSummary = z
+  .object({
+    // The issuer binding captures what CRL verification actually depends on from the issuer
+    // certificate: its subject name (issuer-name binding) and its public key (signature). The
+    // remaining issuer-dependent check, cRLSign key usage, is re-evaluated on the certificate
+    // provided at hit time, so a renewed or cross-certified issuer certificate with the same name
+    // and key can reuse the summary.
+    /** SHA-256 (hex) of the DER-encoded subject name of the issuer certificate */
+    issuerNameSha256: z.string(),
+    /** RFC 7638 JWK thumbprint (hex) of the issuer certificate's public key */
+    issuerPublicJwkThumbprint: z.string(),
+    /** `thisUpdate` as epoch milliseconds */
+    thisUpdate: z.number(),
+    /** `nextUpdate` as epoch milliseconds, absent when the CRL has none */
+    nextUpdate: z.optional(z.number()),
+    deltaCrlIndicator: z.optional(z.number()),
+    issuingDistributionPoint: z.optional(
+      z.object({
+        fullName: z.array(z.string()),
+        onlyContainsUserCerts: z.boolean(),
+        onlyContainsCACerts: z.boolean(),
+        onlySomeReasons: z.optional(z.array(z.number())),
+        indirectCRL: z.boolean(),
+        onlyContainsAttributeCerts: z.boolean(),
+      })
+    ),
+    criticalExtensionIds: z.array(z.string()),
+    // Parallel arrays with one slot per revoked entry, preserving CRL order so lookups keep the
+    // first-match semantics of X509CertificateRevocationList.findRevoked.
+    /** Original serial number strings as parsed from the CRL (not normalized) */
+    serialNumbers: z.array(z.string()),
+    /** Revocation date per entry as epoch milliseconds */
+    revocationDates: z.array(z.number()),
+    /** Revocation reason per entry, `null` when absent (`undefined` is not JSON-safe in arrays) */
+    reasons: z.array(z.nullable(z.number())),
+  })
+  .refine(
+    (summary) =>
+      summary.serialNumbers.length === summary.revocationDates.length &&
+      summary.serialNumbers.length === summary.reasons.length
+  )
+
+export type X509CrlSummary = z.output<typeof zX509CrlSummary>
+
+/**
+ * Guard for cached summaries. Anything that does not match the expected shape (older formats,
+ * corrupted values) is treated as a cache miss by callers, never as an error, so this must not
+ * throw. Callers must keep using the original object rather than zod's parsed copy: cloning would
+ * copy the potentially huge entry arrays on every cache read and break the revoked-index
+ * memoization, which is keyed on object identity.
+ */
+export function isX509CrlSummary(value: unknown): value is X509CrlSummary {
+  return zX509CrlSummary.safeParse(value).success
+}
+
+export function computeIssuerNameSha256(issuerCertificate: X509Certificate): string {
+  return TypedArrayEncoder.toHex(Hasher.hash(issuerCertificate.subjectNameBytes, 'SHA-256'))
+}
+
+export function computeIssuerPublicJwkThumbprint(issuerCertificate: X509Certificate): string {
+  return TypedArrayEncoder.toHex(issuerCertificate.publicJwk.getJwkThumbprint())
+}
+
+/**
+ * Derive the cacheable summary of a verified CRL.
+ *
+ * May throw for malformed CRLs (e.g. duplicate extensions, via the delta/issuing-distribution-point
+ * getters); callers must then skip caching the summary so such CRLs keep their existing behavior.
+ */
+export function buildCrlSummary(
+  crl: X509CertificateRevocationList,
+  issuerCertificate: X509Certificate
+): X509CrlSummary {
+  const serialNumbers: string[] = []
+  const revocationDates: number[] = []
+  const reasons: (number | null)[] = []
+  for (const entry of crl.revokedCertificates) {
+    serialNumbers.push(entry.serialNumber)
+    revocationDates.push(entry.revocationDate.getTime())
+    reasons.push(entry.reason ?? null)
+  }
+
+  const issuingDistributionPoint = crl.issuingDistributionPoint
+
+  return {
+    issuerNameSha256: computeIssuerNameSha256(issuerCertificate),
+    issuerPublicJwkThumbprint: computeIssuerPublicJwkThumbprint(issuerCertificate),
+    thisUpdate: crl.thisUpdate.getTime(),
+    nextUpdate: crl.nextUpdate?.getTime(),
+    deltaCrlIndicator: crl.deltaCrlIndicator,
+    issuingDistributionPoint: issuingDistributionPoint
+      ? {
+          fullName: issuingDistributionPoint.fullName,
+          onlyContainsUserCerts: issuingDistributionPoint.onlyContainsUserCerts,
+          onlyContainsCACerts: issuingDistributionPoint.onlyContainsCACerts,
+          onlySomeReasons: issuingDistributionPoint.onlySomeReasons,
+          indirectCRL: issuingDistributionPoint.indirectCRL,
+          onlyContainsAttributeCerts: issuingDistributionPoint.onlyContainsAttributeCerts,
+        }
+      : undefined,
+    criticalExtensionIds: crl.criticalExtensionIds,
+    serialNumbers,
+    revocationDates,
+    reasons,
+  }
+}
+
+// Lookup index per summary object. Keyed weakly so in-memory caches (which return the same summary
+// object on every hit) only pay the index build once, while the summaries themselves can be evicted.
+const revokedIndexBySummary = new WeakMap<X509CrlSummary, Map<string, number>>()
+
+/**
+ * {@link VerifiedCrl} view over a cached {@link X509CrlSummary}. Read-only: the summary may be a
+ * shared reference owned by an in-memory cache and must never be mutated.
+ */
+export class CrlSummaryVerifiedCrl implements VerifiedCrl {
+  public constructor(private readonly summary: X509CrlSummary) {}
+
+  public get deltaCrlIndicator(): number | undefined {
+    return this.summary.deltaCrlIndicator
+  }
+
+  public get issuingDistributionPoint(): X509IssuingDistributionPoint | undefined {
+    const idp = this.summary.issuingDistributionPoint
+    if (!idp) return undefined
+    return {
+      fullName: [...idp.fullName],
+      onlyContainsUserCerts: idp.onlyContainsUserCerts,
+      onlyContainsCACerts: idp.onlyContainsCACerts,
+      onlySomeReasons: idp.onlySomeReasons ? [...idp.onlySomeReasons] : undefined,
+      indirectCRL: idp.indirectCRL,
+      onlyContainsAttributeCerts: idp.onlyContainsAttributeCerts,
+    }
+  }
+
+  public get criticalExtensionIds(): string[] {
+    return [...this.summary.criticalExtensionIds]
+  }
+
+  public findRevoked(certificate: X509Certificate): X509CertificateRevocationListEntry | null {
+    const index = this.revokedIndex.get(normalizeSerialNumber(certificate.data.serialNumber))
+    if (index === undefined) return null
+
+    return {
+      serialNumber: this.summary.serialNumbers[index],
+      revocationDate: new Date(this.summary.revocationDates[index]),
+      reason: (this.summary.reasons[index] ?? undefined) as X509CertificateRevocationListEntryReason | undefined,
+    }
+  }
+
+  private get revokedIndex(): Map<string, number> {
+    let index = revokedIndexBySummary.get(this.summary)
+    if (!index) {
+      index = new Map()
+      for (let i = 0; i < this.summary.serialNumbers.length; i++) {
+        const normalized = normalizeSerialNumber(this.summary.serialNumbers[i])
+        // Keep the first occurrence of a duplicate serial, matching the linear scan of
+        // X509CertificateRevocationList.findRevoked
+        if (!index.has(normalized)) index.set(normalized, i)
+      }
+      revokedIndexBySummary.set(this.summary, index)
+    }
+    return index
+  }
+}

--- a/packages/core/src/modules/x509/utils/serialNumber.ts
+++ b/packages/core/src/modules/x509/utils/serialNumber.ts
@@ -1,0 +1,7 @@
+/**
+ * Normalize a hexadecimal serial number for comparison by lowercasing and stripping leading
+ * zeros, so that e.g. `0A1B2C` and `0a1b2c` are treated as equal.
+ */
+export function normalizeSerialNumber(serialNumber: string): string {
+  return serialNumber.toLowerCase().replace(/^0+/, '') || '0'
+}


### PR DESCRIPTION
Improves X509 CRL caching by caching the data of the parsed CRL instead of the raw bytes. The download is cheap, but the parsing isn't. We also cache information about the signer key in order to be able to fast check/verify on subsequent calls. Also fixes a bug where the globally configured CRL caching time wasn't being taken into account.

No changelog because this feature (CRL) hasn't been released yet.