### PR TITLE
feat(didDoc): purpose aware key lookup

### DIFF
--- a/packages/core/src/modules/dids/domain/DidDocument.ts
+++ b/packages/core/src/modules/dids/domain/DidDocument.ts
@@ -330,15 +330,17 @@ export class DidDocument {
 
 /**
  * Extracting the verification method for signature type
- * @param type Signature type
+ * @param keyType Signature key type
  * @param didDocument DidDocument
+ * @param allowedPurposes Optional array of purposes to search in order. Defaults to all purposes.
  * @returns verification method
  */
 export async function findVerificationMethodByKeyType(
   keyType: string,
-  didDocument: DidDocument
+  didDocument: DidDocument,
+  allowedPurposes?: DidVerificationMethods[]
 ): Promise<VerificationMethod | null> {
-  const didVerificationMethods: DidVerificationMethods[] = [
+  const allPurposes: DidVerificationMethods[] = [
     'verificationMethod',
     'authentication',
     'keyAgreement',
@@ -346,7 +348,8 @@ export async function findVerificationMethodByKeyType(
     'capabilityInvocation',
     'capabilityDelegation',
   ]
-  for (const purpose of didVerificationMethods) {
+  const purposes = allowedPurposes ?? allPurposes
+  for (const purpose of purposes) {
     const key: VerificationMethod[] | (string | VerificationMethod)[] | undefined = didDocument[purpose]
     if (Array.isArray(key)) {
       for (const method of key) {

--- a/packages/didcomm/src/modules/credentials/formats/jsonld/DidCommJsonLdCredentialFormat.ts
+++ b/packages/didcomm/src/modules/credentials/formats/jsonld/DidCommJsonLdCredentialFormat.ts
@@ -1,4 +1,4 @@
-import type { JsonObject, SingleOrArray, W3cIssuerOptions } from '@credo-ts/core'
+import type { DidPurpose, JsonObject, SingleOrArray, W3cIssuerOptions } from '@credo-ts/core'
 import type { DidCommCredentialFormat } from '../DidCommCredentialFormat'
 
 export interface JsonCredential {
@@ -87,7 +87,7 @@ export interface JsonLdFormatDataCredentialDetail {
  * format data interfaces.
  */
 export interface JsonLdFormatDataCredentialDetailOptions {
-  proofPurpose: string
+  proofPurpose?: DidPurpose
   proofType: string
   created?: string
   domain?: string

--- a/packages/didcomm/src/modules/credentials/formats/jsonld/DidCommJsonLdCredentialFormatService.ts
+++ b/packages/didcomm/src/modules/credentials/formats/jsonld/DidCommJsonLdCredentialFormatService.ts
@@ -301,7 +301,7 @@ export class DidCommJsonLdCredentialFormatService
       throw new CredoError(`No Key Type found for proofType ${proofType}`)
     }
 
-    // Support issuer DID documents with separate keys for different purposes (authentication vs assertionMethod).
+    // Support issuer DID documents with separate keys for different purposes
     const proofPurpose = credentialRequest.options.proofPurpose ?? 'assertionMethod'
 
     try {

--- a/packages/didcomm/src/modules/credentials/formats/jsonld/DidCommJsonLdCredentialFormatService.ts
+++ b/packages/didcomm/src/modules/credentials/formats/jsonld/DidCommJsonLdCredentialFormatService.ts
@@ -1,4 +1,4 @@
-import type { AgentContext } from '@credo-ts/core'
+import type { AgentContext, DidDocument } from '@credo-ts/core'
 import {
   ClaimFormat,
   CredoError,
@@ -304,37 +304,28 @@ export class DidCommJsonLdCredentialFormatService
     // Support issuer DID documents with separate keys for different purposes
     const proofPurpose = credentialRequest.options.proofPurpose ?? 'assertionMethod'
 
+    // Try created DID first (local, faster, no network call); fall back to network resolution
+    let issuerDidDocument: DidDocument
     try {
-      // Try created DID first (local, faster, no network call)
       const parsedDid = parseDid(issuerDid)
-      const { didDocument } = await didsApi.resolveCreatedDidDocumentWithKeys(parsedDid.did)
-
-      const verificationMethod = await findVerificationMethodByKeyType(keyType[0], didDocument, [
-        proofPurpose,
-        'verificationMethod',
-      ])
-
-      if (!verificationMethod) {
-        throw new CredoError(`Missing verification method for key type ${keyType}`)
-      }
-
-      return verificationMethod.id
+      const resolved = await didsApi.resolveCreatedDidDocumentWithKeys(parsedDid.did)
+      issuerDidDocument = resolved.didDocument
     } catch (_error) {
       // Fall back to network resolution if DID is not locally stored
       // this will throw an error if the issuer did is invalid
-      const issuerDidDocument = await didResolver.resolveDidDocument(agentContext, issuerDid)
-
-      const verificationMethod = await findVerificationMethodByKeyType(keyType[0], issuerDidDocument, [
-        proofPurpose,
-        'verificationMethod',
-      ])
-
-      if (!verificationMethod) {
-        throw new CredoError(`Missing verification method for key type ${keyType}`)
-      }
-
-      return verificationMethod.id
+      issuerDidDocument = await didResolver.resolveDidDocument(agentContext, issuerDid)
     }
+
+    const verificationMethod = await findVerificationMethodByKeyType(keyType[0], issuerDidDocument, [
+      proofPurpose,
+      'verificationMethod',
+    ])
+
+    if (!verificationMethod) {
+      throw new CredoError(`Missing verification method for key type ${keyType}`)
+    }
+
+    return verificationMethod.id
   }
   /**
    * Processes an incoming credential - retrieve metadata, retrieve payload and store it in the Indy wallet

--- a/packages/didcomm/src/modules/credentials/formats/jsonld/DidCommJsonLdCredentialFormatService.ts
+++ b/packages/didcomm/src/modules/credentials/formats/jsonld/DidCommJsonLdCredentialFormatService.ts
@@ -3,9 +3,11 @@ import {
   ClaimFormat,
   CredoError,
   DidResolverService,
+  DidsApi,
   findVerificationMethodByKeyType,
   JsonEncoder,
   JsonTransformer,
+  parseDid,
   utils,
   W3cCredential,
   W3cCredentialRecord,
@@ -276,6 +278,7 @@ export class DidCommJsonLdCredentialFormatService
     credentialAsJson: JsonCredential,
     credentialRequest: JsonLdFormatDataCredentialDetail
   ): Promise<string> {
+    const didsApi = agentContext.dependencyManager.resolve(DidsApi)
     const didResolver = agentContext.dependencyManager.resolve(DidResolverService)
     const w3cJsonLdCredentialService = agentContext.dependencyManager.resolve(W3cJsonLdCredentialService)
 
@@ -287,8 +290,6 @@ export class DidCommJsonLdCredentialFormatService
     if (typeof issuerDid !== 'string') {
       issuerDid = issuerDid.id
     }
-    // this will throw an error if the issuer did is invalid
-    const issuerDidDocument = await didResolver.resolveDidDocument(agentContext, issuerDid)
 
     // find first key which matches proof type
     const proofType = credentialRequest.options.proofType
@@ -300,12 +301,40 @@ export class DidCommJsonLdCredentialFormatService
       throw new CredoError(`No Key Type found for proofType ${proofType}`)
     }
 
-    const verificationMethod = await findVerificationMethodByKeyType(keyType[0], issuerDidDocument)
-    if (!verificationMethod) {
-      throw new CredoError(`Missing verification method for key type ${keyType}`)
-    }
+    // Support issuer DID documents with separate keys for different purposes (authentication vs assertionMethod).
+    const proofPurpose = credentialRequest.options.proofPurpose ?? 'assertionMethod'
 
-    return verificationMethod.id
+    try {
+      // Try created DID first (local, faster, no network call)
+      const parsedDid = parseDid(issuerDid)
+      const { didDocument } = await didsApi.resolveCreatedDidDocumentWithKeys(parsedDid.did)
+
+      const verificationMethod = await findVerificationMethodByKeyType(keyType[0], didDocument, [
+        proofPurpose,
+        'verificationMethod',
+      ])
+
+      if (!verificationMethod) {
+        throw new CredoError(`Missing verification method for key type ${keyType}`)
+      }
+
+      return verificationMethod.id
+    } catch (_error) {
+      // Fall back to network resolution if DID is not locally stored
+      // this will throw an error if the issuer did is invalid
+      const issuerDidDocument = await didResolver.resolveDidDocument(agentContext, issuerDid)
+
+      const verificationMethod = await findVerificationMethodByKeyType(keyType[0], issuerDidDocument, [
+        proofPurpose,
+        'verificationMethod',
+      ])
+
+      if (!verificationMethod) {
+        throw new CredoError(`Missing verification method for key type ${keyType}`)
+      }
+
+      return verificationMethod.id
+    }
   }
   /**
    * Processes an incoming credential - retrieve metadata, retrieve payload and store it in the Indy wallet

--- a/packages/didcomm/src/modules/credentials/formats/jsonld/DidCommJsonLdCredentialFormatService.ts
+++ b/packages/didcomm/src/modules/credentials/formats/jsonld/DidCommJsonLdCredentialFormatService.ts
@@ -1,13 +1,11 @@
-import type { AgentContext, DidDocument } from '@credo-ts/core'
+import type { AgentContext } from '@credo-ts/core'
 import {
   ClaimFormat,
   CredoError,
   DidResolverService,
-  DidsApi,
   findVerificationMethodByKeyType,
   JsonEncoder,
   JsonTransformer,
-  parseDid,
   utils,
   W3cCredential,
   W3cCredentialRecord,
@@ -278,7 +276,6 @@ export class DidCommJsonLdCredentialFormatService
     credentialAsJson: JsonCredential,
     credentialRequest: JsonLdFormatDataCredentialDetail
   ): Promise<string> {
-    const didsApi = agentContext.dependencyManager.resolve(DidsApi)
     const didResolver = agentContext.dependencyManager.resolve(DidResolverService)
     const w3cJsonLdCredentialService = agentContext.dependencyManager.resolve(W3cJsonLdCredentialService)
 
@@ -290,6 +287,8 @@ export class DidCommJsonLdCredentialFormatService
     if (typeof issuerDid !== 'string') {
       issuerDid = issuerDid.id
     }
+    // this will throw an error if the issuer did is invalid
+    const issuerDidDocument = await didResolver.resolveDidDocument(agentContext, issuerDid)
 
     // find first key which matches proof type
     const proofType = credentialRequest.options.proofType
@@ -301,23 +300,8 @@ export class DidCommJsonLdCredentialFormatService
       throw new CredoError(`No Key Type found for proofType ${proofType}`)
     }
 
-    // Support issuer DID documents with separate keys for different purposes
-    const proofPurpose = credentialRequest.options.proofPurpose ?? 'assertionMethod'
-
-    // Try created DID first (local, faster, no network call); fall back to network resolution
-    let issuerDidDocument: DidDocument
-    try {
-      const parsedDid = parseDid(issuerDid)
-      const resolved = await didsApi.resolveCreatedDidDocumentWithKeys(parsedDid.did)
-      issuerDidDocument = resolved.didDocument
-    } catch (_error) {
-      // Fall back to network resolution if DID is not locally stored
-      // this will throw an error if the issuer did is invalid
-      issuerDidDocument = await didResolver.resolveDidDocument(agentContext, issuerDid)
-    }
-
     const verificationMethod = await findVerificationMethodByKeyType(keyType[0], issuerDidDocument, [
-      proofPurpose,
+      'assertionMethod',
       'verificationMethod',
     ])
 


### PR DESCRIPTION
Enhanced `findVerificationMethodByKeyType()` in `DidDocument.ts` to accept an optional `proofPurpose`, matching existing `resolveVerificationMethodFromCreatedDidRecord(vm, allowedPurposes?)` and `dereferenceKey(keyId, purposes?)`

Optimise key lookup in `LDP` DIDComm signing path by passing `proofPurpose` to support retrieving `assertionMethod` from DID Documents with multiple keys and not just pick the first key found