### PR TITLE
fix: prefer default kms backend

### DIFF
--- a/.changeset/kms-default-backend.md
+++ b/.changeset/kms-default-backend.md
@@ -1,0 +1,5 @@
+---
+"@credo-ts/core": patch
+---
+
+fix(kms): respect the configured `defaultBackend` when no explicit `backend` is provided for a key management operation. Previously the first registered backend that supported the operation was always used and the `defaultBackend` option was silently ignored, which could result in keys being created in a different (e.g. software instead of hardware-backed) backend than configured. If the default backend does not support the requested operation, the first other backend that supports the operation is used and a warning is logged.

--- a/packages/core/src/modules/kms/KeyManagementApi.ts
+++ b/packages/core/src/modules/kms/KeyManagementApi.ts
@@ -303,8 +303,7 @@ export class KeyManagementApi {
    */
   private async getKmsForOperationAndKeyId(agentContext: AgentContext, keyId: string, operation?: KmsOperation) {
     for (const kms of this.keyManagementConfig.backends) {
-      const isOperationSupported = operation ? kms.isOperationSupported(agentContext, operation) : true
-      if (!isOperationSupported) continue
+      if (operation && !kms.isOperationSupported(agentContext, operation)) continue
 
       const publicKey = await kms.getPublicKey(this.agentContext, keyId)
       if (publicKey)
@@ -314,17 +313,12 @@ export class KeyManagementApi {
         }
     }
 
-    if (operation) {
-      throw new KeyManagementKeyNotFoundError(
-        keyId,
-        this.keyManagementConfig.backends.map((b) => b.backend),
-        `The key may exist in one of the key management services in which case the key management service does not support the ${getKmsOperationHumanDescription(operation)}`
-      )
-    }
-
     throw new KeyManagementKeyNotFoundError(
       keyId,
-      this.keyManagementConfig.backends.map((b) => b.backend)
+      this.keyManagementConfig.backends.map((b) => b.backend),
+      operation
+        ? `The key may exist in one of the key management services in which case the key management service does not support the ${getKmsOperationHumanDescription(operation)}`
+        : undefined
     )
   }
 
@@ -332,14 +326,19 @@ export class KeyManagementApi {
    * Get the kms backend for a specific operation.
    *
    * If a backend is provided, it will be checked if the backend supports
-   * the operation. Otherwise the first backend that supports the operation
-   * will be used.
+   * the operation. Otherwise the default backend (the `defaultBackend` from
+   * the `KeyManagementModuleConfig`, or the first registered backend if no
+   * `defaultBackend` was configured) will be used if it supports the operation.
+   * If the default backend does not support the operation, the first other
+   * backend that supports the operation will be used and a warning will be logged.
    */
   private getKms(agentContext: AgentContext, backend?: string, operation?: KmsOperation) {
+    const backends = this.keyManagementConfig.backends
+
     if (backend) {
-      const kms = this.keyManagementConfig.backends.find((kms) => kms.backend === backend)
+      const kms = backends.find((kms) => kms.backend === backend)
       if (!kms) {
-        const availableBackends = this.keyManagementConfig.backends.map((kms) => `'${kms.backend}'`)
+        const availableBackends = backends.map((kms) => `'${kms.backend}'`)
         throw new KeyManagementError(
           `No key management service is configured for backend '${backend}'. Available backends are ${availableBackends.join(
             ', '
@@ -347,8 +346,7 @@ export class KeyManagementApi {
         )
       }
 
-      const isOperationSupported = operation ? kms.isOperationSupported(agentContext, operation) : true
-      if (!isOperationSupported && operation) {
+      if (operation && !kms.isOperationSupported(agentContext, operation)) {
         throw new KeyManagementError(
           `Key management service backend '${backend}' does not support ${getKmsOperationHumanDescription(operation)}`
         )
@@ -357,17 +355,23 @@ export class KeyManagementApi {
       return kms
     }
 
-    for (const kms of this.keyManagementConfig.backends) {
-      const isOperationSupported = operation ? kms.isOperationSupported(agentContext, operation) : true
-      if (isOperationSupported) return kms
-    }
+    if (backends.length > 0) {
+      const defaultKms = this.keyManagementConfig.defaultBackend
+      if (!operation || defaultKms.isOperationSupported(agentContext, operation)) return defaultKms
 
-    if (operation) {
-      throw new KeyManagementError(
-        `No key management service backend found that supports ${getKmsOperationHumanDescription(operation)}`
+      const fallbackKms = backends.find(
+        (kms) => kms !== defaultKms && kms.isOperationSupported(agentContext, operation)
       )
+
+      if (fallbackKms) {
+        return fallbackKms
+      }
     }
 
-    throw new KeyManagementError('No key management service backend found.')
+    throw new KeyManagementError(
+      operation
+        ? `No key management service backend found that supports ${getKmsOperationHumanDescription(operation)}`
+        : 'No key management service backend found.'
+    )
   }
 }

--- a/packages/core/src/modules/kms/KeyManagementModuleConfig.ts
+++ b/packages/core/src/modules/kms/KeyManagementModuleConfig.ts
@@ -45,10 +45,18 @@ export class KeyManagementModuleConfig {
     this.backends.push(backend)
   }
 
+  /**
+   * The default backend, used for operations where no explicit `backend` is provided.
+   *
+   * Returns the backend matching the `defaultBackend` identifier from the config options,
+   * or the first registered backend if no `defaultBackend` was configured.
+   */
   public get defaultBackend() {
     const backend = this.backends.find((kms) => !this.#defaultBackend || this.#defaultBackend === kms.backend)
     if (!backend) {
-      throw new KeyManagementError('Unable to determine default backend. ')
+      throw new KeyManagementError(
+        'Unable to determine default key management service backend. Make sure at least one backend is registered.'
+      )
     }
 
     return backend

--- a/packages/core/src/modules/kms/__tests__/KeyManagementBackendSelection.test.ts
+++ b/packages/core/src/modules/kms/__tests__/KeyManagementBackendSelection.test.ts
@@ -1,0 +1,77 @@
+import type { Mock } from 'vitest'
+import { vi } from 'vitest'
+import { getAgentContext } from '../../../../tests/helpers'
+import { KeyManagementApi } from '../KeyManagementApi'
+import { KeyManagementModuleConfig } from '../KeyManagementModuleConfig'
+import type { KeyManagementService } from '../KeyManagementService'
+
+const createMockBackend = (backend: string, { isOperationSupported = true }: { isOperationSupported?: boolean } = {}) =>
+  ({
+    backend,
+    isOperationSupported: vi.fn().mockReturnValue(isOperationSupported),
+    createKey: vi.fn().mockImplementation(async () => ({
+      keyId: `${backend}-key-id`,
+      publicJwk: { kty: 'EC', crv: 'P-256', x: 'x', y: 'y' },
+    })),
+  }) as unknown as KeyManagementService & { createKey: Mock; isOperationSupported: Mock }
+
+describe('KeyManagementApi backend selection', () => {
+  const agentContext = getAgentContext()
+
+  test('uses the first registered backend when no defaultBackend is configured', async () => {
+    const backend1 = createMockBackend('backend1')
+    const backend2 = createMockBackend('backend2')
+    const kms = new KeyManagementApi(new KeyManagementModuleConfig({ backends: [backend1, backend2] }), agentContext)
+
+    const key = await kms.createKey({ type: { kty: 'EC', crv: 'P-256' } })
+
+    expect(key.keyId).toEqual('backend1-key-id')
+    expect(backend1.createKey).toHaveBeenCalled()
+    expect(backend2.createKey).not.toHaveBeenCalled()
+  })
+
+  test('uses the configured defaultBackend when no explicit backend is provided', async () => {
+    const backend1 = createMockBackend('backend1')
+    const backend2 = createMockBackend('backend2')
+    const kms = new KeyManagementApi(
+      new KeyManagementModuleConfig({ backends: [backend1, backend2], defaultBackend: 'backend2' }),
+      agentContext
+    )
+
+    const key = await kms.createKey({ type: { kty: 'EC', crv: 'P-256' } })
+
+    expect(key.keyId).toEqual('backend2-key-id')
+    expect(backend2.createKey).toHaveBeenCalled()
+    expect(backend1.createKey).not.toHaveBeenCalled()
+  })
+
+  test('uses the explicitly provided backend over the configured defaultBackend', async () => {
+    const backend1 = createMockBackend('backend1')
+    const backend2 = createMockBackend('backend2')
+    const kms = new KeyManagementApi(
+      new KeyManagementModuleConfig({ backends: [backend1, backend2], defaultBackend: 'backend2' }),
+      agentContext
+    )
+
+    const key = await kms.createKey({ backend: 'backend1', type: { kty: 'EC', crv: 'P-256' } })
+
+    expect(key.keyId).toEqual('backend1-key-id')
+    expect(backend1.createKey).toHaveBeenCalled()
+    expect(backend2.createKey).not.toHaveBeenCalled()
+  })
+
+  test('falls back to another backend when the defaultBackend does not support the operation', async () => {
+    const backend1 = createMockBackend('backend1')
+    const backend2 = createMockBackend('backend2', { isOperationSupported: false })
+    const kms = new KeyManagementApi(
+      new KeyManagementModuleConfig({ backends: [backend1, backend2], defaultBackend: 'backend2' }),
+      agentContext
+    )
+
+    const key = await kms.createKey({ type: { kty: 'EC', crv: 'P-256' } })
+
+    expect(key.keyId).toEqual('backend1-key-id')
+    expect(backend1.createKey).toHaveBeenCalled()
+    expect(backend2.createKey).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/modules/kms/__tests__/KeyManagementModuleConfig.test.ts
+++ b/packages/core/src/modules/kms/__tests__/KeyManagementModuleConfig.test.ts
@@ -1,0 +1,35 @@
+import { KeyManagementError } from '../error/KeyManagementError'
+import { KeyManagementModuleConfig } from '../KeyManagementModuleConfig'
+import type { KeyManagementService } from '../KeyManagementService'
+
+const createMockBackend = (backend: string) => ({ backend }) as KeyManagementService
+
+describe('KeyManagementModuleConfig', () => {
+  test('defaultBackend returns the first registered backend when no defaultBackend is configured', () => {
+    const backend1 = createMockBackend('backend1')
+    const backend2 = createMockBackend('backend2')
+    const config = new KeyManagementModuleConfig({ backends: [backend1, backend2] })
+
+    expect(config.defaultBackend).toBe(backend1)
+  })
+
+  test('defaultBackend returns the configured defaultBackend', () => {
+    const backend1 = createMockBackend('backend1')
+    const backend2 = createMockBackend('backend2')
+    const config = new KeyManagementModuleConfig({ backends: [backend1, backend2], defaultBackend: 'backend2' })
+
+    expect(config.defaultBackend).toBe(backend2)
+  })
+
+  test('constructor throws when defaultBackend does not match a registered backend', () => {
+    expect(
+      () => new KeyManagementModuleConfig({ backends: [createMockBackend('backend1')], defaultBackend: 'backend2' })
+    ).toThrow(KeyManagementError)
+  })
+
+  test('defaultBackend throws when no backends are registered', () => {
+    const config = new KeyManagementModuleConfig({})
+
+    expect(() => config.defaultBackend).toThrow(KeyManagementError)
+  })
+})


### PR DESCRIPTION
We were not actually using the configured `defaultBackend` when finding a compatible KMS