### PR TITLE
feat(vc): support VCDM 2.0 on JSON-LD over DIDComm

### DIFF
--- a/.changeset/vcdm-2-0-json-ld.md
+++ b/.changeset/vcdm-2-0-json-ld.md
@@ -1,0 +1,16 @@
+---
+"@credo-ts/core": minor
+"@credo-ts/didcomm": minor
+---
+
+feat: support Verifiable Credentials Data Model 2.0 for JSON-LD credentials
+
+`W3cCredential` and `W3cPresentation` now accept the `https://www.w3.org/ns/credentials/v2` context in addition to `https://www.w3.org/2018/credentials/v1`, so data model 2.0 credentials can be issued and verified using Data Integrity (linked data) proofs. Previously data model 2.0 was only supported through the enveloping `W3cV2*` models (JWT and SD-JWT).
+
+- `W3cCredential` gained the data model 2.0 `validFrom` and `validUntil` properties. Which date properties are valid is now derived from the credential's base context: `issuanceDate`/`expirationDate` are required/allowed only for data model 1.1, `validFrom`/`validUntil` only for data model 2.0. `issuanceDate` is therefore no longer unconditionally required.
+- Added `credential.dataModelVersion`, plus the version-agnostic `credential.validFromDate` and `credential.validUntilDate` getters.
+- The data model 2.0 context (`https://www.w3.org/ns/credentials/v2`) is now bundled in `DEFAULT_CONTEXTS`, so it resolves without a network request.
+- `IsCredentialJsonLdContext` accepts a list of credential contexts through its `credentialContext` option.
+- Constructing a `W3cCredential` or `W3cPresentation` without an `id` no longer serializes an `id` key with an undefined value, which produced an invalid JSON-LD document.
+
+Securing a data model 2.0 credential with the data model 1.1 JWT VC envelope now throws a descriptive error pointing at `W3cV2Credential`.

--- a/packages/core/src/modules/vc/credentialContextVersion.ts
+++ b/packages/core/src/modules/vc/credentialContextVersion.ts
@@ -1,0 +1,42 @@
+import type { JsonObject } from '../../types'
+import { asArray } from '../../utils/array'
+import { CREDENTIALS_CONTEXT_V1_URL, CREDENTIALS_CONTEXT_V2_URL } from './constants'
+
+/**
+ * The Verifiable Credentials Data Model versions that can be expressed using the
+ * {@link W3cCredential} and {@link W3cPresentation} models.
+ */
+export type W3cCredentialDataModelVersion = '1.1' | '2.0'
+
+/**
+ * Credential context URLs accepted as the first entry of a credential or presentation
+ * `@context`, in order of data model version.
+ */
+export const DEFAULT_CREDENTIAL_CONTEXTS = [CREDENTIALS_CONTEXT_V1_URL, CREDENTIALS_CONTEXT_V2_URL]
+
+/**
+ * Determines the Verifiable Credentials Data Model version based on the base JSON-LD context.
+ *
+ * Both data models require the base context to be the first entry of the `@context`, which makes
+ * it the authoritative signal for the version in use.
+ *
+ * @returns the data model version, or `undefined` if the context does not start with a known base context.
+ */
+export function getCredentialContextVersion(
+  context: string | Array<string | JsonObject> | undefined
+): W3cCredentialDataModelVersion | undefined {
+  const baseContext = asArray(context ?? [])[0]
+
+  if (baseContext === CREDENTIALS_CONTEXT_V1_URL) return '1.1'
+  if (baseContext === CREDENTIALS_CONTEXT_V2_URL) return '2.0'
+
+  return undefined
+}
+
+/**
+ * Whether the provided `@context` describes a Verifiable Credentials Data Model 2.0 credential
+ * or presentation.
+ */
+export function isCredentialContextV2(context: string | Array<string | JsonObject> | undefined): boolean {
+  return getCredentialContextVersion(context) === '2.0'
+}

--- a/packages/core/src/modules/vc/index.ts
+++ b/packages/core/src/modules/vc/index.ts
@@ -1,4 +1,5 @@
 export * from './constants'
+export * from './credentialContextVersion'
 export * from './jsonld'
 export * from './jwt-vc'
 export * from './linked-data-proofs'

