### PR TITLE
feat(openid4vc): support updating the signed metadata signer on issuer update

### DIFF
--- a/.changeset/lucky-moons-repeat.md
+++ b/.changeset/lucky-moons-repeat.md
@@ -1,0 +1,5 @@
+---
+"@credo-ts/openid4vc": patch
+---
+
+Support configuring the signed issuer metadata signer when updating an issuer. `updateIssuerMetadata` and `updateIssuer` now accept a `metadataSigner`, which can be omitted to keep the current signer, set to a signer to enable or replace it, or set to `null` to stop signing the metadata. Previously a signer could only be configured when creating an issuer.

--- a/packages/openid4vc/src/openid4vc-issuer/OpenId4VcIssuerApi.ts
+++ b/packages/openid4vc/src/openid4vc-issuer/OpenId4VcIssuerApi.ts
@@ -7,6 +7,7 @@ import type {
   OpenId4VciCreateDeferredCredentialResponseOptions,
   OpenId4VciCreateIssuerOptions,
   OpenId4VciCreateStatelessCredentialOfferOptions,
+  OpenId4VcUpdateIssuerOptions,
   OpenId4VcUpdateIssuerRecordOptions,
 } from './OpenId4VcIssuerServiceOptions'
 import { OpenId4VcIssuerRecord } from './repository'
@@ -59,6 +60,7 @@ export class OpenId4VcIssuerApi {
       clientAttestationPopSigningAlgValuesSupported,
       batchCredentialIssuance,
       authorizationServerConfigs,
+      metadataSigner,
     } = options
 
     const issuer = await this.openId4VcIssuerService.getIssuerByIssuerId(this.agentContext, issuerId)
@@ -71,14 +73,14 @@ export class OpenId4VcIssuerApi {
     issuer.batchCredentialIssuance = batchCredentialIssuance
     issuer.authorizationServerConfigs = authorizationServerConfigs
 
-    return this.openId4VcIssuerService.updateIssuer(this.agentContext, issuer)
+    return this.openId4VcIssuerService.updateIssuer(this.agentContext, issuer, { metadataSigner })
   }
 
   /**
    * Updates an issuer and stores the corresponding updated issuer metadata.
    */
-  public async updateIssuer(issuer: OpenId4VcIssuerRecord) {
-    return this.openId4VcIssuerService.updateIssuer(this.agentContext, issuer)
+  public async updateIssuer(issuer: OpenId4VcIssuerRecord, options?: OpenId4VcUpdateIssuerOptions) {
+    return this.openId4VcIssuerService.updateIssuer(this.agentContext, issuer, options)
   }
 
   /**

--- a/packages/openid4vc/src/openid4vc-issuer/OpenId4VcIssuerService.ts
+++ b/packages/openid4vc/src/openid4vc-issuer/OpenId4VcIssuerService.ts
@@ -92,6 +92,7 @@ import type {
   OpenId4VciPreAuthorizedCodeFlowConfig,
   OpenId4VciSignCredentials,
   OpenId4VciSignW3cCredentials,
+  OpenId4VcUpdateIssuerOptions,
 } from './OpenId4VcIssuerServiceOptions'
 import {
   OpenId4VcIssuanceSessionRecord,
@@ -1234,14 +1235,30 @@ export class OpenId4VcIssuerService {
     return this.openId4VcIssuerRepository.getByIssuerId(agentContext, issuerId)
   }
 
-  public async updateIssuer(agentContext: AgentContext, issuer: OpenId4VcIssuerRecord) {
-    if (issuer.signedMetadata) {
+  public async updateIssuer(
+    agentContext: AgentContext,
+    issuer: OpenId4VcIssuerRecord,
+    options?: OpenId4VcUpdateIssuerOptions
+  ) {
+    // An explicitly provided signer takes precedence (including `null` to remove it). Otherwise the
+    // previously configured signer is reused, so the signed metadata stays in sync with the updated
+    // issuer metadata.
+    const metadataSigner =
+      options?.metadataSigner !== undefined
+        ? options.metadataSigner
+        : issuer.signedMetadata
+          ? decodeJwtIssuer(issuer.signedMetadata.signer)
+          : undefined
+
+    if (metadataSigner) {
       const issuerMetadata = await this.getIssuerMetadata(agentContext, issuer, false)
       issuer.signedMetadata = await this.createSignedMetadata(
         agentContext,
         issuerMetadata.credentialIssuer,
-        decodeJwtIssuer(issuer.signedMetadata.signer)
+        metadataSigner
       )
+    } else {
+      issuer.signedMetadata = undefined
     }
 
     await this.openId4VcIssuerRepository.update(agentContext, issuer)

--- a/packages/openid4vc/src/openid4vc-issuer/OpenId4VcIssuerServiceOptions.ts
+++ b/packages/openid4vc/src/openid4vc-issuer/OpenId4VcIssuerServiceOptions.ts
@@ -749,6 +749,21 @@ export type OpenId4VciCreateIssuerOptions = {
   metadataSigner?: OpenId4VcJwtIssuer
 }
 
+export interface OpenId4VcUpdateIssuerOptions {
+  /**
+   * Configures signing of the issuer metadata, allowing wallets to fetch signed metadata.
+   *
+   * - When omitted, the previously configured signer (if any) is kept. The signed metadata is
+   *   always re-signed, so it stays in sync with the updated issuer metadata.
+   * - When `null`, a previously configured signer is removed and the metadata is no longer signed.
+   * - When a signer is provided, signed metadata is enabled, or the previously configured signer
+   *   is replaced.
+   *
+   * See {@link OpenId4VciCreateIssuerOptions.metadataSigner} for the signing behaviour.
+   */
+  metadataSigner?: OpenId4VcJwtIssuer | null
+}
+
 export type OpenId4VcUpdateIssuerRecordOptions = Pick<
   OpenId4VcIssuerRecordProps,
   | 'issuerId'
