### PR TITLE
fix(webvh): improve error logging when DID Document is not found

### DIFF
--- a/packages/webvh/src/dids/WebVhDidResolver.ts
+++ b/packages/webvh/src/dids/WebVhDidResolver.ts
@@ -118,7 +118,19 @@ export class WebVhDidResolver implements DidResolver {
 
   private async resolveDidDoc(agentContext: AgentContext, did: string): Promise<DidResolutionResult> {
     const crypto = new WebVhDidCrypto(agentContext)
-    const { doc } = await resolveDID(did, { verifier: crypto })
+    const { doc, meta } = await resolveDID(did, { verifier: crypto })
+
+    if (!doc) {
+      return {
+        didDocument: null,
+        didDocumentMetadata: {},
+        didResolutionMetadata: {
+          error: meta.error && /not_?found/i.test(meta.error) ? 'notFound' : 'invalidDid',
+          message: `resolver_error: Unable to resolve did '${did}': ${meta.problemDetails?.detail ?? meta.error ?? 'no did document returned'}`,
+        },
+      }
+    }
+
     return {
       didDocument: DidDocument.fromJSON(doc),
       didDocumentMetadata: {},


### PR DESCRIPTION
Something I've experienced recently when trying to resolve the DID Log of a service that was not yet ready and thus throwing a 503 status code. `didwebvh-ts` surfaces it as a thrown fetch error, but `WebVhDidResolver.resolveDidDoc()` ends up calling `DidDocument.fromJSON(undefined)`, throwing the unhelpful `ClassValidationError: Cannot validate instance of undefined`.

cc @rmlearney-digicatapult @brianorwhatever 