### PR TITLE
feat(openid4vc): allow supplying the issuance session id for dynamic issuance

### DIFF
--- a/.changeset/dynamic-issuance-session-id.md
+++ b/.changeset/dynamic-issuance-session-id.md
@@ -1,0 +1,5 @@
+---
+"@credo-ts/openid4vc": patch
+---
+
+Allow the `getDynamicIssuanceSession` callback to supply the `id` of the issuance session to create. A dynamic issuance session is created after the callback returns, so the callback could not previously know the id of the session it just authorized. Supplying it lets an external system reference the session before it exists, for example to record it in its own database while handling the same request. When omitted a random id is generated, as before.

--- a/packages/openid4vc/src/openid4vc-issuer/OpenId4VcIssuerService.ts
+++ b/packages/openid4vc/src/openid4vc-issuer/OpenId4VcIssuerService.ts
@@ -521,6 +521,9 @@ export class OpenId4VcIssuerService {
         : sessionOptions
 
     const issuanceSession = new OpenId4VcIssuanceSessionRecord({
+      // Optional: allows the `getDynamicIssuanceSession` callback to bind the session to an id it
+      // generated itself, as it cannot otherwise know the id of the session it just authorized.
+      id: sessionOptions.id,
       createdAt,
       expiresAt,
       issuerId: issuer.issuerId,

--- a/packages/openid4vc/src/openid4vc-issuer/OpenId4VcIssuerServiceOptions.ts
+++ b/packages/openid4vc/src/openid4vc-issuer/OpenId4VcIssuerServiceOptions.ts
@@ -281,6 +281,18 @@ export type OpenId4VciDynamicIssuanceAuthorizationFlow = 'chained' | 'presentati
 
 interface OpenId4VciDynamicIssuanceSessionOptionsBase {
   /**
+   * The id to create the issuance session record with. If not provided, a random id is generated.
+   *
+   * A dynamic issuance session is created by Credo *after* the `getDynamicIssuanceSession` callback
+   * returns, so the callback cannot otherwise know the id of the session it just authorized.
+   * Supplying the id here lets an external system reference the session before it exists, for
+   * example to record it in its own database as part of handling the same request.
+   *
+   * Must be unique. Reusing the id of an existing issuance session overwrites that session.
+   */
+  id?: string
+
+  /**
    * The ids of the credential configurations to bind to this issuance session. All ids must be
    * part of the `credentialConfigurationsSupported` of the issuer.
    */

--- a/packages/openid4vc/tests/openid4vci-wallet-initiated.e2e.test.ts
+++ b/packages/openid4vc/tests/openid4vci-wallet-initiated.e2e.test.ts
@@ -288,6 +288,11 @@ describe('OpenId4Vc (Wallet Initiated Issuance)', () => {
     const idpClientSecret = 'bar'
     const walletClientId = 'wallet'
 
+    // The callback runs before the issuance session exists, so it cannot otherwise know the id of
+    // the session it just authorized. Supplying one lets it reference the session up front, for
+    // example to record it in an external system as part of handling the same request.
+    const issuanceSessionId = randomUUID()
+
     const getDynamicIssuanceSession: OpenId4VciGetDynamicIssuanceSession = async ({
       requestedScopes,
       requestedCredentialConfigurations,
@@ -297,6 +302,7 @@ describe('OpenId4Vc (Wallet Initiated Issuance)', () => {
       expect(supportedAuthorizationFlows).toContain('chained')
 
       return {
+        id: issuanceSessionId,
         authorizationFlow: 'chained',
         authorizationServerUrl: 'http://localhost:4747',
         credentialConfigurationIds: Object.keys(requestedCredentialConfigurations),
@@ -362,9 +368,12 @@ describe('OpenId4Vc (Wallet Initiated Issuance)', () => {
       clientId: walletClientId,
     })
 
+    // Filtering on the id the callback supplied also asserts it was actually used for the session:
+    // had it been ignored, the session would carry a generated id and this would time out.
     await waitForCredentialIssuanceSessionRecordSubject(issuer.replaySubject, {
       state: OpenId4VcIssuanceSessionState.Completed,
       contextCorrelationId: issuerTenant.context.contextCorrelationId,
+      issuanceSessionId,
     })
 
     expect(credentialResponse.credentials).toHaveLength(1)


### PR DESCRIPTION
Adds an optional `id` to the options returned by `getDynamicIssuanceSession`, letting the callback determine the id of the issuance session that is about to be created. Dynamic issuance sessions are only created after the callback returns, so this id was previously unknowable at that point. Omitting the field keeps the current behaviour of generating a random one.

Signed-off-by: Ilias Elbarnoussi <ilias@animo.id>