--- a/packages/core/src/modules/vc/jsonld/contexts/credentials_v2.ts
+++ b/packages/core/src/modules/vc/jsonld/contexts/credentials_v2.ts
@@ -1,0 +1,302 @@
+// Verifiable Credentials Data Model v2.0 context, as published at https://www.w3.org/ns/credentials/v2
+export const CREDENTIALS_V2 = {
+  '@context': {
+    '@protected': true,
+    id: '@id',
+    type: '@type',
+    description: 'https://schema.org/description',
+    digestMultibase: {
+      '@id': 'https://w3id.org/security#digestMultibase',
+      '@type': 'https://w3id.org/security#multibase',
+    },
+    digestSRI: {
+      '@id': 'https://www.w3.org/2018/credentials#digestSRI',
+      '@type': 'https://www.w3.org/2018/credentials#sriString',
+    },
+    mediaType: {
+      '@id': 'https://schema.org/encodingFormat',
+    },
+    name: 'https://schema.org/name',
+    VerifiableCredential: {
+      '@id': 'https://www.w3.org/2018/credentials#VerifiableCredential',
+      '@context': {
+        '@protected': true,
+        id: '@id',
+        type: '@type',
+        confidenceMethod: {
+          '@id': 'https://www.w3.org/2018/credentials#confidenceMethod',
+          '@type': '@id',
+        },
+        credentialSchema: {
+          '@id': 'https://www.w3.org/2018/credentials#credentialSchema',
+          '@type': '@id',
+        },
+        credentialStatus: {
+          '@id': 'https://www.w3.org/2018/credentials#credentialStatus',
+          '@type': '@id',
+        },
+        credentialSubject: {
+          '@id': 'https://www.w3.org/2018/credentials#credentialSubject',
+          '@type': '@id',
+        },
+        description: 'https://schema.org/description',
+        evidence: {
+          '@id': 'https://www.w3.org/2018/credentials#evidence',
+          '@type': '@id',
+        },
+        issuer: {
+          '@id': 'https://www.w3.org/2018/credentials#issuer',
+          '@type': '@id',
+        },
+        name: 'https://schema.org/name',
+        proof: {
+          '@id': 'https://w3id.org/security#proof',
+          '@type': '@id',
+          '@container': '@graph',
+        },
+        refreshService: {
+          '@id': 'https://www.w3.org/2018/credentials#refreshService',
+          '@type': '@id',
+        },
+        relatedResource: {
+          '@id': 'https://www.w3.org/2018/credentials#relatedResource',
+          '@type': '@id',
+        },
+        renderMethod: {
+          '@id': 'https://www.w3.org/2018/credentials#renderMethod',
+          '@type': '@id',
+        },
+        termsOfUse: {
+          '@id': 'https://www.w3.org/2018/credentials#termsOfUse',
+          '@type': '@id',
+        },
+        validFrom: {
+          '@id': 'https://www.w3.org/2018/credentials#validFrom',
+          '@type': 'http://www.w3.org/2001/XMLSchema#dateTime',
+        },
+        validUntil: {
+          '@id': 'https://www.w3.org/2018/credentials#validUntil',
+          '@type': 'http://www.w3.org/2001/XMLSchema#dateTime',
+        },
+      },
+    },
+    EnvelopedVerifiableCredential: 'https://www.w3.org/2018/credentials#EnvelopedVerifiableCredential',
+    VerifiablePresentation: {
+      '@id': 'https://www.w3.org/2018/credentials#VerifiablePresentation',
+      '@context': {
+        '@protected': true,
+        id: '@id',
+        type: '@type',
+        holder: {
+          '@id': 'https://www.w3.org/2018/credentials#holder',
+          '@type': '@id',
+        },
+        proof: {
+          '@id': 'https://w3id.org/security#proof',
+          '@type': '@id',
+          '@container': '@graph',
+        },
+        termsOfUse: {
+          '@id': 'https://www.w3.org/2018/credentials#termsOfUse',
+          '@type': '@id',
+        },
+        verifiableCredential: {
+          '@id': 'https://www.w3.org/2018/credentials#verifiableCredential',
+          '@type': '@id',
+          '@container': '@graph',
+          '@context': null,
+        },
+      },
+    },
+    EnvelopedVerifiablePresentation: 'https://www.w3.org/2018/credentials#EnvelopedVerifiablePresentation',
+    JsonSchemaCredential: 'https://www.w3.org/2018/credentials#JsonSchemaCredential',
+    JsonSchema: {
+      '@id': 'https://www.w3.org/2018/credentials#JsonSchema',
+      '@context': {
+        '@protected': true,
+        id: '@id',
+        type: '@type',
+        jsonSchema: {
+          '@id': 'https://www.w3.org/2018/credentials#jsonSchema',
+          '@type': '@json',
+        },
+      },
+    },
+    BitstringStatusListCredential: 'https://www.w3.org/ns/credentials/status#BitstringStatusListCredential',
+    BitstringStatusList: {
+      '@id': 'https://www.w3.org/ns/credentials/status#BitstringStatusList',
+      '@context': {
+        '@protected': true,
+        id: '@id',
+        type: '@type',
+        encodedList: {
+          '@id': 'https://www.w3.org/ns/credentials/status#encodedList',
+          '@type': 'https://w3id.org/security#multibase',
+        },
+        statusPurpose: 'https://www.w3.org/ns/credentials/status#statusPurpose',
+        ttl: 'https://www.w3.org/ns/credentials/status#ttl',
+      },
+    },
+    BitstringStatusListEntry: {
+      '@id': 'https://www.w3.org/ns/credentials/status#BitstringStatusListEntry',
+      '@context': {
+        '@protected': true,
+        id: '@id',
+        type: '@type',
+        statusListCredential: {
+          '@id': 'https://www.w3.org/ns/credentials/status#statusListCredential',
+          '@type': '@id',
+        },
+        statusListIndex: 'https://www.w3.org/ns/credentials/status#statusListIndex',
+        statusPurpose: 'https://www.w3.org/ns/credentials/status#statusPurpose',
+        statusMessage: {
+          '@id': 'https://www.w3.org/ns/credentials/status#statusMessage',
+          '@context': {
+            '@protected': true,
+            id: '@id',
+            type: '@type',
+            message: 'https://www.w3.org/ns/credentials/status#message',
+            status: 'https://www.w3.org/ns/credentials/status#status',
+          },
+        },
+        statusReference: {
+          '@id': 'https://www.w3.org/ns/credentials/status#statusReference',
+          '@type': '@id',
+        },
+        statusSize: {
+          '@id': 'https://www.w3.org/ns/credentials/status#statusSize',
+          '@type': 'https://www.w3.org/2001/XMLSchema#integer',
+        },
+      },
+    },
+    DataIntegrityProof: {
+      '@id': 'https://w3id.org/security#DataIntegrityProof',
+      '@context': {
+        '@protected': true,
+        id: '@id',
+        type: '@type',
+        challenge: 'https://w3id.org/security#challenge',
+        created: {
+          '@id': 'http://purl.org/dc/terms/created',
+          '@type': 'http://www.w3.org/2001/XMLSchema#dateTime',
+        },
+        cryptosuite: {
+          '@id': 'https://w3id.org/security#cryptosuite',
+          '@type': 'https://w3id.org/security#cryptosuiteString',
+        },
+        domain: 'https://w3id.org/security#domain',
+        expires: {
+          '@id': 'https://w3id.org/security#expiration',
+          '@type': 'http://www.w3.org/2001/XMLSchema#dateTime',
+        },
+        nonce: 'https://w3id.org/security#nonce',
+        previousProof: {
+          '@id': 'https://w3id.org/security#previousProof',
+          '@type': '@id',
+        },
+        proofPurpose: {
+          '@id': 'https://w3id.org/security#proofPurpose',
+          '@type': '@vocab',
+          '@context': {
+            '@protected': true,
+            id: '@id',
+            type: '@type',
+            assertionMethod: {
+              '@id': 'https://w3id.org/security#assertionMethod',
+              '@type': '@id',
+              '@container': '@set',
+            },
+            authentication: {
+              '@id': 'https://w3id.org/security#authenticationMethod',
+              '@type': '@id',
+              '@container': '@set',
+            },
+            capabilityDelegation: {
+              '@id': 'https://w3id.org/security#capabilityDelegationMethod',
+              '@type': '@id',
+              '@container': '@set',
+            },
+            capabilityInvocation: {
+              '@id': 'https://w3id.org/security#capabilityInvocationMethod',
+              '@type': '@id',
+              '@container': '@set',
+            },
+            keyAgreement: {
+              '@id': 'https://w3id.org/security#keyAgreementMethod',
+              '@type': '@id',
+              '@container': '@set',
+            },
+          },
+        },
+        proofValue: {
+          '@id': 'https://w3id.org/security#proofValue',
+          '@type': 'https://w3id.org/security#multibase',
+        },
+        verificationMethod: {
+          '@id': 'https://w3id.org/security#verificationMethod',
+          '@type': '@id',
+        },
+      },
+    },
+    '...': {
+      '@id': 'https://www.iana.org/assignments/jwt#...',
+    },
+    _sd: {
+      '@id': 'https://www.iana.org/assignments/jwt#_sd',
+      '@type': '@json',
+    },
+    _sd_alg: {
+      '@id': 'https://www.iana.org/assignments/jwt#_sd_alg',
+    },
+    aud: {
+      '@id': 'https://www.iana.org/assignments/jwt#aud',
+      '@type': '@id',
+    },
+    cnf: {
+      '@id': 'https://www.iana.org/assignments/jwt#cnf',
+      '@context': {
+        '@protected': true,
+        kid: {
+          '@id': 'https://www.iana.org/assignments/jwt#kid',
+          '@type': '@id',
+        },
+        jwk: {
+          '@id': 'https://www.iana.org/assignments/jwt#jwk',
+          '@type': '@json',
+        },
+      },
+    },
+    exp: {
+      '@id': 'https://www.iana.org/assignments/jwt#exp',
+      '@type': 'https://www.w3.org/2001/XMLSchema#nonNegativeInteger',
+    },
+    iat: {
+      '@id': 'https://www.iana.org/assignments/jwt#iat',
+      '@type': 'https://www.w3.org/2001/XMLSchema#nonNegativeInteger',
+    },
+    iss: {
+      '@id': 'https://www.iana.org/assignments/jose#iss',
+      '@type': '@id',
+    },
+    jku: {
+      '@id': 'https://www.iana.org/assignments/jose#jku',
+      '@type': '@id',
+    },
+    kid: {
+      '@id': 'https://www.iana.org/assignments/jose#kid',
+      '@type': '@id',
+    },
+    nbf: {
+      '@id': 'https://www.iana.org/assignments/jwt#nbf',
+      '@type': 'https://www.w3.org/2001/XMLSchema#nonNegativeInteger',
+    },
+    sub: {
+      '@id': 'https://www.iana.org/assignments/jose#sub',
+      '@type': '@id',
+    },
+    x5u: {
+      '@id': 'https://www.iana.org/assignments/jose#x5u',
+      '@type': '@id',
+    },
+  },
+}

