### PR TITLE
feat(openid4vc): validate chained scope mappings before PAR

### DIFF
--- a/packages/openid4vc/src/openid4vc-issuer/OpenId4VcIssuerService.ts
+++ b/packages/openid4vc/src/openid4vc-issuer/OpenId4VcIssuerService.ts
@@ -62,7 +62,11 @@ import type {
 } from '../shared'
 import { keyAttestationLevelSatisfies, OpenId4VciCredentialFormatProfile } from '../shared'
 import { dynamicOid4vciClientAuthentication, getOid4vcCallbacks } from '../shared/callbacks'
-import { getCredentialConfigurationsSupportedForScopes, getOfferedCredentials } from '../shared/issuerMetadataUtils'
+import {
+  getCredentialConfigurationsSupportedForScopes,
+  getOfferedCredentials,
+  getScopesFromCredentialConfigurationsSupported,
+} from '../shared/issuerMetadataUtils'
 import { storeActorIdForContextCorrelationId } from '../shared/router'
 import {
   credoJwtIssuerToOpenId4VcJwtIssuer,
@@ -213,11 +217,31 @@ export class OpenId4VcIssuerService {
     // Check if all the offered credential configuration ids have a scope value. If not, it won't be possible to actually request
     // issuance of the credential later on. For pre-auth it's not needed to add a scope.
     if (options.authorizationCodeFlowConfig) {
+      const authorizationCodeConfig = options.authorizationCodeFlowConfig
       extractScopesForCredentialConfigurationIds({
         credentialConfigurationIds: options.credentialConfigurationIds,
         issuerMetadata,
         throwOnConfigurationWithoutScope: true,
       })
+
+      // Chained authorization adds a second, structural check: every offered internal
+      // scope must have a static mapping to upstream authorization-server scopes.
+      const chainedAuthorizationServerConfig = issuer.chainedAuthorizationServerConfigs?.find(
+        (config) => config.issuer === authorizationCodeConfig.authorizationServerUrl
+      )
+      if (
+        chainedAuthorizationServerConfig?.type === 'chained' &&
+        !this.openId4VcIssuerConfig.getChainedAuthorizationRequestParameters
+      ) {
+        const offeredCredentialConfigurations = getOfferedCredentials(
+          options.credentialConfigurationIds,
+          issuerMetadata.credentialIssuer.credential_configurations_supported
+        )
+        this.getStaticChainedAuthorizationScopes({
+          authorizationServerConfig: chainedAuthorizationServerConfig,
+          requestedScopes: getScopesFromCredentialConfigurationsSupported(offeredCredentialConfigurations),
+        })
+      }
     }
 
     const grants = await this.getGrantsFromConfig(agentContext, {
@@ -1949,6 +1973,31 @@ export class OpenId4VcIssuerService {
     }
 
     return grants
+  }
+
+  public getStaticChainedAuthorizationScopes(options: {
+    authorizationServerConfig: {
+      issuer: string
+      scopesMapping?: Record<string, string[]>
+    }
+    requestedScopes: string[]
+  }): string[] {
+    const { authorizationServerConfig, requestedScopes } = options
+    const scopesMapping = authorizationServerConfig.scopesMapping
+    if (!scopesMapping) {
+      throw new CredoError(
+        `Issuer does not have a static scope mapping for chained authorization server '${authorizationServerConfig.issuer}'.`
+      )
+    }
+
+    const missingScope = requestedScopes.find((scope) => !(scope in scopesMapping))
+    if (missingScope) {
+      throw new CredoError(
+        `Issuer does not have a scope mapping for '${missingScope}' for chained authorization server '${authorizationServerConfig.issuer}'.`
+      )
+    }
+
+    return requestedScopes.flatMap((scope) => scopesMapping[scope])
   }
 
   private getCredentialConfigurationsForRequest(options: {

--- a/packages/openid4vc/src/openid4vc-issuer/router/pushedAuthorizationRequestEndpoint.ts
+++ b/packages/openid4vc/src/openid4vc-issuer/router/pushedAuthorizationRequestEndpoint.ts
@@ -215,7 +215,6 @@ export async function handlePushedAuthorizationRequest(
       throw new Oauth2ServerErrorResponseError(
         {
           error: Oauth2ErrorCodes.ServerError,
-          error_description: 'Invalid chained authorization server scope mapping.',
         },
         {
           internalMessage: `Invalid scope mapping for chained authorization server '${authorizationServerConfig.issuer}'.`,

--- a/packages/openid4vc/src/openid4vc-issuer/router/pushedAuthorizationRequestEndpoint.ts
+++ b/packages/openid4vc/src/openid4vc-issuer/router/pushedAuthorizationRequestEndpoint.ts
@@ -206,30 +206,22 @@ export async function handlePushedAuthorizationRequest(
     additionalRequestPayload = dynamicConfiguration.additionalPayload
     redirectUris = dynamicConfiguration.redirectUris
   } else {
-    for (const scope of requestedScopes) {
-      if (!authorizationServerConfig.scopesMapping) {
-        throw new Oauth2ServerErrorResponseError(
-          {
-            error: Oauth2ErrorCodes.ServerError,
-          },
-          {
-            internalMessage: `Issuer '${issuer.issuerId}' does not have a scope mapping for scope '${scope}' for external authorization server '${authorizationServerConfig.issuer}'`,
-          }
-        )
-      }
-
-      if (scope in authorizationServerConfig.scopesMapping) {
-        scopes.push(...authorizationServerConfig.scopesMapping[scope])
-      } else {
-        throw new Oauth2ServerErrorResponseError(
-          {
-            error: Oauth2ErrorCodes.ServerError,
-          },
-          {
-            internalMessage: `Issuer '${issuer.issuerId}' does not have a scope mapping for scope '${scope}' for external authorization server '${authorizationServerConfig.issuer}'`,
-          }
-        )
-      }
+    try {
+      scopes = openId4VcIssuerService.getStaticChainedAuthorizationScopes({
+        authorizationServerConfig,
+        requestedScopes,
+      })
+    } catch (error) {
+      throw new Oauth2ServerErrorResponseError(
+        {
+          error: Oauth2ErrorCodes.ServerError,
+          error_description: 'Invalid chained authorization server scope mapping.',
+        },
+        {
+          internalMessage: `Invalid scope mapping for chained authorization server '${authorizationServerConfig.issuer}'.`,
+          cause: error,
+        }
+      )
     }
   }
 

--- a/packages/openid4vc/tests/openid4vci-chained.e2e.test.ts
+++ b/packages/openid4vc/tests/openid4vci-chained.e2e.test.ts
@@ -890,4 +890,212 @@ describe('OpenId4Vc (Chained Authorization)', () => {
     clearIdpNock()
     clearHolderNock()
   })
+
+  it('rejects a chained authorization-code offer when a static scope mapping is incomplete', async () => {
+    issuer = (await createAgentFromModules(
+      {
+        inMemory: new InMemoryWalletModule(),
+        openid4vc: new OpenId4VcModule({
+          app: expressApp,
+          issuer: {
+            baseUrl: issuanceBaseUrl,
+            credentialRequestToCredentialMapper,
+          },
+        }),
+        tenants: new TenantsModule(),
+      },
+      '96213c3d7fc8d4d6754c7a0fd969598g',
+      global.fetch
+    )) as unknown as typeof issuer
+    issuer1 = await createTenantForAgent(issuer.agent, 'iTenant1')
+
+    const issuerTenant = await issuer.agent.modules.tenants.getTenantAgent({ tenantId: issuer1.tenantId })
+    const openIdIssuerTenant = await issuerTenant.openid4vc.issuer.createIssuer({
+      issuerId: '8bc91672-6a32-466c-96ec-6efca8760068',
+      credentialConfigurationsSupported: {
+        universityDegree: universityDegreeCredentialConfigurationSupported,
+      },
+      authorizationServerConfigs: [
+        {
+          type: 'chained',
+          issuer: 'http://localhost:4747',
+          clientAuthentication: {
+            type: 'clientSecret',
+            clientId: 'issuer-client',
+            clientSecret: 'issuer-secret',
+          },
+          scopesMapping: {},
+        },
+      ],
+    })
+
+    await expect(
+      issuerTenant.openid4vc.issuer.createCredentialOffer({
+        issuerId: openIdIssuerTenant.issuerId,
+        credentialConfigurationIds: ['universityDegree'],
+        authorizationCodeFlowConfig: {
+          authorizationServerUrl: 'http://localhost:4747',
+        },
+      })
+    ).rejects.toThrow(
+      "Issuer does not have a scope mapping for 'UniversityDegreeCredential' for chained authorization server 'http://localhost:4747'."
+    )
+
+    await issuerTenant.endSession()
+  })
+
+  it('rejects a chained authorization-code offer when no static scope mapping is configured', async () => {
+    issuer = (await createAgentFromModules(
+      {
+        inMemory: new InMemoryWalletModule(),
+        openid4vc: new OpenId4VcModule({
+          app: expressApp,
+          issuer: {
+            baseUrl: issuanceBaseUrl,
+            credentialRequestToCredentialMapper,
+          },
+        }),
+        tenants: new TenantsModule(),
+      },
+      '96213c3d7fc8d4d6754c7a0fd969598g',
+      global.fetch
+    )) as unknown as typeof issuer
+    issuer1 = await createTenantForAgent(issuer.agent, 'iTenant1')
+
+    const issuerTenant = await issuer.agent.modules.tenants.getTenantAgent({ tenantId: issuer1.tenantId })
+    const openIdIssuerTenant = await issuerTenant.openid4vc.issuer.createIssuer({
+      issuerId: '8bc91672-6a32-466c-96ec-6efca8760068',
+      credentialConfigurationsSupported: {
+        universityDegree: universityDegreeCredentialConfigurationSupported,
+      },
+      authorizationServerConfigs: [
+        {
+          type: 'chained',
+          issuer: 'http://localhost:4747',
+          clientAuthentication: {
+            type: 'clientSecret',
+            clientId: 'issuer-client',
+            clientSecret: 'issuer-secret',
+          },
+        },
+      ],
+    })
+
+    await expect(
+      issuerTenant.openid4vc.issuer.createCredentialOffer({
+        issuerId: openIdIssuerTenant.issuerId,
+        credentialConfigurationIds: ['universityDegree'],
+        authorizationCodeFlowConfig: {
+          authorizationServerUrl: 'http://localhost:4747',
+        },
+      })
+    ).rejects.toThrow(
+      "Issuer does not have a static scope mapping for chained authorization server 'http://localhost:4747'."
+    )
+
+    await issuerTenant.endSession()
+  })
+
+  it('returns an OAuth error from PAR when a previously valid static scope mapping is removed', async () => {
+    issuer = (await createAgentFromModules(
+      {
+        inMemory: new InMemoryWalletModule(),
+        openid4vc: new OpenId4VcModule({
+          app: expressApp,
+          issuer: {
+            baseUrl: issuanceBaseUrl,
+            credentialRequestToCredentialMapper,
+          },
+        }),
+        tenants: new TenantsModule(),
+      },
+      '96213c3d7fc8d4d6754c7a0fd969598g',
+      global.fetch
+    )) as unknown as typeof issuer
+    issuer1 = await createTenantForAgent(issuer.agent, 'iTenant1')
+
+    const issuerTenant = await issuer.agent.modules.tenants.getTenantAgent({ tenantId: issuer1.tenantId })
+    const openIdIssuerTenant = await issuerTenant.openid4vc.issuer.createIssuer({
+      issuerId: '8bc91672-6a32-466c-96ec-6efca8760068',
+      credentialConfigurationsSupported: {
+        universityDegree: universityDegreeCredentialConfigurationSupported,
+      },
+      authorizationServerConfigs: [
+        {
+          type: 'chained',
+          issuer: 'http://localhost:4747',
+          clientAuthentication: {
+            type: 'clientSecret',
+            clientId: 'issuer-client',
+            clientSecret: 'issuer-secret',
+          },
+          scopesMapping: {
+            UniversityDegreeCredential: ['openid'],
+          },
+        },
+      ],
+    })
+
+    const { issuanceSession } = await issuerTenant.openid4vc.issuer.createCredentialOffer({
+      issuerId: openIdIssuerTenant.issuerId,
+      credentialConfigurationIds: ['universityDegree'],
+      authorizationCodeFlowConfig: {
+        authorizationServerUrl: 'http://localhost:4747',
+      },
+    })
+
+    await issuerTenant.openid4vc.issuer.updateIssuerMetadata({
+      issuerId: openIdIssuerTenant.issuerId,
+      credentialConfigurationsSupported: {
+        universityDegree: universityDegreeCredentialConfigurationSupported,
+      },
+      authorizationServerConfigs: [
+        {
+          type: 'chained',
+          issuer: 'http://localhost:4747',
+          clientAuthentication: {
+            type: 'clientSecret',
+            clientId: 'issuer-client',
+            clientSecret: 'issuer-secret',
+          },
+        },
+      ],
+    })
+
+    const idpApp = express()
+    idpApp.get('/.well-known/oauth-authorization-server', (_req, res) =>
+      res.json({
+        issuer: 'http://localhost:4747',
+        authorization_endpoint: 'http://localhost:4747/authorize',
+        token_endpoint: 'http://localhost:4747/token',
+      } satisfies AuthorizationServerMetadata)
+    )
+    const clearIdpNock = setupNockToExpress('http://localhost:4747', idpApp)
+
+    const response = await fetch(`${issuanceBaseUrl}/${openIdIssuerTenant.issuerId}/par`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        client_id: 'wallet',
+        response_type: 'code',
+        redirect_uri: 'http://localhost:5757/redirect',
+        scope: 'UniversityDegreeCredential',
+        state: 'wallet-state',
+        issuer_state: issuanceSession.authorization?.issuerState,
+        code_challenge: 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+        code_challenge_method: 'S256',
+      }),
+    })
+
+    const responseBody = await response.json()
+    expect(response.status).toBe(400)
+    expect(responseBody).toMatchObject({
+      error: 'server_error',
+      error_description: 'Invalid chained authorization server scope mapping.',
+    })
+
+    clearIdpNock()
+
+    await issuerTenant.endSession()
+  })
 })

--- a/packages/openid4vc/tests/openid4vci-chained.e2e.test.ts
+++ b/packages/openid4vc/tests/openid4vci-chained.e2e.test.ts
@@ -1091,7 +1091,6 @@ describe('OpenId4Vc (Chained Authorization)', () => {
     expect(response.status).toBe(400)
     expect(responseBody).toMatchObject({
       error: 'server_error',
-      error_description: 'Invalid chained authorization server scope mapping.',
     })
 
     clearIdpNock()


### PR DESCRIPTION
Validate static chained authorization-server scope mappings when an Authorization-code credential offer is created. Use same validation during PAR processing.

* Configuration errors now detected early in flows
Code previously allowed auth-code offer to be created even when chained server had no mapping for one of the offered credential scopes. Failure was deferred until wallet submitted PAR request

* Improve error messages for PAR
PAR previously returned generic OAuth `server_error` for both missing mapping cases. Now reports missing internal scope and upstream auth server and PAR translates into specific OAuth error response

* No duplicated mapping logic
Both offer creation and PAR now use shared helper centralised in issuer service

* Separated PAR validation from request handling
Issuer config error previously only appeared after interaction had begun. Static mapping validation now happens at offer creation and PAR still performs same validation as defensive check.
