### PR TITLE
fix(openid4vc): check trusted DIDs when verifying OID4VC JWTs

### DIFF
--- a/.changeset/trusted-issuers-did-signed-jwts.md
+++ b/.changeset/trusted-issuers-did-signed-jwts.md
@@ -1,0 +1,5 @@
+---
+"@credo-ts/openid4vc": patch
+---
+
+Consult the `getTrustedIssuersForVerification` callback for `did` signed OpenID4VC JWTs. Previously only `x5c` signed JWTs were checked against a trust list, meaning a signed authorization request (JAR), an OpenID4VCI key attestation, an OAuth2 client (wallet) attestation, or signed credential issuer metadata signed by any DID was accepted. Semantics now match `did` signed credentials in core: allowed when no callback is registered or it returns `undefined`, rejected when the signer DID is not in the returned list. Behavior for `x5c` signed JWTs is unchanged.

--- a/packages/openid4vc/src/shared/__tests__/callbacks.test.ts
+++ b/packages/openid4vc/src/shared/__tests__/callbacks.test.ts
@@ -1,0 +1,278 @@
+import type { AgentContext, KeyDidCreateOptions } from '@credo-ts/core'
+import { Agent, DidKey, JwtPayload, Kms, utils, X509ModuleConfig } from '@credo-ts/core'
+import type { JwtSigner } from '@openid4vc/oauth2'
+import { decodeJwt } from '@openid4vc/oauth2'
+import { InMemoryWalletModule } from '../../../../../tests/InMemoryWalletModule'
+import { agentDependencies } from '../../../../node/src'
+import { OpenId4VcModule } from '../../OpenId4VcModule'
+import { OpenId4VcIssuanceSessionState } from '../../openid4vc-issuer/OpenId4VcIssuanceSessionState'
+import { OpenId4VcIssuanceSessionRecord } from '../../openid4vc-issuer/repository'
+import { getOid4vcJwtSignCallback, getOid4vcJwtVerifyCallback } from '../callbacks'
+
+const agent = new Agent({
+  config: {},
+  dependencies: agentDependencies,
+  modules: {
+    openid4vc: new OpenId4VcModule(),
+    inMemory: new InMemoryWalletModule(),
+  },
+})
+
+const issuanceSession = new OpenId4VcIssuanceSessionRecord({
+  createdAt: new Date(),
+  expiresAt: utils.addSecondsToDate(new Date(), 300),
+  state: OpenId4VcIssuanceSessionState.CredentialRequestReceived,
+  issuerId: 'issuer-id',
+  credentialOfferId: 'credential-offer-id',
+  credentialOfferPayload: {
+    credential_issuer: 'https://issuer.com',
+    credential_configuration_ids: ['configuration-id'],
+  },
+  openId4VciVersion: 'v1.draft15',
+})
+
+// Signs a jwt with the given typ and returns everything the verify callback needs
+const createJwt = async (agentContext: AgentContext, options: { typ: string; signer: JwtSigner }) => {
+  const { jwt } = await getOid4vcJwtSignCallback(agentContext)(options.signer, {
+    header: { alg: options.signer.alg, typ: options.typ },
+    payload: new JwtPayload({ iss: 'https://wallet-provider.com' }).toJson(),
+  })
+
+  const { header, payload } = decodeJwt({ jwt })
+  return { signer: options.signer, compact: jwt, header, payload }
+}
+
+describe('getOid4vcJwtVerifyCallback', () => {
+  let didUrl: string
+  let did: string
+  let didSigner: JwtSigner
+  let jwkSigner: JwtSigner
+
+  let x5cSigner: JwtSigner
+  let certificatePem: string
+
+  const otherDid = 'did:key:zUC74VEqqhEHQcgv4zagSPkqFJxuNWuoBPKjJuHETEUeHLoSqWt92viSsmaWjy82y'
+
+  const verify = (options: Awaited<ReturnType<typeof createJwt>>, callbackOptions?: { issuanceSession?: boolean }) =>
+    getOid4vcJwtVerifyCallback(agent.context, {
+      issuanceSession: callbackOptions?.issuanceSession === false ? undefined : issuanceSession,
+    })(options.signer, { compact: options.compact, header: options.header, payload: options.payload })
+
+  beforeAll(async () => {
+    await agent.initialize()
+
+    const { keyId } = await agent.kms.createKey({ type: { kty: 'OKP', crv: 'Ed25519' } })
+
+    const didCreateResult = await agent.dids.create<KeyDidCreateOptions>({
+      method: 'key',
+      options: { keyId },
+    })
+
+    did = didCreateResult.didState.did as string
+    didUrl = `${did}#${DidKey.fromDid(did).publicJwk.fingerprint}`
+    // `kid` is the kms key id used for signing, the did document jwk itself carries no key id
+    didSigner = { method: 'did', alg: Kms.KnownJwaSignatureAlgorithms.EdDSA, didUrl, kid: keyId }
+
+    const jwkKey = Kms.PublicJwk.fromPublicJwk(
+      (await agent.kms.createKey({ type: { kty: 'EC', crv: 'P-256' } })).publicJwk
+    )
+    jwkSigner = {
+      method: 'jwk',
+      alg: Kms.KnownJwaSignatureAlgorithms.ES256,
+      // biome-ignore lint/suspicious/noExplicitAny: jwk type from kms is compatible
+      publicJwk: jwkKey.toJson() as any,
+    }
+
+    const certificate = await agent.x509.createCertificate({
+      authorityKey: Kms.PublicJwk.fromPublicJwk(
+        (await agent.kms.createKey({ type: { kty: 'EC', crv: 'P-256' } })).publicJwk
+      ),
+      issuer: { commonName: 'Credo Wallet Provider' },
+    })
+    certificatePem = certificate.toString('pem')
+    x5cSigner = {
+      method: 'x5c',
+      alg: Kms.KnownJwaSignatureAlgorithms.ES256,
+      x5c: [certificate.toString('base64url')],
+      kid: certificate.publicJwk.keyId,
+    }
+  })
+
+  afterAll(async () => {
+    await agent.shutdown()
+  })
+
+  afterEach(() => {
+    const x509ModuleConfig = agent.context.dependencyManager.resolve(X509ModuleConfig)
+    agent.context.config.setTrustedIssuersForVerification(undefined)
+    x509ModuleConfig.setTrustedCertificatesForVerification(undefined)
+    x509ModuleConfig.setTrustedCertificates(undefined)
+  })
+
+  describe('did signer', () => {
+    test('is rejected when not in the trusted issuers', async () => {
+      const jwt = await createJwt(agent.context, { typ: 'key-attestation+jwt', signer: didSigner })
+      agent.context.config.setTrustedIssuersForVerification(async () => ({
+        trustedIssuers: [{ method: 'did', issuance: otherDid }],
+      }))
+
+      await expect(verify(jwt)).rejects.toThrow(`Signer did ${did} is not trusted. Unable to verify signature.`)
+    })
+
+    test('is accepted when in the trusted issuers', async () => {
+      const jwt = await createJwt(agent.context, { typ: 'key-attestation+jwt', signer: didSigner })
+      agent.context.config.setTrustedIssuersForVerification(async () => ({
+        trustedIssuers: [{ method: 'did', issuance: did }],
+      }))
+
+      await expect(verify(jwt)).resolves.toEqual(expect.objectContaining({ verified: true }))
+    })
+
+    test('is rejected when an empty trusted issuers array is returned', async () => {
+      const jwt = await createJwt(agent.context, { typ: 'key-attestation+jwt', signer: didSigner })
+      agent.context.config.setTrustedIssuersForVerification(async () => ({ trustedIssuers: [] }))
+
+      await expect(verify(jwt)).rejects.toThrow(`Signer did ${did} is not trusted. Unable to verify signature.`)
+    })
+
+    test('is allowed by default when no trusted issuers callback is registered', async () => {
+      const jwt = await createJwt(agent.context, { typ: 'key-attestation+jwt', signer: didSigner })
+
+      await expect(verify(jwt)).resolves.toEqual(expect.objectContaining({ verified: true }))
+    })
+
+    test.each([
+      ['oauth-authz-req+jwt', 'oauth2SecuredAuthorizationRequest'],
+      ['keyattestation+jwt', 'openId4VciKeyAttestation'],
+      ['key-attestation+jwt', 'openId4VciKeyAttestation'],
+      ['openidvci-issuer-metadata+jwt', 'openId4VciCredentialIssuerMetadata'],
+      ['oauth-client-attestation+jwt', 'oauth2ClientAttestation'],
+    ])('trusted issuers callback is called for typ %s', async (typ, verificationType) => {
+      const getTrustedIssuersForVerification = vi.fn().mockResolvedValue(undefined)
+      agent.context.config.setTrustedIssuersForVerification(getTrustedIssuersForVerification)
+
+      const jwt = await createJwt(agent.context, { typ, signer: didSigner })
+      await expect(verify(jwt)).resolves.toEqual(expect.objectContaining({ verified: true }))
+
+      expect(getTrustedIssuersForVerification).toHaveBeenCalledWith(
+        agent.context,
+        expect.objectContaining({
+          signer: { method: 'did', didUrl },
+          verification: expect.objectContaining({ type: verificationType }),
+        })
+      )
+    })
+
+    test('trusted issuers callback is not called for an unrelated typ', async () => {
+      const getTrustedIssuersForVerification = vi.fn().mockResolvedValue({ trustedIssuers: [] })
+      agent.context.config.setTrustedIssuersForVerification(getTrustedIssuersForVerification)
+
+      const jwt = await createJwt(agent.context, { typ: 'openid4vci-proof+jwt', signer: didSigner })
+      await expect(verify(jwt)).resolves.toEqual(expect.objectContaining({ verified: true }))
+
+      expect(getTrustedIssuersForVerification).not.toHaveBeenCalled()
+    })
+
+    test.each([
+      'key-attestation+jwt',
+      'oauth-client-attestation+jwt',
+    ])('trusted issuers callback is not called for typ %s without an issuance session', async (typ) => {
+      const getTrustedIssuersForVerification = vi.fn().mockResolvedValue({ trustedIssuers: [] })
+      agent.context.config.setTrustedIssuersForVerification(getTrustedIssuersForVerification)
+
+      const jwt = await createJwt(agent.context, { typ, signer: didSigner })
+      await expect(verify(jwt, { issuanceSession: false })).resolves.toEqual(
+        expect.objectContaining({ verified: true })
+      )
+
+      expect(getTrustedIssuersForVerification).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('jwk signer', () => {
+    // There is no `jwk` variant of `VerificationSigner`/`TrustedIssuer`, so a bare jwk signed
+    // key attestation is not checked against a trust list.
+    test('is not checked against the trusted issuers', async () => {
+      const jwt = await createJwt(agent.context, { typ: 'key-attestation+jwt', signer: jwkSigner })
+      agent.context.config.setTrustedIssuersForVerification(async () => ({ trustedIssuers: [] }))
+
+      await expect(verify(jwt)).resolves.toEqual(expect.objectContaining({ verified: true }))
+    })
+  })
+
+  describe('x5c signer', () => {
+    test('is accepted when its certificate is returned as a trusted issuer', async () => {
+      const jwt = await createJwt(agent.context, { typ: 'key-attestation+jwt', signer: x5cSigner })
+      agent.context.config.setTrustedIssuersForVerification(async () => ({
+        trustedIssuers: [{ method: 'x509', issuance: [certificatePem] }],
+      }))
+
+      await expect(verify(jwt)).resolves.toEqual(expect.objectContaining({ verified: true }))
+    })
+
+    test('falls back to the deprecated x509 callback, which receives the issuance session id', async () => {
+      const jwt = await createJwt(agent.context, { typ: 'key-attestation+jwt', signer: x5cSigner })
+      const getTrustedCertificatesForVerification = vi.fn().mockResolvedValue([certificatePem])
+      agent.context.dependencyManager
+        .resolve(X509ModuleConfig)
+        .setTrustedCertificatesForVerification(getTrustedCertificatesForVerification)
+
+      await expect(verify(jwt)).resolves.toEqual(expect.objectContaining({ verified: true }))
+
+      expect(getTrustedCertificatesForVerification).toHaveBeenCalledWith(
+        agent.context,
+        expect.objectContaining({
+          verification: expect.objectContaining({
+            type: 'openId4VciKeyAttestation',
+            openId4VcIssuanceSessionId: issuanceSession.id,
+          }),
+        })
+      )
+    })
+
+    test('does not call the deprecated x509 callback when the trusted issuers callback returns a result', async () => {
+      const jwt = await createJwt(agent.context, { typ: 'key-attestation+jwt', signer: x5cSigner })
+      const getTrustedCertificatesForVerification = vi.fn().mockResolvedValue([certificatePem])
+      agent.context.dependencyManager
+        .resolve(X509ModuleConfig)
+        .setTrustedCertificatesForVerification(getTrustedCertificatesForVerification)
+      agent.context.config.setTrustedIssuersForVerification(async () => ({
+        trustedIssuers: [{ method: 'x509', issuance: [certificatePem] }],
+      }))
+
+      await expect(verify(jwt)).resolves.toEqual(expect.objectContaining({ verified: true }))
+
+      expect(getTrustedCertificatesForVerification).not.toHaveBeenCalled()
+    })
+
+    test('falls back to the globally configured trusted certificates', async () => {
+      const jwt = await createJwt(agent.context, { typ: 'key-attestation+jwt', signer: x5cSigner })
+      agent.context.dependencyManager.resolve(X509ModuleConfig).setTrustedCertificates([certificatePem])
+
+      await expect(verify(jwt)).resolves.toEqual(expect.objectContaining({ verified: true }))
+    })
+
+    test('is rejected when an empty trusted issuers array is returned', async () => {
+      const jwt = await createJwt(agent.context, { typ: 'key-attestation+jwt', signer: x5cSigner })
+      agent.context.config.setTrustedIssuersForVerification(async () => ({ trustedIssuers: [] }))
+
+      await expect(verify(jwt)).rejects.toThrow(
+        "trustedCertificates is required when the JWS protected header contains an 'x5c' property."
+      )
+    })
+
+    test('does not call the trusted issuers callback when trusted certificates are provided', async () => {
+      const jwt = await createJwt(agent.context, { typ: 'key-attestation+jwt', signer: x5cSigner })
+      const getTrustedIssuersForVerification = vi.fn().mockResolvedValue({ trustedIssuers: [] })
+      agent.context.config.setTrustedIssuersForVerification(getTrustedIssuersForVerification)
+
+      const result = await getOid4vcJwtVerifyCallback(agent.context, {
+        issuanceSession,
+        trustedCertificates: [certificatePem],
+      })(jwt.signer, { compact: jwt.compact, header: jwt.header, payload: jwt.payload })
+
+      expect(result).toEqual(expect.objectContaining({ verified: true }))
+      expect(getTrustedIssuersForVerification).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/packages/openid4vc/src/shared/callbacks.ts
+++ b/packages/openid4vc/src/shared/callbacks.ts
@@ -13,6 +13,7 @@ import {
   X509Certificate,
   X509ModuleConfig,
   X509Service,
+  type X509VerificationContext,
   type X509VerificationTrustedCertificates,
 } from '@credo-ts/core'
 import type {
@@ -29,6 +30,80 @@ import type { OpenId4VcIssuanceSessionRecord, OpenId4VcIssuerRecord } from '../o
 import type { OpenId4VcVerificationTypes } from './OpenId4VcTrustedIssuersVerificationTypes'
 
 import { getPublicJwkFromDid } from './utils'
+
+/**
+ * Maps the `typ` header of a jwt verified by oid4vc-ts to the trust verification context.
+ *
+ * Two shapes are returned, as the deprecated x509 callback only carries the issuance session id.
+ * Returns `undefined` for jwts that are not bound to a trusted issuer (proofs, dpop, access tokens, ...),
+ * for which only the signature is verified.
+ */
+function getOid4vcJwtVerificationContext(options: {
+  typ?: string
+  compact: string
+  payload: Record<string, unknown>
+  issuanceSession?: OpenId4VcIssuanceSessionRecord
+  isAuthorizationRequestJwt?: boolean
+}):
+  | { verification: OpenId4VcVerificationTypes; legacyVerification: X509VerificationContext['verification'] }
+  | undefined {
+  const { typ, compact, issuanceSession, isAuthorizationRequestJwt } = options
+  const payload = JwtPayload.fromJson(options.payload)
+
+  // oauth2 secured authorization request (JAR)
+  if (typ === 'oauth-authz-req+jwt' || isAuthorizationRequestJwt) {
+    const authorizationRequest = { jwt: compact, payload }
+    return {
+      verification: { type: 'oauth2SecuredAuthorizationRequest', authorizationRequest },
+      legacyVerification: { type: 'oauth2SecuredAuthorizationRequest', authorizationRequest },
+    }
+  }
+
+  // OID4VCI key attestation
+  if ((typ === 'keyattestation+jwt' || typ === 'key-attestation+jwt') && issuanceSession) {
+    const keyAttestation = { jwt: compact, payload }
+    return {
+      verification: {
+        type: 'openId4VciKeyAttestation',
+        openId4VcIssuanceSessionRecord: issuanceSession,
+        keyAttestation,
+      },
+      legacyVerification: {
+        type: 'openId4VciKeyAttestation',
+        openId4VcIssuanceSessionId: issuanceSession.id,
+        keyAttestation,
+      },
+    }
+  }
+
+  // OID4VCI credential issuer metadata
+  if (typ === 'openidvci-issuer-metadata+jwt') {
+    const credentialIssuerMetadata = { jwt: compact, payload }
+    return {
+      verification: { type: 'openId4VciCredentialIssuerMetadata', credentialIssuerMetadata },
+      legacyVerification: { type: 'openId4VciCredentialIssuerMetadata', credentialIssuerMetadata },
+    }
+  }
+
+  // OAuth2 client attestation
+  if (typ === 'oauth-client-attestation+jwt' && issuanceSession) {
+    const clientAttestation = { jwt: compact, payload }
+    return {
+      verification: {
+        type: 'oauth2ClientAttestation',
+        openId4VcIssuanceSessionRecord: issuanceSession,
+        clientAttestation,
+      },
+      legacyVerification: {
+        type: 'oauth2ClientAttestation',
+        openId4VcIssuanceSessionId: issuanceSession.id,
+        clientAttestation,
+      },
+    }
+  }
+
+  return undefined
+}
 
 export function getOid4vcJwtVerifyCallback(
   agentContext: AgentContext,
@@ -51,140 +126,44 @@ export function getOid4vcJwtVerifyCallback(
   return async (signer, { compact, header, payload }) => {
     let trustedCertificates = options?.trustedCertificates
 
-    // oauth2 secured authorization request (JAR)
-    if (
-      signer.method === 'x5c' &&
-      (header.typ === 'oauth-authz-req+jwt' || options?.isAuthorizationRequestJwt) &&
-      !trustedCertificates
-    ) {
-      const x509Config = agentContext.dependencyManager.resolve(X509ModuleConfig)
-      const certificateChain = signer.x5c?.map((cert) => X509Certificate.fromEncodedCertificate(cert))
-      const jwtPayload = JwtPayload.fromJson(payload)
+    const verificationContext = getOid4vcJwtVerificationContext({
+      typ: header.typ,
+      compact,
+      payload,
+      issuanceSession: options?.issuanceSession,
+      isAuthorizationRequestJwt: options?.isAuthorizationRequestJwt,
+    })
 
-      if (certificateChain) {
-        const genericResult = await TrustedIssuerContext.getTrustedIssuersForVerification(agentContext, {
-          signer: { method: 'x509', certificateChain },
-          verification: {
-            type: 'oauth2SecuredAuthorizationRequest',
-            authorizationRequest: { jwt: compact, payload: jwtPayload },
-          } satisfies OpenId4VcVerificationTypes,
+    if (verificationContext) {
+      if (signer.method === 'x5c' && !trustedCertificates) {
+        const x509Config = agentContext.dependencyManager.resolve(X509ModuleConfig)
+        const certificateChain = signer.x5c.map((cert) => X509Certificate.fromEncodedCertificate(cert))
+
+        // NOTE: we can't use `ensureTrustedSigner` here (unlike the did branch below), as `JwsService`
+        // already validates the certificate chain, and falls back to the globally configured trusted
+        // certificates when nothing is resolved here.
+        trustedCertificates =
+          (
+            await TrustedIssuerContext.getTrustedIssuersForVerification(agentContext, {
+              signer: { method: 'x509', certificateChain },
+              verification: verificationContext.verification,
+            })
+          )?.trustedIssuers ??
+          (await x509Config.getTrustedCertificatesForVerification?.(agentContext, {
+            certificateChain,
+            verification: verificationContext.legacyVerification,
+          }))
+      } else if (signer.method === 'did') {
+        // Consistent with did signed credentials, this allows the did when no trusted issuers are
+        // returned, and throws when the signer did is not in the returned list.
+        await TrustedIssuerContext.ensureTrustedSigner(agentContext, {
+          signer: { method: 'did', didUrl: signer.didUrl },
+          verification: verificationContext.verification,
         })
-        if (genericResult !== undefined) {
-          trustedCertificates = genericResult.trustedIssuers
-        } else {
-          trustedCertificates = await x509Config.getTrustedCertificatesForVerification?.(agentContext, {
-            certificateChain,
-            verification: {
-              type: 'oauth2SecuredAuthorizationRequest',
-              authorizationRequest: { jwt: compact, payload: jwtPayload },
-            },
-          })
-        }
       }
-    }
 
-    // OID4VCI key attestation
-    if (
-      signer.method === 'x5c' &&
-      (header.typ === 'keyattestation+jwt' || header.typ === 'key-attestation+jwt') &&
-      options?.issuanceSession &&
-      !trustedCertificates
-    ) {
-      const x509Config = agentContext.dependencyManager.resolve(X509ModuleConfig)
-      const certificateChain = signer.x5c?.map((cert) => X509Certificate.fromEncodedCertificate(cert))
-      const jwtPayload = JwtPayload.fromJson(payload)
-
-      if (certificateChain) {
-        if (agentContext.config.getTrustedIssuersForVerification) {
-          const genericResult = await TrustedIssuerContext.getTrustedIssuersForVerification(agentContext, {
-            signer: { method: 'x509', certificateChain },
-            verification: {
-              type: 'openId4VciKeyAttestation',
-              openId4VcIssuanceSessionRecord: options.issuanceSession,
-              keyAttestation: { jwt: compact, payload: jwtPayload },
-            } satisfies OpenId4VcVerificationTypes,
-          })
-          if (genericResult !== undefined) {
-            trustedCertificates = genericResult.trustedIssuers
-          }
-        }
-        if (trustedCertificates === undefined) {
-          trustedCertificates = await x509Config.getTrustedCertificatesForVerification?.(agentContext, {
-            certificateChain,
-            verification: {
-              type: 'openId4VciKeyAttestation',
-              openId4VcIssuanceSessionId: options.issuanceSession.id,
-              keyAttestation: { jwt: compact, payload: jwtPayload },
-            },
-          })
-        }
-      }
-    }
-
-    // OID4VCI credential issuer metadata
-    if (signer.method === 'x5c' && header.typ === 'openidvci-issuer-metadata+jwt' && !trustedCertificates) {
-      const x509Config = agentContext.dependencyManager.resolve(X509ModuleConfig)
-      const certificateChain = signer.x5c?.map((cert) => X509Certificate.fromEncodedCertificate(cert))
-      const jwtPayload = JwtPayload.fromJson(payload)
-
-      if (certificateChain) {
-        const genericResult = await TrustedIssuerContext.getTrustedIssuersForVerification(agentContext, {
-          signer: { method: 'x509', certificateChain },
-          verification: {
-            type: 'openId4VciCredentialIssuerMetadata',
-            credentialIssuerMetadata: { jwt: compact, payload: jwtPayload },
-          } satisfies OpenId4VcVerificationTypes,
-        })
-        if (genericResult !== undefined) {
-          trustedCertificates = genericResult.trustedIssuers
-        } else {
-          trustedCertificates = await x509Config.getTrustedCertificatesForVerification?.(agentContext, {
-            certificateChain,
-            verification: {
-              type: 'openId4VciCredentialIssuerMetadata',
-              credentialIssuerMetadata: { jwt: compact, payload: jwtPayload },
-            },
-          })
-        }
-      }
-    }
-
-    // OAuth2 client attestation
-    if (
-      signer.method === 'x5c' &&
-      header.typ === 'oauth-client-attestation+jwt' &&
-      options?.issuanceSession &&
-      !trustedCertificates
-    ) {
-      const x509Config = agentContext.dependencyManager.resolve(X509ModuleConfig)
-      const certificateChain = signer.x5c?.map((cert) => X509Certificate.fromEncodedCertificate(cert))
-      const jwtPayload = JwtPayload.fromJson(payload)
-
-      if (certificateChain) {
-        if (agentContext.config.getTrustedIssuersForVerification) {
-          const genericResult = await TrustedIssuerContext.getTrustedIssuersForVerification(agentContext, {
-            signer: { method: 'x509', certificateChain },
-            verification: {
-              type: 'oauth2ClientAttestation',
-              openId4VcIssuanceSessionRecord: options.issuanceSession,
-              clientAttestation: { jwt: compact, payload: jwtPayload },
-            } satisfies OpenId4VcVerificationTypes,
-          })
-          if (genericResult !== undefined) {
-            trustedCertificates = genericResult.trustedIssuers
-          }
-        }
-        if (trustedCertificates === undefined) {
-          trustedCertificates = await x509Config.getTrustedCertificatesForVerification?.(agentContext, {
-            certificateChain,
-            verification: {
-              type: 'oauth2ClientAttestation',
-              openId4VcIssuanceSessionId: options.issuanceSession.id,
-              clientAttestation: { jwt: compact, payload: jwtPayload },
-            },
-          })
-        }
-      }
+      // NOTE: jwts signed with a bare `jwk` are not checked against a trust list, as there is no
+      // `jwk` variant of `VerificationSigner`/`TrustedIssuer`.
     }
 
     const alg = signer.alg as Kms.KnownJwaSignatureAlgorithm

--- a/packages/openid4vc/tests/openid4vc-wallet-key-attestation.e2e.test.ts
+++ b/packages/openid4vc/tests/openid4vc-wallet-key-attestation.e2e.test.ts
@@ -1,4 +1,5 @@
-import { CredoError, Kms, Mdoc, MdocRecord, SdJwtVcRecord, utils } from '@credo-ts/core'
+import type { KeyDidCreateOptions } from '@credo-ts/core'
+import { CredoError, DidKey, Kms, Mdoc, MdocRecord, SdJwtVcRecord, utils } from '@credo-ts/core'
 import type { AuthorizationServerMetadata, Jwk } from '@openid4vc/oauth2'
 import { AuthorizationFlow, Openid4vciWalletProvider } from '@openid4vc/openid4vci'
 import express, { type Express } from 'express'
@@ -82,6 +83,8 @@ let generateKeyAttestation: (
     userAuthentication: OpenId4VciKeyAttestationLevel[]
   }
 ) => Promise<string>
+let generateDidKeyAttestation: () => Promise<string>
+let walletProviderDid: string
 
 describe('OpenId4Vc Wallet and Key Attestations', () => {
   let expressApp: Express
@@ -277,6 +280,30 @@ describe('OpenId4Vc Wallet and Key Attestations', () => {
         // 5 minutes
         expiresAt: utils.addSecondsToDate(new Date(), 300),
         nonce,
+      })
+
+    const walletProviderKey = await holder.agent.kms.createKey({ type: { kty: 'OKP', crv: 'Ed25519' } })
+    const walletProviderDidResult = await holder.agent.dids.create<KeyDidCreateOptions>({
+      method: 'key',
+      options: { keyId: walletProviderKey.keyId },
+    })
+    walletProviderDid = walletProviderDidResult.didState.did as string
+
+    generateDidKeyAttestation = () =>
+      walletProvider.createKeyAttestationJwt({
+        attestedKeys: attestedKeys.map((key) => key.toJson() as Jwk),
+        signer: {
+          method: 'did',
+          alg: Kms.KnownJwaSignatureAlgorithms.EdDSA,
+          didUrl: `${walletProviderDid}#${DidKey.fromDid(walletProviderDid).publicJwk.fingerprint}`,
+          // `kid` is the kms key id used for signing, the did document jwk itself carries no key id
+          kid: walletProviderKey.keyId,
+        },
+        use: 'proof_type.jwt',
+        keyStorage: highLevels,
+        userAuthentication: highLevels,
+        // 5 minutes
+        expiresAt: utils.addSecondsToDate(new Date(), 300),
       })
 
     // Trust wallet provider
@@ -485,6 +512,47 @@ describe('OpenId4Vc Wallet and Key Attestations', () => {
         }),
       })
     ).rejects.toThrow('Insufficient key_storage for key attestation')
+  })
+
+  it('throws error when the key attestation is signed by an untrusted did', async () => {
+    issuer.agent.context.config.setTrustedIssuersForVerification(async (_agentContext, { signer }) =>
+      // Keep using the x509 config for the x5c signed wallet attestation
+      signer.method === 'did'
+        ? {
+            trustedIssuers: [
+              { method: 'did', issuance: 'did:key:zUC74VEqqhEHQcgv4zagSPkqFJxuNWuoBPKjJuHETEUeHLoSqWt92viSsmaWjy82y' },
+            ],
+          }
+        : undefined
+    )
+
+    const { credentialOffer } = await issuer.agent.openid4vc.issuer.createCredentialOffer({
+      issuerId: issuerRecord.issuerId,
+      credentialConfigurationIds: ['universityDegree'],
+      preAuthorizedCodeFlowConfig: {},
+      authorization: {
+        requireDpop: true,
+        requireWalletAttestation: true,
+      },
+    })
+
+    const resolvedCredentialOffer = await holder.agent.openid4vc.holder.resolveCredentialOffer(credentialOffer)
+    const tokenResponse = await holder.agent.openid4vc.holder.requestToken({
+      resolvedCredentialOffer,
+      walletAttestationJwt,
+      clientId: 'wallet',
+    })
+
+    await expect(
+      holder.agent.openid4vc.holder.requestCredentials({
+        resolvedCredentialOffer,
+        ...tokenResponse,
+        credentialBindingResolver: async () => ({
+          method: 'attestation',
+          keyAttestationJwt: await generateDidKeyAttestation(),
+        }),
+      })
+    ).rejects.toThrow('Error verifying key attestation jwt')
   })
 
   it('e2e flow issuing a batch of mdoc based on wallet and nonce-bound key attestation', async () => {


### PR DESCRIPTION
We were missing the checks for Trusted DIDs in the OID4VC callbacks. This also simplifies and unifies some of the logic.

Note that conformance tests failing is unrelated to this PR. They've been changed upstream and we've been having failures for some days already.