--- a/packages/core/src/modules/vc/jsonld/contexts/defaultContexts.ts
+++ b/packages/core/src/modules/vc/jsonld/contexts/defaultContexts.ts
@@ -1,4 +1,5 @@
 import { CREDENTIALS_V1 } from './credentials_v1'
+import { CREDENTIALS_V2 } from './credentials_v2'
 import { DATA_INTEGRITY_V2 } from './dataIntegrity_v2'
 import { DID_V1 } from './did_v1'
 import { ED25519_2020_V1 } from './ed25519_2020_v1'
@@ -22,6 +23,7 @@ export const DEFAULT_CONTEXTS = {
   'https://w3id.org/security/suites/ed25519-2020/v1': ED25519_2020_V1,
   'https://w3id.org/security/suites/secp256k1-2019/v1': SECP256K1_V1,
   'https://www.w3.org/2018/credentials/v1': CREDENTIALS_V1,
+  'https://www.w3.org/ns/credentials/v2': CREDENTIALS_V2,
   'https://w3id.org/did/v1': DID_V1,
   'https://www.w3.org/ns/did/v1': DID_V1,
   'https://w3.org/ns/did/v1': DID_V1,

--- a/packages/core/src/modules/vc/jwt-vc/W3cJwtVerifiableCredential.ts
+++ b/packages/core/src/modules/vc/jwt-vc/W3cJwtVerifiableCredential.ts
@@ -76,6 +76,26 @@ export class W3cJwtVerifiableCredential {
     return this.credential.expirationDate
   }
 
+  public get validFrom() {
+    return this.credential.validFrom
+  }
+
+  public get validUntil() {
+    return this.credential.validUntil
+  }
+
+  public get dataModelVersion() {
+    return this.credential.dataModelVersion
+  }
+
+  public get validFromDate() {
+    return this.credential.validFromDate
+  }
+
+  public get validUntilDate() {
+    return this.credential.validUntilDate
+  }
+
   public get credentialSubject() {
     return this.credential.credentialSubject
   }

--- a/packages/core/src/modules/vc/jwt-vc/__tests__/W3cJwtCredentialService.test.ts
+++ b/packages/core/src/modules/vc/jwt-vc/__tests__/W3cJwtCredentialService.test.ts
@@ -168,7 +168,7 @@ describe('W3cJwtCredentialService', () => {
           format: ClaimFormat.JwtVc,
         })
       ).rejects.toThrow(
-        'property issuanceDate has failed the following constraints: issuanceDate must be RFC 3339 date'
+        'property issuanceDate has failed the following constraints: issuanceDate is only defined by the Verifiable Credentials Data Model 1.1 context'
       )
 
       // Throw when verificationMethod id does not exist in did document

