### PR TITLE
fix(openid4vc): allow a DPoP key that differs from the client attestation confirmation key

### DIFF
--- a/.changeset/client-attestation-separate-dpop-key.md
+++ b/.changeset/client-attestation-separate-dpop-key.md
@@ -1,0 +1,5 @@
+---
+"@credo-ts/openid4vc": patch
+---
+
+Don't require the DPoP proof to use the client attestation confirmation key at the pushed authorization request and authorization challenge endpoints. Per the attestation-based client authentication draft, the DPoP key and the client instance key only have to be the same for the `attest_jwt_client_auth_dpop` method (DPoP combined mode), where a single DPoP proof replaces the client attestation PoP JWT. When the dedicated `OAuth-Client-Attestation-PoP` header is present, the DPoP proof is validated according to RFC 9449 independently, and its public key is not required to match the `cnf` claim of the client attestation. The issuer wrongly enforced key equality for both methods, rejecting interoperable wallets that use a separate DPoP key. Key equality for the DPoP-bound method at the token endpoint is unaffected.

--- a/packages/openid4vc/src/openid4vc-issuer/router/accessTokenEndpoint.ts
+++ b/packages/openid4vc/src/openid4vc-issuer/router/accessTokenEndpoint.ts
@@ -138,8 +138,9 @@ export function handleTokenRequest(config: OpenId4VcIssuerModuleConfig) {
             // First session config, fall back to global config
             required: issuanceSession.walletAttestation?.required ?? config.walletAttestationsRequired,
 
-            // NOTE: we might want to enforce this? Not sure
-            // ensureConfirmationKeyMatchesDpopKey: true
+            // NOTE: `ensureConfirmationKeyMatchesDpopKey` is intentionally not enabled. Per draft §7.2 a request
+            // with an `OAuth-Client-Attestation-PoP` header has its DPoP proof verified per RFC 9449
+            // independently. The library enforces key equality itself for DPoP combined mode (§7.3).
           },
           dpop: {
             ...dpop,
@@ -182,8 +183,9 @@ export function handleTokenRequest(config: OpenId4VcIssuerModuleConfig) {
             // set required to true previously if client attestations were provided or required.
             required: issuanceSession.walletAttestation?.required,
 
-            // NOTE: we might want to enforce this? Not sure
-            // ensureConfirmationKeyMatchesDpopKey: true
+            // NOTE: `ensureConfirmationKeyMatchesDpopKey` is intentionally not enabled. Per draft §7.2 a request
+            // with an `OAuth-Client-Attestation-PoP` header has its DPoP proof verified per RFC 9449
+            // independently. The library enforces key equality itself for DPoP combined mode (§7.3).
           },
           dpop: {
             ...dpop,
@@ -219,8 +221,9 @@ export function handleTokenRequest(config: OpenId4VcIssuerModuleConfig) {
             // First session config, fall back to global config
             required: issuanceSession.walletAttestation?.required ?? config.walletAttestationsRequired,
 
-            // NOTE: we might want to enforce this? Not sure
-            // ensureConfirmationKeyMatchesDpopKey: true
+            // NOTE: `ensureConfirmationKeyMatchesDpopKey` is intentionally not enabled. Per draft §7.2 a request
+            // with an `OAuth-Client-Attestation-PoP` header has its DPoP proof verified per RFC 9449
+            // independently. The library enforces key equality itself for DPoP combined mode (§7.3).
           },
           dpop: {
             ...dpop,

--- a/packages/openid4vc/src/openid4vc-issuer/router/authorizationChallengeEndpoint.ts
+++ b/packages/openid4vc/src/openid4vc-issuer/router/authorizationChallengeEndpoint.ts
@@ -248,9 +248,8 @@ async function handleAuthorizationChallengeNoAuthSession(options: {
       ...parseResult.clientAttestation,
       // First session config, fall back to global config
       required: issuanceSession.walletAttestation?.required ?? config.walletAttestationsRequired,
-      // draft 09 §5.2: when a client attestation is presented alongside DPoP, the DPoP key must be the
-      // attestation's confirmation key, so the DPoP-bound method can be used at the token endpoint.
-      ensureConfirmationKeyMatchesDpopKey: true,
+      // NOTE: `ensureConfirmationKeyMatchesDpopKey` is intentionally not set. Per draft §7.2/§7.3 the DPoP key
+      // only has to match the attestation `cnf.jwk` in DPoP combined mode, which this endpoint doesn't support.
     },
     dpop: {
       ...parseResult.dpop,
@@ -405,9 +404,8 @@ async function handleAuthorizationChallengeWithAuthSession(options: {
       // We only look at the issuance session here. If it is required
       // it will be defined on the issuance session now.
       required: issuanceSession.walletAttestation?.required,
-      // draft 09 §5.2: when a client attestation is presented alongside DPoP, the DPoP key must be the
-      // attestation's confirmation key, so the DPoP-bound method can be used at the token endpoint.
-      ensureConfirmationKeyMatchesDpopKey: true,
+      // NOTE: `ensureConfirmationKeyMatchesDpopKey` is intentionally not set. Per draft §7.2/§7.3 the DPoP key
+      // only has to match the attestation `cnf.jwk` in DPoP combined mode, which this endpoint doesn't support.
     },
     dpop: {
       ...parseResult.dpop,

--- a/packages/openid4vc/src/openid4vc-issuer/router/pushedAuthorizationRequestEndpoint.ts
+++ b/packages/openid4vc/src/openid4vc-issuer/router/pushedAuthorizationRequestEndpoint.ts
@@ -94,10 +94,8 @@ export async function handlePushedAuthorizationRequest(
       ...parsedAuthorizationRequest.clientAttestation,
       // First session config, fall back to global config
       required: issuanceSession.walletAttestation?.required ?? config.walletAttestationsRequired,
-      // draft 09 §5.2: bind the interaction to the client instance key. When a client attestation is
-      // presented alongside DPoP, the DPoP key must be the attestation's confirmation key, so the
-      // DPoP-bound method can be used consistently at the token endpoint.
-      ensureConfirmationKeyMatchesDpopKey: true,
+      // NOTE: `ensureConfirmationKeyMatchesDpopKey` is intentionally not set. Per draft §7.2/§7.3 the DPoP key
+      // only has to match the attestation `cnf.jwk` in DPoP combined mode, which this endpoint doesn't support.
     },
     dpop: {
       ...parsedAuthorizationRequest.dpop,

--- a/packages/openid4vc/tests/openid4vc-wallet-key-attestation.e2e.test.ts
+++ b/packages/openid4vc/tests/openid4vc-wallet-key-attestation.e2e.test.ts
@@ -1,5 +1,5 @@
 import { CredoError, Kms, Mdoc, MdocRecord, SdJwtVcRecord, utils } from '@credo-ts/core'
-import type { Jwk } from '@openid4vc/oauth2'
+import type { AuthorizationServerMetadata, Jwk } from '@openid4vc/oauth2'
 import { AuthorizationFlow, Openid4vciWalletProvider } from '@openid4vc/openid4vci'
 import express, { type Express } from 'express'
 import { InMemoryWalletModule } from '../../../tests/InMemoryWalletModule'
@@ -11,6 +11,7 @@ import {
   OpenId4VcIssuerService,
   type OpenId4VciCredentialConfigurationSupportedWithFormats,
   OpenId4VciCredentialFormatProfile,
+  OpenId4VciHolderService,
   OpenId4VciKeyAttestationLevel,
   OpenId4VcModule,
   type OpenId4VcVerifierModuleConfigOptions,
@@ -73,6 +74,7 @@ const universityDegreeModerateCredentialConfigurationSupportedMdoc = {
 const baseUrl = 'http://localhost:3991'
 const issuerBaseUrl = `${baseUrl}/oid4vci`
 const verifierBaseUrl = `${baseUrl}/oid4vp`
+const externalAuthorizationServerUrl = 'http://localhost:3992'
 let generateKeyAttestation: (
   nonce?: string,
   levels?: {
@@ -634,6 +636,186 @@ describe('OpenId4Vc Wallet and Key Attestations', () => {
 
     expect(credentialResponse.credentials).toHaveLength(1)
     expect(credentialResponse.credentials[0].record.credentialInstances).toHaveLength(10)
+  })
+
+  it('e2e flow with presentation during issuance where the DPoP key differs from the client attestation confirmation key', async () => {
+    // Create offer for university degree
+    const { issuanceSession, credentialOffer } = await issuer.agent.openid4vc.issuer.createCredentialOffer({
+      issuerId: issuerRecord.issuerId,
+      credentialConfigurationIds: ['universityDegree'],
+      authorizationCodeFlowConfig: {
+        requirePresentationDuringIssuance: true,
+      },
+
+      // Require DPoP and wallet attestations
+      authorization: {
+        requireDpop: true,
+        requireWalletAttestation: true,
+      },
+    })
+
+    // Resolve offer
+    const resolvedCredentialOffer = await holder.agent.openid4vc.holder.resolveCredentialOffer(credentialOffer)
+
+    // Force the standard `attest_jwt_client_auth` method with a DPoP key that is NOT the client instance key.
+    // Per draft §7.2 the DPoP proof must then be verified per RFC 9449 independently of the client attestation,
+    // so the issuer must not require it to match the attestation's `cnf.jwk`.
+    const holderService = holder.agent.dependencyManager.resolve(OpenId4VciHolderService)
+    // biome-ignore lint/suspicious/noExplicitAny: spying on a private method
+    vi.spyOn(holderService as any, 'getDpopBoundClientAttestationKey').mockReturnValue(undefined)
+
+    const resolvedAuthorizationRequest = await holder.agent.openid4vc.holder.resolveOpenId4VciAuthorizationRequest(
+      resolvedCredentialOffer,
+      {
+        clientId: 'wallet',
+        redirectUri: 'http://localhost/callback',
+        walletAttestationJwt,
+      }
+    )
+
+    expect(resolvedAuthorizationRequest.dpop?.jwk.fingerprint).not.toEqual(walletInstanceKey.fingerprint)
+
+    if (resolvedAuthorizationRequest.authorizationFlow !== AuthorizationFlow.PresentationDuringIssuance) {
+      throw new Error('expected presentation during issuance')
+    }
+
+    const resolvedPresentationRequest = await holder.agent.openid4vc.holder.resolveOpenId4VpAuthorizationRequest(
+      resolvedAuthorizationRequest.openid4vpRequestUrl
+    )
+    if (!resolvedPresentationRequest.dcql) {
+      throw new Error('Missing dcql')
+    }
+
+    // Submit presentation
+    const selectedCredentials = holder.agent.openid4vc.holder.selectCredentialsForDcqlRequest(
+      resolvedPresentationRequest.dcql.queryResult
+    )
+    const openId4VpResult = await holder.agent.openid4vc.holder.acceptOpenId4VpAuthorizationRequest({
+      authorizationRequestPayload: resolvedPresentationRequest.authorizationRequestPayload,
+      dcql: {
+        credentials: selectedCredentials,
+      },
+    })
+    if (!openId4VpResult.ok) {
+      throw new Error('not ok')
+    }
+
+    // Request authorization code
+    const { authorizationCode, dpop } = await holder.agent.openid4vc.holder.retrieveAuthorizationCodeUsingPresentation({
+      authSession: resolvedAuthorizationRequest.authSession,
+      resolvedCredentialOffer,
+      presentationDuringIssuanceSession: openId4VpResult.presentationDuringIssuanceSession,
+      dpop: resolvedAuthorizationRequest.dpop,
+      walletAttestationJwt,
+    })
+
+    // Request access token
+    const tokenResponse = await holder.agent.openid4vc.holder.requestToken({
+      resolvedCredentialOffer,
+      code: authorizationCode,
+      dpop,
+      walletAttestationJwt,
+      clientId: 'wallet',
+    })
+
+    // The access token is bound to the separate DPoP key, not to the wallet attestation `cnf.jwk`.
+    expect(tokenResponse.dpop?.jwk.fingerprint).toEqual(resolvedAuthorizationRequest.dpop?.jwk.fingerprint)
+
+    // Request credentials
+    const credentialResponse = await holder.agent.openid4vc.holder.requestCredentials({
+      resolvedCredentialOffer,
+      clientId: 'wallet',
+      ...tokenResponse,
+      credentialBindingResolver: async () => ({
+        method: 'attestation',
+        keyAttestationJwt: await generateKeyAttestation(),
+      }),
+    })
+
+    await waitForCredentialIssuanceSessionRecordSubject(issuer.replaySubject, {
+      state: OpenId4VcIssuanceSessionState.Completed,
+      issuanceSessionId: issuanceSession.id,
+    })
+
+    expect(credentialResponse.credentials).toHaveLength(1)
+  })
+
+  it('pushed authorization request accepts a DPoP key that differs from the client attestation confirmation key', async () => {
+    // Minimal external authorization server. The client attestation and DPoP verification in the pushed
+    // authorization request happens before any interaction with it, and building the authorization request
+    // url does not require any further requests, so only the metadata endpoint is needed.
+    const idpApp = express()
+    idpApp.get('/.well-known/oauth-authorization-server', (_req, res) =>
+      res.json({
+        issuer: externalAuthorizationServerUrl,
+        token_endpoint: `${externalAuthorizationServerUrl}/token`,
+        authorization_endpoint: `${externalAuthorizationServerUrl}/authorize`,
+      } satisfies AuthorizationServerMetadata)
+    )
+    const clearIdpNock = setupNockToExpress(externalAuthorizationServerUrl, idpApp)
+
+    try {
+      const chainedIssuerRecord = await issuer.agent.openid4vc.issuer.createIssuer({
+        issuerId: 'f8b7b4c4-6a3e-4a19-9c6a-1d0c5f2b1e34',
+        dpopSigningAlgValuesSupported: [Kms.KnownJwaSignatureAlgorithms.ES256],
+        clientAttestationSigningAlgValuesSupported: [Kms.KnownJwaSignatureAlgorithms.ES256],
+        clientAttestationPopSigningAlgValuesSupported: [Kms.KnownJwaSignatureAlgorithms.ES256],
+        credentialConfigurationsSupported: {
+          universityDegree: universityDegreeCredentialConfigurationSupportedMdoc,
+        },
+        authorizationServerConfigs: [
+          {
+            type: 'chained',
+            issuer: externalAuthorizationServerUrl,
+            clientAuthentication: {
+              type: 'clientSecret',
+              clientId: 'issuer-client-id',
+              clientSecret: 'issuer-client-secret',
+            },
+            scopesMapping: {
+              [universityDegreeCredentialConfigurationSupportedMdoc.scope]: ['MappedUniversityDegreeCredential'],
+            },
+          },
+        ],
+      })
+
+      const { credentialOffer } = await issuer.agent.openid4vc.issuer.createCredentialOffer({
+        issuerId: chainedIssuerRecord.issuerId,
+        credentialConfigurationIds: ['universityDegree'],
+        authorizationCodeFlowConfig: {
+          authorizationServerUrl: externalAuthorizationServerUrl,
+          issuerState: utils.uuid(),
+        },
+
+        // Require DPoP and wallet attestations
+        authorization: {
+          requireDpop: true,
+          requireWalletAttestation: true,
+        },
+      })
+
+      const resolvedCredentialOffer = await holder.agent.openid4vc.holder.resolveCredentialOffer(credentialOffer)
+
+      // Force the standard `attest_jwt_client_auth` method with a DPoP key that is NOT the client instance key.
+      const holderService = holder.agent.dependencyManager.resolve(OpenId4VciHolderService)
+      // biome-ignore lint/suspicious/noExplicitAny: spying on a private method
+      vi.spyOn(holderService as any, 'getDpopBoundClientAttestationKey').mockReturnValue(undefined)
+
+      const resolvedAuthorizationRequest = await holder.agent.openid4vc.holder.resolveOpenId4VciAuthorizationRequest(
+        resolvedCredentialOffer,
+        {
+          clientId: 'wallet',
+          redirectUri: 'http://localhost/callback',
+          scope: [universityDegreeCredentialConfigurationSupportedMdoc.scope],
+          walletAttestationJwt,
+        }
+      )
+
+      expect(resolvedAuthorizationRequest.authorizationFlow).toEqual(AuthorizationFlow.Oauth2Redirect)
+      expect(resolvedAuthorizationRequest.dpop?.jwk.fingerprint).not.toEqual(walletInstanceKey.fingerprint)
+    } finally {
+      clearIdpNock()
+    }
   })
 
   it('throws error if wallet attestation required but not provided', async () => {


### PR DESCRIPTION
Fixes #2889.

The pushed authorization request and authorization challenge endpoints passed `ensureConfirmationKeyMatchesDpopKey: true`, so a client presenting `OAuth-Client-Attestation` + `OAuth-Client-Attestation-PoP` alongside a DPoP proof signed with a separate key was rejected with `invalid_request`. That breaks any wallet keeping its client instance key separate from its DPoP key.

### Spec

The issue cites draft-10 §5.2, but the decisive text is §7.2/§7.3, which is already present in **draft-09** — the version we target:

- **§7.2** (Client Attestation PoP JWT) lists nine MUST rules for the PoP-header method; none mention the DPoP key. It opens with *"When operating in DPoP combined mode as defined in Section 5.2, this section does not apply; instead, see Section 7.3."*
- **§7.3** (DPoP Combined Mode) is where the equality MUST lives, and it opens with the mirror statement: *"When the Client Attestation PoP JWT is used as the Proof of Possession instead, this section does not apply."*

Draft-10 then makes it explicit — §7 intro: *"If the request contains an OAuth-Client-Attestation-PoP HTTP request header field, the receiving server MUST apply the validation rules of Section 7.2 and if present, a DPoP proof present in the request is validated according to [RFC9449] **independently of this specification**."* And §5.2: *"its public key is **not required to match** the key in the cnf claim"*, plus *"When using dpop_jkt, the normal mode has to be used"* — which makes combined mode inapplicable at PAR by construction.

Binding the interaction to the client instance is still achieved the way §9.4 intends: client attestation at PAR and again at the token endpoint (`issuanceSession.clientId` ← attestation `sub`, `expectedClientId`).

### Notes

- Removal rather than a conditional: `verifyAuthorizationRequestClientAttestation` in `@openid4vc/oauth2` hard-requires both the attestation and PoP JWTs, so combined mode is unreachable at these endpoints and a gated flag would be dead code. The token endpoint's combined-mode path (`verifyAccessTokenRequestClientAttestationDpop`) enforces equality itself, independent of this option — unaffected by this change.
- Second commit is comment-only: the `we might want to enforce this? Not sure` note in `accessTokenEndpoint.ts` invited reintroducing the same bug for `attest_jwt_client_auth`. Drop it if you'd rather keep the diff to the three broken call sites.

### Tests

Two e2e regression tests in `openid4vc-wallet-key-attestation.e2e.test.ts`, both forcing the standard method with a DPoP key that is not the attestation `cnf.jwk`. Existing tests never hit this because our holder reuses the instance key as its DPoP key whenever the issuer advertises `attest_jwt_client_auth_dpop`.

With the flag restored, both fail with *"Expected the DPoP JWK thumbprint value to match…"*. Reverting only the PAR site makes the second pass while the first still fails, confirming the three call sites are independently covered.