@@ -759,4 +774,5 @@ export type OpenId4VcUpdateIssuerRecordOptions = Pick<
   | 'credentialConfigurationsSupported'
   | 'batchCredentialIssuance'
   | 'authorizationServerConfigs'
->
+> &
+  OpenId4VcUpdateIssuerOptions

--- a/packages/openid4vc/src/openid4vc-issuer/__tests__/openid4vc-issuer.test.ts
+++ b/packages/openid4vc/src/openid4vc-issuer/__tests__/openid4vc-issuer.test.ts
@@ -15,7 +15,9 @@ import {
   equalsIgnoreOrder,
   JsonTransformer,
   JwsService,
+  Jwt,
   JwtPayload,
+  Kms,
   RecordNotFoundError,
   SdJwtVcApi,
   TypedArrayEncoder,
@@ -1130,5 +1132,93 @@ describe('OpenId4VcIssuer', () => {
     await expect(issuer.openid4vc.issuer.deleteIssuanceSessionById('non-existent-id')).rejects.toThrow(
       RecordNotFoundError
     )
+  })
+
+  it('configures, keeps in sync and removes the signed metadata signer', async () => {
+    const metadataSigner = { method: 'did', didUrl: issuerVerificationMethod.id } as const
+    const credentialConfigurationsSupported = { openBadgeCredential }
+
+    // Metadata is not signed by default
+    expect(openId4VcIssuer.signedMetadata).toBeUndefined()
+
+    // A signer can be configured on an already existing issuer
+    await issuer.openid4vc.issuer.updateIssuerMetadata({
+      issuerId: openId4VcIssuer.issuerId,
+      credentialConfigurationsSupported,
+      display: [{ name: 'Initial issuer' }],
+      metadataSigner,
+    })
+
+    const enabled = await issuer.openid4vc.issuer.getIssuerByIssuerId(openId4VcIssuer.issuerId)
+    expect(enabled.signedMetadata?.signer).toEqual(metadataSigner)
+    expect(Jwt.fromSerializedJwt(enabled.signedMetadata?.jwt as string).payload.additionalClaims.display).toMatchObject(
+      [{ name: 'Initial issuer' }]
+    )
+
+    // Omitting the signer keeps it configured, and the metadata is re-signed so the signed
+    // metadata stays in sync with the updated issuer metadata
+    await issuer.openid4vc.issuer.updateIssuerMetadata({
+      issuerId: openId4VcIssuer.issuerId,
+      credentialConfigurationsSupported,
+      display: [{ name: 'Updated issuer' }],
+    })
+
+    const kept = await issuer.openid4vc.issuer.getIssuerByIssuerId(openId4VcIssuer.issuerId)
+    expect(kept.signedMetadata?.signer).toEqual(metadataSigner)
+    expect(Jwt.fromSerializedJwt(kept.signedMetadata?.jwt as string).payload.additionalClaims.display).toMatchObject([
+      { name: 'Updated issuer' },
+    ])
+
+    // Passing null removes the signer, so the metadata is no longer signed
+    await issuer.openid4vc.issuer.updateIssuerMetadata({
+      issuerId: openId4VcIssuer.issuerId,
+      credentialConfigurationsSupported,
+      display: [{ name: 'Updated issuer' }],
+      metadataSigner: null,
+    })
+
+    const removed = await issuer.openid4vc.issuer.getIssuerByIssuerId(openId4VcIssuer.issuerId)
+    expect(removed.signedMetadata).toBeUndefined()
+    expect(
+      (await issuer.openid4vc.issuer.getIssuerMetadata(openId4VcIssuer.issuerId)).signedMetadataJwt
+    ).toBeUndefined()
+  })
+
+  it('re-signs the metadata with a stored x5c signer', async () => {
+    const credentialConfigurationsSupported = { openBadgeCredential }
+
+    const key = await issuer.kms.createKey({ type: { crv: 'P-256', kty: 'EC' } })
+    const certificate = await issuer.x509.createCertificate({
+      authorityKey: Kms.PublicJwk.fromPublicJwk(key.publicJwk),
+      issuer: 'C=NL',
+    })
+    // The leaf needs a key id so the signing key can be resolved from the KMS.
+    certificate.keyId = key.keyId
+
+    await issuer.openid4vc.issuer.updateIssuerMetadata({
+      issuerId: openId4VcIssuer.issuerId,
+      credentialConfigurationsSupported,
+      display: [{ name: 'Initial issuer' }],
+      metadataSigner: { method: 'x5c', x5c: [certificate] },
+    })
+
+    const enabled = await issuer.openid4vc.issuer.getIssuerByIssuerId(openId4VcIssuer.issuerId)
+    expect(enabled.signedMetadata?.signer).toMatchObject({ method: 'x5c', leafCertificateKeyId: key.keyId })
+
+    // Updating without a signer re-signs using the stored one. Unlike a did signer, an x5c signer
+    // has to survive a full encode/decode round trip (certificates rebuilt from base64, and the
+    // leaf key id restored), so this would fail to sign if that round trip lost the key id.
+    await issuer.openid4vc.issuer.updateIssuerMetadata({
+      issuerId: openId4VcIssuer.issuerId,
+      credentialConfigurationsSupported,
+      display: [{ name: 'Updated issuer' }],
+    })
+
+    const kept = await issuer.openid4vc.issuer.getIssuerByIssuerId(openId4VcIssuer.issuerId)
+    expect(kept.signedMetadata?.signer).toMatchObject({ method: 'x5c', leafCertificateKeyId: key.keyId })
+
+    const jwt = Jwt.fromSerializedJwt(kept.signedMetadata?.jwt as string)
+    expect(jwt.header.x5c).toEqual([certificate.toString('base64')])
+    expect(jwt.payload.additionalClaims.display).toMatchObject([{ name: 'Updated issuer' }])
   })
 })


### PR DESCRIPTION
Allow configuring, replacing, or removing the metadata signer when updating an existing issuer. When the signer is omitted, the previously configured signer is preserved and the signed metadata is re-signed to stay in sync with updated issuer metadata. Passing `null` explicitly removes the signer.

- Add `OpenId4VcUpdateIssuerOptions` with optional `metadataSigner`
- Thread the new options through `updateIssuerMetadata` and `updateIssuer`
- Re-sign metadata automatically using the stored signer on updates
- Add tests for the configure → keep-in-sync → remove lifecycle
- Add test for x5c signer round-trip (encode/decode with key id)

Signed-off-by: Ilias Elbarnoussi <ilias@animo.id>