--- a/packages/core/src/modules/vc/jwt-vc/credentialTransformer.ts
+++ b/packages/core/src/modules/vc/jwt-vc/credentialTransformer.ts
@@ -17,8 +17,14 @@ export function getJwtPayloadFromCredential(credential: W3cCredential) {
     },
   }
 
+  if (credential.dataModelVersion === '2.0') {
+    throw new CredoError(
+      'Verifiable Credentials Data Model 2.0 credentials cannot be secured using the JWT VC (data model 1.1) envelope. Use W3cV2Credential with the JWT or SD-JWT format instead.'
+    )
+  }
+
   // Extract `nbf` and remove issuance date from vc
-  const issuanceDate = Date.parse(credential.issuanceDate)
+  const issuanceDate = Date.parse(credential.issuanceDate as string)
   if (Number.isNaN(issuanceDate)) {
     throw new CredoError('JWT VCs must have a valid issuance date')
   }

--- a/packages/core/src/modules/vc/linked-data-proofs/__tests__/W3cJsonLdCredentialService.test.ts
+++ b/packages/core/src/modules/vc/linked-data-proofs/__tests__/W3cJsonLdCredentialService.test.ts
@@ -18,6 +18,8 @@ import {
   VERIFICATION_METHOD_TYPE_ED25519_VERIFICATION_KEY_2020,
 } from '../../../dids'
 import { Ed25519PublicJwk, KeyManagementApi, PublicJwk } from '../../../kms'
+import { CREDENTIALS_CONTEXT_V2_URL } from '../../constants'
+import { DEFAULT_CONTEXTS } from '../../jsonld/contexts'
 import { ClaimFormat, W3cCredential } from '../../models'
 import { W3cPresentation } from '../../models/presentation/W3cPresentation'
 import { W3cCredentialsModuleConfig } from '../../W3cCredentialsModuleConfig'
@@ -27,7 +29,7 @@ import { W3cJsonLdVerifiableCredential } from '../models/W3cJsonLdVerifiableCred
 import { W3cJsonLdVerifiablePresentation } from '../models/W3cJsonLdVerifiablePresentation'
 import { CredentialIssuancePurpose } from '../proof-purposes/CredentialIssuancePurpose'
 import { SignatureSuiteRegistry } from '../SignatureSuiteRegistry'
-import { Ed25519Signature2018 } from '../signature-suites'
+import { Ed25519Signature2018, Ed25519Signature2020 } from '../signature-suites'
 import { W3cJsonLdCredentialService } from '../W3cJsonLdCredentialService'
 import { customDocumentLoader } from './documentLoader'
 import { Ed25519Signature2018Fixtures } from './fixtures'
@@ -578,6 +580,115 @@ describe('W3cJsonLdCredentialsService', () => {
           isValid: true,
           validations: { credentialSubjectAuthentication: { isValid: true } },
         })
