### PR TITLE
feat(openid4vc): add updateIssuer to OpenId4VcIssuerApi

### DIFF
--- a/.changeset/green-geckos-clean.md
+++ b/.changeset/green-geckos-clean.md
@@ -1,0 +1,5 @@
+---
+"@credo-ts/openid4vc": patch
+---
+
+Exposed updateIssuer method on OpenId4VcIssuerApi

--- a/packages/openid4vc/src/openid4vc-issuer/OpenId4VcIssuerApi.ts
+++ b/packages/openid4vc/src/openid4vc-issuer/OpenId4VcIssuerApi.ts
@@ -9,6 +9,7 @@ import type {
   OpenId4VciCreateStatelessCredentialOfferOptions,
   OpenId4VcUpdateIssuerRecordOptions,
 } from './OpenId4VcIssuerServiceOptions'
+import { OpenId4VcIssuerRecord } from './repository'
 
 /**
  * @public
@@ -70,6 +71,13 @@ export class OpenId4VcIssuerApi {
     issuer.batchCredentialIssuance = batchCredentialIssuance
     issuer.authorizationServerConfigs = authorizationServerConfigs
 
+    return this.openId4VcIssuerService.updateIssuer(this.agentContext, issuer)
+  }
+
+  /**
+   * Updates an issuer and stores the corresponding updated issuer metadata.
+   */
+  public async updateIssuer(issuer: OpenId4VcIssuerRecord) {
     return this.openId4VcIssuerService.updateIssuer(this.agentContext, issuer)
   }
 


### PR DESCRIPTION
Exposes the `updateIssuer` method on the public `OpenId4VcIssuerApi` to allow directly updating a full `OpenId4VcIssuerRecord`. Previously, only the `updateIssuerMetadata` wrapper was available.