+      })
+    })
+
+    describe('Verifiable Credentials Data Model 2.0', () => {
+      const createV2Credential = (extra: Record<string, unknown> = {}) =>
+        new W3cCredential({
+          context: [CREDENTIALS_CONTEXT_V2_URL],
+          id: 'urn:uuid:8f1f1e3a-4f52-4a5a-9d2b-8f2a0c1a1d11',
+          type: ['VerifiableCredential'],
+          issuer: issuerDidKey.did,
+          validFrom: '2010-01-01T19:23:24Z',
+          validUntil: '2030-01-01T19:23:24Z',
+          credentialSubject: { id: 'did:example:ebfeb1f712ebc6f1c276e12ec21' },
+          ...extra,
+        })
+
+      it('signs and verifies a credential using the data model 2.0 context', async () => {
+        const vc = await w3cJsonLdCredentialService.signCredential(agentContext, {
+          format: ClaimFormat.LdpVc,
+          credential: createV2Credential(),
+          proofType: 'Ed25519Signature2018',
+          verificationMethod,
+        })
+
+        expect(vc).toBeInstanceOf(W3cJsonLdVerifiableCredential)
+        expect(vc.dataModelVersion).toBe('2.0')
+        expect(vc.validFrom).toBe('2010-01-01T19:23:24Z')
+        expect(vc.issuanceDate).toBeUndefined()
+        expect(vc.toJson()).not.toHaveProperty('issuanceDate')
+
+        const result = await w3cJsonLdCredentialService.verifyCredential(agentContext, { credential: vc })
+        expect(result.isValid).toBe(true)
+      })
+
+      it('signs and verifies a presentation using the data model 2.0 context', async () => {
+        const vc = await w3cJsonLdCredentialService.signCredential(agentContext, {
+          format: ClaimFormat.LdpVc,
+          credential: createV2Credential({ credentialSubject: { id: issuerDidKey.did } }),
+          proofType: 'Ed25519Signature2018',
+          verificationMethod,
+        })
+
+        const presentation = new W3cPresentation({
+          context: [CREDENTIALS_CONTEXT_V2_URL],
+          holder: issuerDidKey.did,
+          verifiableCredential: [vc],
+        })
+
+        const vp = await w3cJsonLdCredentialService.signPresentation(agentContext, {
+          format: ClaimFormat.LdpVp,
+          presentation,
+          proofPurpose: new AuthenticationProofPurpose({ challenge: 'challenge-data-model-2' }),
+          proofType: 'Ed25519Signature2018',
+          challenge: 'challenge-data-model-2',
+          verificationMethod,
+        })
+
+        expect(vp).toBeInstanceOf(W3cJsonLdVerifiablePresentation)
+
+        const result = await w3cJsonLdCredentialService.verifyPresentation(agentContext, {
+          presentation: vp as W3cJsonLdVerifiablePresentation,
+          challenge: 'challenge-data-model-2',
+        })
+
+        expect(result.isValid).toBe(true)
+      })
+
+      // The data model 1.1 context defines the Ed25519Signature2020 terms, the data model 2.0 context does not.
+      // Signing therefore has to add the suite context, which must resolve through the default document loader.
+      it('adds the resolvable Ed25519Signature2020 suite context when signing', async () => {
+        const service = new W3cJsonLdCredentialService(
+          new SignatureSuiteRegistry([
+            {
+              suiteClass: Ed25519Signature2020,
+              proofType: 'Ed25519Signature2020',
+              verificationMethodTypes: [VERIFICATION_METHOD_TYPE_ED25519_VERIFICATION_KEY_2020],
+              supportedPublicJwkTypes: [Ed25519PublicJwk],
+            },
+          ]),
+          new W3cCredentialsModuleConfig({ documentLoader: customDocumentLoader })
+        )
+
+        const vc = await service.signCredential(agentContext, {
+          format: ClaimFormat.LdpVc,
+          credential: createV2Credential(),
+          proofType: 'Ed25519Signature2020',
+          verificationMethod,
+        })
+
+        expect(asArray(vc.proof)[0].type).toBe('Ed25519Signature2020')
+        expect(vc.context).toEqual([CREDENTIALS_CONTEXT_V2_URL, 'https://w3id.org/security/suites/ed25519-2020/v1'])
+        expect(DEFAULT_CONTEXTS).toHaveProperty('https://w3id.org/security/suites/ed25519-2020/v1')
+      })
+
+      it('detects a tampered credential using the data model 2.0 context', async () => {
+        const vc = await w3cJsonLdCredentialService.signCredential(agentContext, {
+          format: ClaimFormat.LdpVc,
+          credential: createV2Credential(),
+          proofType: 'Ed25519Signature2018',
+          verificationMethod,
+        })
+
+        const tampered = JsonTransformer.fromJSON(
+          { ...vc.toJson(), validUntil: '2040-01-01T19:23:24Z' },
+          W3cJsonLdVerifiableCredential
+        )
+
+        const result = await w3cJsonLdCredentialService.verifyCredential(agentContext, { credential: tampered })
+        expect(result.isValid).toBe(false)
       })
     })
   })

--- a/packages/core/src/modules/vc/models/credential/W3cCredential.ts
+++ b/packages/core/src/modules/vc/models/credential/W3cCredential.ts
@@ -1,10 +1,11 @@
 import { Expose, Type } from 'class-transformer'
-import { IsInstance, IsOptional, IsRFC3339, ValidateNested } from 'class-validator'
+import { IsInstance, IsOptional, ValidateNested } from 'class-validator'
 import type { JsonObject, SingleOrArray } from '../../../../types'
 import { asArray, JsonTransformer, mapSingleOrArray } from '../../../../utils'
 import { IsInstanceOrArrayOfInstances, IsUri } from '../../../../utils/validators'
 import { CREDENTIALS_CONTEXT_V1_URL } from '../../constants'
-import { IsCredentialJsonLdContext, IsCredentialType } from '../../validators'
+import { getCredentialContextVersion, type W3cCredentialDataModelVersion } from '../../credentialContextVersion'
+import { IsCredentialJsonLdContext, IsCredentialType, IsW3cCredentialDate } from '../../validators'
 import { W3cCredentialSchema } from './W3cCredentialSchema'
 import { W3cCredentialStatus } from './W3cCredentialStatus'
 import type { W3cCredentialSubjectOptions } from './W3cCredentialSubject'
@@ -17,8 +18,27 @@ export interface W3cCredentialOptions {
   id?: string
   type: Array<string>
   issuer: string | W3cIssuerOptions
-  issuanceDate: string
+
+  /**
+   * Data model 1.1 only. Required when the credential uses the data model 1.1 context.
+   */
+  issuanceDate?: string
+
+  /**
+   * Data model 1.1 only.
+   */
   expirationDate?: string
+
+  /**
+   * Data model 2.0 only. Replaces {@link issuanceDate}.
+   */
+  validFrom?: string
+
+  /**
+   * Data model 2.0 only. Replaces {@link expirationDate}.
+   */
+  validUntil?: string
+
   credentialSubject: SingleOrArray<W3cCredentialSubjectOptions>
   credentialStatus?: W3cCredentialStatus
   credentialSchema?: SingleOrArray<W3cCredentialSchema>
@@ -28,14 +48,19 @@ export class W3cCredential {
   public constructor(options: W3cCredentialOptions) {
     if (options) {
       this.context = options.context ?? [CREDENTIALS_CONTEXT_V1_URL]
-      this.id = options.id
+      // Assigning an undefined id would serialize an `id` key without a value, which is invalid JSON-LD
+      if (options.id !== undefined) this.id = options.id
       this.type = options.type || ['VerifiableCredential']
       this.issuer =
         typeof options.issuer === 'string' || options.issuer instanceof W3cIssuer
           ? options.issuer
           : new W3cIssuer(options.issuer)
-      this.issuanceDate = options.issuanceDate
-      this.expirationDate = options.expirationDate
+      // Only assign the dates that apply to the data model version in use, so credentials do not
+      // serialize terms that are not defined by their context.
+      if (options.issuanceDate !== undefined) this.issuanceDate = options.issuanceDate
+      if (options.expirationDate !== undefined) this.expirationDate = options.expirationDate
+      if (options.validFrom !== undefined) this.validFrom = options.validFrom
+      if (options.validUntil !== undefined) this.validUntil = options.validUntil
       this.credentialSubject = mapSingleOrArray(options.credentialSubject, (subject) =>
         subject instanceof W3cCredentialSubject ? subject : new W3cCredentialSubject(subject)
       )
@@ -70,12 +95,17 @@ export class W3cCredential {
   @IsW3cIssuer()
   public issuer!: string | W3cIssuer
 
-  @IsRFC3339()
-  public issuanceDate!: string
+  @IsW3cCredentialDate({ dataModelVersion: '1.1', required: true })
+  public issuanceDate?: string
 
-  @IsRFC3339()
-  @IsOptional()
+  @IsW3cCredentialDate({ dataModelVersion: '1.1' })
   public expirationDate?: string
+
+  @IsW3cCredentialDate({ dataModelVersion: '2.0' })
+  public validFrom?: string
+
+  @IsW3cCredentialDate({ dataModelVersion: '2.0' })
+  public validUntil?: string
 
   @IsW3cCredentialSubject({ each: true })
   @W3cCredentialSubjectTransformer()
@@ -95,6 +125,30 @@ export class W3cCredential {
 
   public get issuerId(): string {
     return this.issuer instanceof W3cIssuer ? this.issuer.id : this.issuer
+  }
+
+  /**
+   * The Verifiable Credentials Data Model version this credential expresses, derived from the
+   * base JSON-LD context.
+   */
+  public get dataModelVersion(): W3cCredentialDataModelVersion | undefined {
+    return getCredentialContextVersion(this.context)
+  }
+
+  /**
+   * The date from which the credential is valid, regardless of the data model version.
+   * Maps to `issuanceDate` in data model 1.1 and to `validFrom` in data model 2.0.
+   */
+  public get validFromDate(): string | undefined {
+    return this.dataModelVersion === '2.0' ? this.validFrom : this.issuanceDate
+  }
+
+  /**
+   * The date after which the credential is no longer valid, regardless of the data model version.
+   * Maps to `expirationDate` in data model 1.1 and to `validUntil` in data model 2.0.
+   */
+  public get validUntilDate(): string | undefined {
+    return this.dataModelVersion === '2.0' ? this.validUntil : this.expirationDate
   }
 
   public get credentialSchemaIds(): string[] {

--- a/packages/core/src/modules/vc/models/credential/W3cJsonCredential.ts
+++ b/packages/core/src/modules/vc/models/credential/W3cJsonCredential.ts
@@ -15,8 +15,27 @@ export interface W3cJsonCredential {
   id?: string
   type: Array<string>
   issuer: string | W3cJsonIssuer
-  issuanceDate: string
+
+  /**
+   * Data model 1.1 only. Always present when the credential uses the data model 1.1 context.
+   */
+  issuanceDate?: string
+
+  /**
+   * Data model 1.1 only.
+   */
   expirationDate?: string
+
+  /**
+   * Data model 2.0 only. Replaces {@link issuanceDate}.
+   */
+  validFrom?: string
+
+  /**
+   * Data model 2.0 only. Replaces {@link expirationDate}.
+   */
+  validUntil?: string
+
   credentialSubject: SingleOrArray<W3cJsonCredentialSubject>
   [key: string]: unknown
 }

--- a/packages/core/src/modules/vc/models/credential/__tests__/W3cCredential.test.ts
+++ b/packages/core/src/modules/vc/models/credential/__tests__/W3cCredential.test.ts
@@ -97,14 +97,46 @@ describe('W3cCredential', () => {
 
   test('throws an error when issuanceDate is not a valid date', () => {
     expect(() => JsonTransformer.fromJSON({ ...validCredential, issuanceDate: '2020' }, W3cCredential)).toThrow(
-      /property issuanceDate has failed the following constraints: issuanceDate must be RFC 3339 date/
+      /property issuanceDate has failed the following constraints: issuanceDate is only defined by the Verifiable Credentials Data Model 1\.1 context/
+    )
+  })
+
+  test('throws an error when issuanceDate is missing', () => {
+    const { issuanceDate, ...withoutIssuanceDate } = validCredential
+    expect(() => JsonTransformer.fromJSON(withoutIssuanceDate, W3cCredential)).toThrow(
+      /property issuanceDate has failed the following constraints: issuanceDate is only defined by the Verifiable Credentials Data Model 1\.1 context/
     )
   })
 
   test('throws an error when expirationDate is present and it is not a valid date', () => {
     expect(() => JsonTransformer.fromJSON({ ...validCredential, expirationDate: '2020' }, W3cCredential)).toThrow(
-      /property expirationDate has failed the following constraints: expirationDate must be RFC 3339 date/
+      /property expirationDate has failed the following constraints: expirationDate is only defined by the Verifiable Credentials Data Model 1\.1 context/
     )
+  })
+
+  test('throws an error when data model 2.0 dates are used with the data model 1.1 context', () => {
+    expect(() =>
+      JsonTransformer.fromJSON({ ...validCredential, validFrom: '2010-01-01T19:23:24Z' }, W3cCredential)
+    ).toThrow(
+      /property validFrom has failed the following constraints: validFrom is only defined by the Verifiable Credentials Data Model 2\.0 context/
+    )
+
+    expect(() =>
+      JsonTransformer.fromJSON({ ...validCredential, validUntil: '2030-01-01T19:23:24Z' }, W3cCredential)
+    ).toThrow(
+      /property validUntil has failed the following constraints: validUntil is only defined by the Verifiable Credentials Data Model 2\.0 context/
+    )
+  })
+
+  test('exposes the data model version and version-agnostic validity dates', () => {
+    const credential = JsonTransformer.fromJSON(
+      { ...validCredential, expirationDate: '2030-01-01T19:23:24Z' },
+      W3cCredential
+    )
+
+    expect(credential.dataModelVersion).toBe('1.1')
+    expect(credential.validFromDate).toBe('2010-01-01T19:23:24Z')
+    expect(credential.validUntilDate).toBe('2030-01-01T19:23:24Z')
   })
 
   test('throws an error when credentialSchema is present and it is not a valid credentialSchema object/array', () => {
@@ -215,5 +247,85 @@ describe('W3cCredential', () => {
 
     const transformedJson = JsonTransformer.toJSON(credential)
     expect(transformedJson).toEqual(validCredential)
+  })
+
+  describe('data model 2.0', () => {
+    const validV2Credential = {
+      '@context': ['https://www.w3.org/ns/credentials/v2', 'https://www.w3.org/ns/credentials/examples/v2'],
+      id: 'http://example.edu/credentials/1872',
+      type: ['VerifiableCredential', 'AlumniCredential'],
+      issuer: 'https://example.edu/issuers/14',
+      validFrom: '2010-01-01T19:23:24Z',
+      validUntil: '2030-01-01T19:23:24Z',
+      credentialSubject: {
+        id: 'did:example:ebfeb1f712ebc6f1c276e12ec21',
+      },
+    }
+
+    test('accepts a credential using the data model 2.0 context without issuanceDate', () => {
+      expect(() => JsonTransformer.fromJSON(validV2Credential, W3cCredential)).not.toThrow()
+    })
+
+    test('accepts a credential using the data model 2.0 context without any validity dates', () => {
+      const { validFrom, validUntil, ...withoutDates } = validV2Credential
+      expect(() => JsonTransformer.fromJSON(withoutDates, W3cCredential)).not.toThrow()
+    })
+
+    test('throws an error when validFrom or validUntil is not a valid date', () => {
+      expect(() => JsonTransformer.fromJSON({ ...validV2Credential, validFrom: '2020' }, W3cCredential)).toThrow(
+        /property validFrom has failed the following constraints: validFrom is only defined by the Verifiable Credentials Data Model 2\.0 context/
+      )
+
+      expect(() => JsonTransformer.fromJSON({ ...validV2Credential, validUntil: '2020' }, W3cCredential)).toThrow(
+        /property validUntil has failed the following constraints: validUntil is only defined by the Verifiable Credentials Data Model 2\.0 context/
+      )
+    })
+
+    test('throws an error when data model 1.1 dates are used with the data model 2.0 context', () => {
+      expect(() =>
+        JsonTransformer.fromJSON({ ...validV2Credential, issuanceDate: '2010-01-01T19:23:24Z' }, W3cCredential)
+      ).toThrow(
+        /property issuanceDate has failed the following constraints: issuanceDate is only defined by the Verifiable Credentials Data Model 1\.1 context/
+      )
+
+      expect(() =>
+        JsonTransformer.fromJSON({ ...validV2Credential, expirationDate: '2030-01-01T19:23:24Z' }, W3cCredential)
+      ).toThrow(
+        /property expirationDate has failed the following constraints: expirationDate is only defined by the Verifiable Credentials Data Model 1\.1 context/
+      )
+    })
+
+    test('exposes the data model version and version-agnostic validity dates', () => {
+      const credential = JsonTransformer.fromJSON(validV2Credential, W3cCredential)
+
+      expect(credential.dataModelVersion).toBe('2.0')
+      expect(credential.validFromDate).toBe('2010-01-01T19:23:24Z')
+      expect(credential.validUntilDate).toBe('2030-01-01T19:23:24Z')
+    })
+
+    test('should transform from JSON to a class instance and back', () => {
+      const credential = JsonTransformer.fromJSON(validV2Credential, W3cCredential)
+      expect(credential).toBeInstanceOf(W3cCredential)
+
+      expect(JsonTransformer.toJSON(credential)).toEqual(validV2Credential)
+    })
+
+    test('does not serialize dates that were not provided', () => {
+      const credential = new W3cCredential({
+        context: ['https://www.w3.org/ns/credentials/v2'],
+        type: ['VerifiableCredential'],
+        issuer: 'did:example:issuer',
+        validFrom: '2010-01-01T19:23:24Z',
+        credentialSubject: { id: 'did:example:subject' },
+      })
+
+      expect(JsonTransformer.toJSON(credential)).toEqual({
+        '@context': ['https://www.w3.org/ns/credentials/v2'],
+        type: ['VerifiableCredential'],
+        issuer: 'did:example:issuer',
+        validFrom: '2010-01-01T19:23:24Z',
+        credentialSubject: { id: 'did:example:subject' },
+      })
+    })
   })
 })

--- a/packages/core/src/modules/vc/models/presentation/W3cPresentation.ts
+++ b/packages/core/src/modules/vc/models/presentation/W3cPresentation.ts
@@ -23,7 +23,8 @@ export interface W3cPresentationOptions {
 export class W3cPresentation {
   public constructor(options: W3cPresentationOptions) {
     if (options) {
-      this.id = options.id
+      // Assigning an undefined id would serialize an `id` key without a value, which is invalid JSON-LD
+      if (options.id !== undefined) this.id = options.id
       this.context = options.context ?? [CREDENTIALS_CONTEXT_V1_URL]
       this.type = options.type ?? [VERIFIABLE_PRESENTATION_TYPE]
       this.verifiableCredential = options.verifiableCredential

--- a/packages/core/src/modules/vc/validators.ts
+++ b/packages/core/src/modules/vc/validators.ts
@@ -1,8 +1,14 @@
 import type { ValidationOptions } from 'class-validator'
 
-import { buildMessage, isString, isURL, ValidateBy } from 'class-validator'
-import { isJsonObject } from '../../types'
-import { CREDENTIALS_CONTEXT_V1_URL, VERIFIABLE_CREDENTIAL_TYPE, VERIFIABLE_PRESENTATION_TYPE } from './constants'
+import { buildMessage, isRFC3339, isString, isURL, ValidateBy } from 'class-validator'
+import { isJsonObject, type JsonObject, type SingleOrArray } from '../../types'
+import { asArray } from '../../utils/array'
+import { VERIFIABLE_CREDENTIAL_TYPE, VERIFIABLE_PRESENTATION_TYPE } from './constants'
+import {
+  DEFAULT_CREDENTIAL_CONTEXTS,
+  getCredentialContextVersion,
+  type W3cCredentialDataModelVersion,
+} from './credentialContextVersion'
 
 export interface IsCredentialJsonLdContextValidationOptions extends ValidationOptions {
   /**
@@ -13,28 +19,30 @@ export interface IsCredentialJsonLdContextValidationOptions extends ValidationOp
   allowString?: boolean
 
   /**
-   * The expected credential context URL.
+   * The credential context URL(s) that are accepted as the first entry of the context.
    *
-   * @default {@link CREDENTIALS_CONTEXT_V1_URL}
+   * @default [{@link CREDENTIALS_CONTEXT_V1_URL}, {@link CREDENTIALS_CONTEXT_V2_URL}]
    */
-  credentialContext?: string
+  credentialContext?: SingleOrArray<string>
 }
 
 export function IsCredentialJsonLdContext(
   validationOptions?: IsCredentialJsonLdContextValidationOptions
 ): PropertyDecorator {
   const allowString = validationOptions?.allowString ?? false
-  const credentialContext = validationOptions?.credentialContext ?? CREDENTIALS_CONTEXT_V1_URL
+  const credentialContexts = validationOptions?.credentialContext
+    ? asArray(validationOptions.credentialContext)
+    : DEFAULT_CREDENTIAL_CONTEXTS
 
   return ValidateBy(
     {
       name: 'IsCredentialJsonLdContext',
       validator: {
         validate: (value): boolean => {
-          if (!Array.isArray(value)) return allowString && isString(value) && value === credentialContext
+          if (!Array.isArray(value)) return allowString && isString(value) && credentialContexts.includes(value)
 
-          // First item must be the verifiable credential context
-          if (value[0] !== credentialContext) return false
+          // First item must be one of the accepted verifiable credential contexts
+          if (!credentialContexts.includes(value[0])) return false
 
           return value.every((v) => (isString(v) && isURL(v)) || isJsonObject(v))
         },
@@ -46,6 +54,60 @@ export function IsCredentialJsonLdContext(
       },
     },
     validationOptions
+  )
+}
+
+export interface IsW3cCredentialDateValidationOptions extends ValidationOptions {
+  /**
+   * The data model version this property belongs to. The property must be undefined when the
+   * credential uses a different data model version, as the term is not defined by that context.
+   */
+  dataModelVersion: W3cCredentialDataModelVersion
+
+  /**
+   * Whether the property is required when the credential uses {@link dataModelVersion}.
+   *
+   * @default false
+   */
+  required?: boolean
+}
+
+/**
+ * Validates a credential date property (`issuanceDate`, `expirationDate`, `validFrom`, `validUntil`)
+ * against the data model version indicated by the credential `@context`.
+ *
+ * Terms are only defined by the context of the data model version that introduced them, so a
+ * property belonging to a different version must be absent.
+ */
+export function IsW3cCredentialDate(options: IsW3cCredentialDateValidationOptions): PropertyDecorator {
+  const { dataModelVersion, required = false } = options
+
+  return ValidateBy(
+    {
+      name: 'IsW3cCredentialDate',
+      validator: {
+        validate: (value, args): boolean => {
+          const context = (args?.object as { context?: string | Array<string | JsonObject> })?.context
+          const version = getCredentialContextVersion(context)
+
+          // The context itself is invalid, and reported by IsCredentialJsonLdContext. Only assert
+          // the value is a valid date so we don't report a confusing data model mismatch.
+          if (version === undefined) return value === undefined || isRFC3339(value)
+
+          if (version !== dataModelVersion) return value === undefined
+          if (value === undefined) return !required
+
+          return isRFC3339(value)
+        },
+        defaultMessage: buildMessage((eachPrefix) => {
+          const other = dataModelVersion === '1.1' ? '2.0' : '1.1'
+          return `${eachPrefix}$property is only defined by the Verifiable Credentials Data Model ${dataModelVersion} context and must be ${
+            required ? 'a valid RFC 3339 date' : 'undefined or a valid RFC 3339 date'
+          }, and undefined when the credential uses the data model ${other} context.`
+        }, options),
+      },
+    },
+    options
   )
 }
 

--- a/packages/didcomm/src/modules/credentials/formats/jsonld/DidCommJsonLdCredentialFormat.ts
+++ b/packages/didcomm/src/modules/credentials/formats/jsonld/DidCommJsonLdCredentialFormat.ts
@@ -6,8 +6,27 @@ export interface JsonCredential {
   id?: string
   type: Array<string>
   issuer: string | W3cIssuerOptions
-  issuanceDate: string
+
+  /**
+   * Data model 1.1 only. Required when the credential uses the data model 1.1 context.
+   */
+  issuanceDate?: string
+
+  /**
+   * Data model 1.1 only.
+   */
   expirationDate?: string
+
+  /**
+   * Data model 2.0 only. Replaces {@link issuanceDate}.
+   */
+  validFrom?: string
+
+  /**
+   * Data model 2.0 only. Replaces {@link expirationDate}.
+   */
+  validUntil?: string
+
   credentialSubject: SingleOrArray<JsonObject>
   [key: string]: unknown
 }


### PR DESCRIPTION
Adding support to exchange VC Data Model 2.0 credentials in Aries RFC 0593 (JSON-LD credentials over DIDComm). Built on top of #2827.