### PR TITLE
fix(webvh): sign attested resources with an assertionMethod key

### DIFF
--- a/.changeset/webvh-assertion-method-proofs.md
+++ b/.changeset/webvh-assertion-method-proofs.md
@@ -1,0 +1,18 @@
+---
+"@credo-ts/webvh": patch
+---
+
+Sign did:webvh attested resources with a verification method authorized for the proof purpose
+
+Attested resource proofs use the `assertionMethod` proof purpose, but the signing key was selected as
+`verificationMethod[0]` without checking that it is referenced from `assertionMethod`. Resources were
+written successfully and then failed to resolve with `Resolved resource proof is invalid.`
+
+- Resource registration now selects a verification method authorized for `assertionMethod`, and
+  validates an explicitly passed `options.verificationMethod` against that purpose.
+- Newly created did:webvh dids reference their verification method from `assertionMethod`, and updating
+  a did no longer drops it.
+- `verifyProof` asserts the expected proof purpose and logs the issues returned by the verifier.
+
+Existing dids need an `agent.dids.update` adding that reference, and the updated log republished, before
+resources they sign will verify.

--- a/packages/webvh/src/anoncreds/services/WebVhAnonCredsRegistry.ts
+++ b/packages/webvh/src/anoncreds/services/WebVhAnonCredsRegistry.ts
@@ -28,6 +28,7 @@ import {
   MultiBaseEncoder,
   MultiHashEncoder,
   type Proof,
+  parseDid,
   TypedArrayEncoder,
   W3cDataIntegrityApi,
   type W3cDataIntegritySingleProofSecuredDocument,
@@ -161,6 +162,12 @@ function isRevocationStatusListShape(value: unknown): value is RevocationStatusL
     typeof candidate.timestamp === 'number'
   )
 }
+
+/**
+ * Attested resources are always signed with, and verified against, a verification method that is
+ * authorized for the `assertionMethod` verification relationship.
+ */
+const ATTESTED_RESOURCE_PROOF_PURPOSE = 'assertionMethod' as const
 
 export class WebVhAnonCredsRegistry implements AnonCredsRegistry {
   public methodName = 'webvh'
@@ -643,8 +650,13 @@ export class WebVhAnonCredsRegistry implements AnonCredsRegistry {
     const { proof, ...restMetadata } = registrationMetadata
 
     const vm = proof?.verificationMethod
-    if (!vm) throw new Error('verificationMethod not found in proof')
-    const verificationMethod = typeof vm === 'string' ? vm : vm.id
+    if (!vm) throw new CredoError('verificationMethod not found in proof')
+    const previousVerificationMethod = typeof vm === 'string' ? vm : vm.id
+
+    // Re-select an authorized verification method rather than reusing the one from the previous
+    // proof, which may never have been authorized for the proof purpose in the first place.
+    const issuerId = parseDid(previousVerificationMethod).did
+    const verificationMethod = await this.getVerificationMethodId(agentContext, issuerId)
 
     const updatedMetadata = { ...restMetadata, ...extraInfo }
 
@@ -698,9 +710,21 @@ export class WebVhAnonCredsRegistry implements AnonCredsRegistry {
   public async verifyProof(agentContext: AgentContext, attestedResource: WebVhAttestedResource): Promise<boolean> {
     const dataIntegrity = agentContext.dependencyManager.resolve(W3cDataIntegrityApi)
     try {
-      const verificationResult = await dataIntegrity.verifyProof({
-        ...attestedResource,
-      } as W3cDataIntegritySingleProofSecuredDocument)
+      const verificationResult = await dataIntegrity.verifyProof(
+        {
+          ...attestedResource,
+        } as W3cDataIntegritySingleProofSecuredDocument,
+        { expectedProofPurpose: ATTESTED_RESOURCE_PROOF_PURPOSE }
+      )
+
+      if (!verificationResult.verified) {
+        agentContext.config.logger.error('Proof validation of did:webvh resource failed', {
+          resourceId: attestedResource.id,
+          verificationMethod: attestedResource.proof?.verificationMethod,
+          errors: verificationResult.errors,
+        })
+      }
+
       return verificationResult.verified
     } catch (error) {
       agentContext.config.logger.error('Error during proof validation of did:webvh resource', {
@@ -722,7 +746,7 @@ export class WebVhAnonCredsRegistry implements AnonCredsRegistry {
         unsecuredDocument,
         cryptosuite: 'eddsa-jcs-2022',
         verificationMethod,
-        proofPurpose: 'assertionMethod',
+        proofPurpose: ATTESTED_RESOURCE_PROOF_PURPOSE,
       })
       return creationResult.proof
     } catch (error) {
@@ -787,17 +811,51 @@ export class WebVhAnonCredsRegistry implements AnonCredsRegistry {
       throw new CredoError(`No DID found for issuer ${issuerId}`)
     }
 
-    // Use the explicit verification method if provided, otherwise use the first available with publicKeyMultibase
-    const verificationMethod =
-      explicitVerificationMethod ??
-      (didRecord.didDocument?.verificationMethod?.[0]?.publicKeyMultibase
-        ? didRecord.didDocument.verificationMethod[0].id
-        : undefined)
-
-    if (!verificationMethod) {
-      throw new CredoError(`No verification method found for DID ${didRecord.id}`)
+    const didDocument = didRecord.didDocument
+    if (!didDocument) {
+      throw new CredoError(`No did document stored on the did record for issuer ${issuerId}`)
     }
-    return verificationMethod
+
+    // Relative references ('#key-1') are valid within a did document, but a proof's
+    // verificationMethod must resolve on its own, so we always return an absolute did url.
+    const toAbsoluteId = (id: string) => (id.startsWith('#') ? `${didDocument.id}${id}` : id)
+
+    if (explicitVerificationMethod) {
+      try {
+        return toAbsoluteId(
+          didDocument.dereferenceKey(explicitVerificationMethod, [ATTESTED_RESOURCE_PROOF_PURPOSE]).id
+        )
+      } catch (error) {
+        throw new CredoError(
+          `Verification method '${explicitVerificationMethod}' is not authorized for '${ATTESTED_RESOURCE_PROOF_PURPOSE}' in the did document of issuer ${issuerId}`,
+          { cause: error }
+        )
+      }
+    }
+
+    const authorizedIds: string[] = []
+    for (const entry of didDocument.assertionMethod ?? []) {
+      const entryId = typeof entry === 'string' ? entry : entry.id
+      try {
+        authorizedIds.push(toAbsoluteId(didDocument.dereferenceKey(entryId, [ATTESTED_RESOURCE_PROOF_PURPOSE]).id))
+      } catch {
+        // Skip entries that cannot be dereferenced within this did document
+      }
+    }
+
+    if (authorizedIds.length === 0) {
+      throw new CredoError(
+        `No verification method authorized for '${ATTESTED_RESOURCE_PROOF_PURPOSE}' found in the did document of issuer ${issuerId}`
+      )
+    }
+
+    // Prefer a verification method this agent holds the key for. Did records created before keys
+    // were tracked have none, and signing those still resolves the key id from the public key, so
+    // the first authorized method remains the fallback rather than an error.
+    return (
+      authorizedIds.find((id) => didRecord.keys?.some((key) => id.endsWith(key.didDocumentRelativeKeyId))) ??
+      authorizedIds[0]
+    )
   }
 }
 

--- a/packages/webvh/src/anoncreds/services/__tests__/WebVhAnonCredsRegistry.signing.test.ts
+++ b/packages/webvh/src/anoncreds/services/__tests__/WebVhAnonCredsRegistry.signing.test.ts
@@ -1,0 +1,235 @@
+/**
+ * Regression tests for the verification method that attested resources are signed with.
+ *
+ * Attested resource proofs use the `assertionMethod` proof purpose, and the core
+ * `W3cDataIntegrityApi` enforces that the proof's verification method is authorized for that
+ * verification relationship. Selecting `verificationMethod[0]` therefore produces resources that
+ * are written successfully and then fail to resolve whenever the first verification method is not
+ * referenced from `assertionMethod` — which is the case for a did:webvh whose log-control
+ * (update) key is separate from its signing key.
+ *
+ * Unlike the other tests in this directory these run against real Ed25519 keys and the real
+ * `W3cDataIntegrityApi`, so a resource actually has to round-trip. No network access is needed:
+ * `WebVhDidResolver` allows serving locally created did records, so did resolution is answered
+ * from the repository.
+ */
+
+import {
+  CacheModuleConfig,
+  DependencyManager,
+  DidDocument,
+  DidDocumentRole,
+  DidRecord,
+  DidRepository,
+  DidsModuleConfig,
+  InjectionSymbols,
+  InMemoryLruCache,
+  Kms,
+  type Proof,
+  VerificationMethod,
+  W3cDataIntegrityModule,
+} from '@credo-ts/core'
+import { Subject } from 'rxjs'
+
+import { InMemoryStorageService } from '../../../../../../tests/InMemoryStorageService'
+import { agentDependencies, getAgentConfig, getAgentContext } from '../../../../../core/tests/helpers'
+import { WebVhDidResolver } from '../../../dids/WebVhDidResolver'
+import { WebVhAnonCredsRegistry } from '../WebVhAnonCredsRegistry'
+
+const issuerId = 'did:webvh:QmXysm9EF3kPH4fdCWf48YqCzREgiAe5nFXG3RCXaCShFX:id.test-suite.app:credo:01'
+
+describe('WebVhAnonCredsRegistry assertionMethod signing', () => {
+  let agentContext: ReturnType<typeof getAgentContext>
+  let registry: WebVhAnonCredsRegistry
+  let resolveResource: ReturnType<typeof vi.spyOn>
+  let updateVerificationMethodId: string
+  let assertionVerificationMethodId: string
+
+  const schema = { issuerId, attrNames: ['firstName', 'lastName'], name: 'CredoTest', version: '1.0' }
+
+  beforeEach(async () => {
+    const webvhResolver = new WebVhDidResolver()
+    resolveResource = vi.spyOn(webvhResolver, 'resolveResource')
+
+    const agentConfig = getAgentConfig('WebVhAnonCredsRegistrySigningTest')
+    const dependencyManager = new DependencyManager()
+    agentContext = getAgentContext({
+      dependencyManager,
+      agentConfig,
+      registerInstances: [
+        [InjectionSymbols.Stop$, new Subject<boolean>()],
+        [InjectionSymbols.AgentDependencies, agentDependencies],
+        [InjectionSymbols.StorageService, new InMemoryStorageService()],
+        [InjectionSymbols.Logger, agentConfig.logger],
+        [CacheModuleConfig, new CacheModuleConfig({ cache: new InMemoryLruCache({ limit: 500 }) })],
+        // The same resolver instance backs both did resolution and resource dereferencing
+        [DidsModuleConfig, new DidsModuleConfig({ resolvers: [webvhResolver] })],
+        [WebVhDidResolver, webvhResolver],
+      ],
+    })
+    // Registers the cryptosuite token that W3cDataIntegrityCryptosuiteRegistry injects
+    new W3cDataIntegrityModule().register(dependencyManager)
+
+    const kms = agentContext.dependencyManager.resolve(Kms.KeyManagementApi)
+    const updateKey = await kms.createKey({ type: { kty: 'OKP', crv: 'Ed25519' } })
+    const assertionKey = await kms.createKey({ type: { kty: 'OKP', crv: 'Ed25519' } })
+    const updateKeyMultibase = Kms.PublicJwk.fromPublicJwk(updateKey.publicJwk).fingerprint
+    const assertionKeyMultibase = Kms.PublicJwk.fromPublicJwk(assertionKey.publicJwk).fingerprint
+
+    updateVerificationMethodId = `${issuerId}#${updateKeyMultibase.slice(-8)}`
+    assertionVerificationMethodId = `${issuerId}#${assertionKeyMultibase.slice(-8)}`
+
+    // The update key controls the did log and is deliberately NOT referenced from assertionMethod,
+    // while remaining first in verificationMethod so the registrar keeps signing log entries with it
+    const didDocument = new DidDocument({
+      context: ['https://www.w3.org/ns/did/v1', 'https://w3id.org/security/multikey/v1'],
+      id: issuerId,
+      controller: issuerId,
+      verificationMethod: [
+        new VerificationMethod({
+          id: updateVerificationMethodId,
+          type: 'Multikey',
+          controller: issuerId,
+          publicKeyMultibase: updateKeyMultibase,
+        }),
+        new VerificationMethod({
+          id: assertionVerificationMethodId,
+          type: 'Multikey',
+          controller: issuerId,
+          publicKeyMultibase: assertionKeyMultibase,
+        }),
+      ],
+      authentication: [updateVerificationMethodId],
+      assertionMethod: [assertionVerificationMethodId],
+    })
+
+    await agentContext.dependencyManager.resolve(DidRepository).save(
+      agentContext,
+      new DidRecord({
+        did: issuerId,
+        role: DidDocumentRole.Created,
+        didDocument,
+        keys: [
+          { kmsKeyId: updateKey.keyId, didDocumentRelativeKeyId: `#${updateKeyMultibase.slice(-8)}` },
+          { kmsKeyId: assertionKey.keyId, didDocumentRelativeKeyId: `#${assertionKeyMultibase.slice(-8)}` },
+        ],
+      })
+    )
+
+    registry = new WebVhAnonCredsRegistry()
+  })
+
+  it('signs with the assertionMethod key and the resource round-trips through getSchema', async () => {
+    const { registrationMetadata, schemaState } = await registry.registerSchema(agentContext, { schema })
+
+    const attestedResource = JSON.parse(JSON.stringify(registrationMetadata.attestedResource))
+    expect(attestedResource.proof.proofPurpose).toBe('assertionMethod')
+    expect(attestedResource.proof.verificationMethod).toBe(assertionVerificationMethodId)
+    expect(attestedResource.proof.verificationMethod).not.toBe(updateVerificationMethodId)
+
+    if (schemaState.state !== 'finished') throw new Error(`registerSchema did not finish: ${schemaState.state}`)
+    const { schemaId } = schemaState
+
+    resolveResource.mockResolvedValue({
+      content: attestedResource,
+      dereferencingMetadata: { contentType: 'application/json' },
+    })
+
+    const schemaResponse = await registry.getSchema(agentContext, schemaId)
+
+    expect(resolveResource).toHaveBeenCalledWith(agentContext, schemaId)
+    expect(schemaResponse.resolutionMetadata.error).toBeUndefined()
+    expect(schemaResponse.schema).toEqual(schema)
+  })
+
+  it('rejects an explicit verification method that is not authorized for assertionMethod', async () => {
+    await expect(
+      registry.registerSchema(agentContext, {
+        schema,
+        options: { verificationMethod: updateVerificationMethodId },
+      })
+    ).rejects.toThrow(
+      `Verification method '${updateVerificationMethodId}' is not authorized for 'assertionMethod' in the did document of issuer ${issuerId}`
+    )
+  })
+
+  it('throws when the did document has no verification method authorized for assertionMethod', async () => {
+    const didRepository = agentContext.dependencyManager.resolve(DidRepository)
+    const didRecord = await didRepository.getSingleByQuery(agentContext, { did: issuerId })
+    const didDocument = didRecord.didDocument
+    if (!didDocument) throw new Error('did record has no did document')
+    didDocument.assertionMethod = []
+    await didRepository.update(agentContext, didRecord)
+
+    await expect(registry.registerSchema(agentContext, { schema })).rejects.toThrow(
+      `No verification method authorized for 'assertionMethod' found in the did document of issuer ${issuerId}`
+    )
+  })
+
+  it('does not verify a resource signed with a verification method outside assertionMethod', async () => {
+    const unsecuredDocument = {
+      '@context': [
+        'https://identity.foundation/did-attested-resources/context/v0.1',
+        'https://w3id.org/security/data-integrity/v2',
+      ],
+      type: ['AttestedResource'],
+      id: `${issuerId}/resources/zQmSmhgCkiknv5HpLWiiNjgcurgQvwhUqiu8MSGMDVJt3xK`,
+      content: schema,
+      metadata: { resourceType: 'anonCredsSchema', resourceName: schema.name },
+    }
+
+    // Signing succeeds, as the agent holds the update key, but the proof is not verifiable
+    const proof = await registry.createProof(agentContext, unsecuredDocument, updateVerificationMethodId)
+
+    await expect(
+      registry.verifyProof(agentContext, JSON.parse(JSON.stringify({ ...unsecuredDocument, proof })))
+    ).resolves.toBe(false)
+  })
+
+  it('re-signs an updated revocation registry definition with an authorized verification method', async () => {
+    const metadata = { resourceType: 'anonCredsRevocRegDef', resourceName: 'default' }
+
+    // A resource first signed with the unauthorized update key is healed on update
+    const previousProof = await registry.createProof(agentContext, metadata, updateVerificationMethodId)
+    // updateRevocationRegistryDefinition declares its metadata as Record<string, object> and its
+    // proof as the legacy linked-data Proof, neither of which describes an attested resource or
+    // the proof createProof returns, so realistic input only reaches it through a cast.
+    const previousMetadata = { ...metadata, proof: previousProof } as unknown as { proof: Proof } & Record<
+      string,
+      object
+    >
+    const { registrationMetadata } = await registry.updateRevocationRegistryDefinition(agentContext, previousMetadata, {
+      extra: { updated: true },
+    })
+
+    const updated = JSON.parse(JSON.stringify(registrationMetadata))
+    expect(updated.proof.verificationMethod).toBe(assertionVerificationMethodId)
+    expect(updated.extra).toEqual({ updated: true })
+  })
+
+  it('prefers an assertionMethod key the agent holds over one it does not', async () => {
+    const didRepository = agentContext.dependencyManager.resolve(DidRepository)
+    const didRecord = await didRepository.getSingleByQuery(agentContext, { did: issuerId })
+    const didDocument = didRecord.didDocument
+    if (!didDocument) throw new Error('did record has no did document')
+
+    // A delegate key the agent has no private key for, listed ahead of the agent's own key
+    const foreignVerificationMethodId = `${issuerId}#foreignkey`
+    didDocument.verificationMethod = [
+      ...(didDocument.verificationMethod ?? []),
+      new VerificationMethod({
+        id: foreignVerificationMethodId,
+        type: 'Multikey',
+        controller: issuerId,
+        publicKeyMultibase: 'z6MkukEa8GPVCEPy7EzRSbeHPXD1vsuPy3eD13CkDKQsoCGS',
+      }),
+    ]
+    didDocument.assertionMethod = [foreignVerificationMethodId, assertionVerificationMethodId]
+    await didRepository.update(agentContext, didRecord)
+
+    const { registrationMetadata } = await registry.registerSchema(agentContext, { schema })
+
+    const attestedResource = JSON.parse(JSON.stringify(registrationMetadata.attestedResource))
+    expect(attestedResource.proof.verificationMethod).toBe(assertionVerificationMethodId)
+  })
+})

--- a/packages/webvh/src/anoncreds/services/__tests__/WebVhAnonCredsRegistry.test.ts
+++ b/packages/webvh/src/anoncreds/services/__tests__/WebVhAnonCredsRegistry.test.ts
@@ -21,6 +21,7 @@ import {
   mockResolvedDidRecord,
   mockRevRegDefResource,
   mockSchemaResource,
+  verificationMethodId,
 } from './mock-resources'
 
 // Mock the WebVhDidResolver
@@ -358,6 +359,11 @@ describe('WebVhAnonCredsRegistry', () => {
         },
       })
 
+      // The resource must be signed with a verification method authorized for assertionMethod
+      expect(mockDataIntegrityCreateProofOrThrow).toHaveBeenCalledWith(
+        expect.objectContaining({ verificationMethod: verificationMethodId, proofPurpose: 'assertionMethod' })
+      )
+
       const schemaResponse = await registry.getSchema(agentContext, schemaId)
 
       expect(mockResolveResource).toHaveBeenCalledWith(agentContext, schemaId)
@@ -644,7 +650,9 @@ describe('WebVhAnonCredsRegistry', () => {
       const result = await registry.verifyProof(agentContext, mockSchemaResource)
 
       expect(result).toBe(true)
-      expect(mockDataIntegrityVerifyProof).toHaveBeenCalledWith(mockSchemaResource)
+      expect(mockDataIntegrityVerifyProof).toHaveBeenCalledWith(mockSchemaResource, {
+        expectedProofPurpose: 'assertionMethod',
+      })
     })
 
     it('should return false for null proof', async () => {
@@ -659,7 +667,7 @@ describe('WebVhAnonCredsRegistry', () => {
       })
       const result = await registry.verifyProof(agentContext, testInput)
       expect(result).toBe(false)
-      expect(mockDataIntegrityVerifyProof).toHaveBeenCalledWith(testInput)
+      expect(mockDataIntegrityVerifyProof).toHaveBeenCalledWith(testInput, { expectedProofPurpose: 'assertionMethod' })
     })
 
     it('should return false for undefined proof', async () => {
@@ -674,7 +682,7 @@ describe('WebVhAnonCredsRegistry', () => {
       })
       const result = await registry.verifyProof(agentContext, testInput)
       expect(result).toBe(false)
-      expect(mockDataIntegrityVerifyProof).toHaveBeenCalledWith(testInput)
+      expect(mockDataIntegrityVerifyProof).toHaveBeenCalledWith(testInput, { expectedProofPurpose: 'assertionMethod' })
     })
 
     it('should return false for non-object proof', async () => {
@@ -689,7 +697,7 @@ describe('WebVhAnonCredsRegistry', () => {
       })
       const result = await registry.verifyProof(agentContext, testInput)
       expect(result).toBe(false)
-      expect(mockDataIntegrityVerifyProof).toHaveBeenCalledWith(testInput)
+      expect(mockDataIntegrityVerifyProof).toHaveBeenCalledWith(testInput, { expectedProofPurpose: 'assertionMethod' })
     })
 
     it('should return false for wrong proof type', async () => {
@@ -705,7 +713,7 @@ describe('WebVhAnonCredsRegistry', () => {
       })
       const result = await registry.verifyProof(agentContext, testInput)
       expect(result).toBe(false)
-      expect(mockDataIntegrityVerifyProof).toHaveBeenCalledWith(testInput)
+      expect(mockDataIntegrityVerifyProof).toHaveBeenCalledWith(testInput, { expectedProofPurpose: 'assertionMethod' })
     })
 
     it('should return false for wrong cryptosuite', async () => {
@@ -721,7 +729,7 @@ describe('WebVhAnonCredsRegistry', () => {
       })
       const result = await registry.verifyProof(agentContext, testInput)
       expect(result).toBe(false)
-      expect(mockDataIntegrityVerifyProof).toHaveBeenCalledWith(testInput)
+      expect(mockDataIntegrityVerifyProof).toHaveBeenCalledWith(testInput, { expectedProofPurpose: 'assertionMethod' })
     })
 
     it('should return false for missing verificationMethod', async () => {
@@ -738,7 +746,7 @@ describe('WebVhAnonCredsRegistry', () => {
       })
       const result = await registry.verifyProof(agentContext, testInput)
       expect(result).toBe(false)
-      expect(mockDataIntegrityVerifyProof).toHaveBeenCalledWith(testInput)
+      expect(mockDataIntegrityVerifyProof).toHaveBeenCalledWith(testInput, { expectedProofPurpose: 'assertionMethod' })
     })
 
     it('should return false for invalid verificationMethod type', async () => {
@@ -755,7 +763,7 @@ describe('WebVhAnonCredsRegistry', () => {
       })
       const result = await registry.verifyProof(agentContext, testInput)
       expect(result).toBe(false)
-      expect(mockDataIntegrityVerifyProof).toHaveBeenCalledWith(testInput)
+      expect(mockDataIntegrityVerifyProof).toHaveBeenCalledWith(testInput, { expectedProofPurpose: 'assertionMethod' })
     })
 
     it('should return false for missing proofValue', async () => {
@@ -772,7 +780,7 @@ describe('WebVhAnonCredsRegistry', () => {
       })
       const result = await registry.verifyProof(agentContext, testInput)
       expect(result).toBe(false)
-      expect(mockDataIntegrityVerifyProof).toHaveBeenCalledWith(testInput)
+      expect(mockDataIntegrityVerifyProof).toHaveBeenCalledWith(testInput, { expectedProofPurpose: 'assertionMethod' })
     })
 
     it('should return false for invalid proofValue type', async () => {
@@ -789,7 +797,7 @@ describe('WebVhAnonCredsRegistry', () => {
       })
       const result = await registry.verifyProof(agentContext, testInput)
       expect(result).toBe(false)
-      expect(mockDataIntegrityVerifyProof).toHaveBeenCalledWith(testInput)
+      expect(mockDataIntegrityVerifyProof).toHaveBeenCalledWith(testInput, { expectedProofPurpose: 'assertionMethod' })
     })
 
     it('should return false when core Data Integrity verification reports failure', async () => {
@@ -809,7 +817,7 @@ describe('WebVhAnonCredsRegistry', () => {
 
       const result = await registry.verifyProof(agentContext, testInput)
       expect(result).toBe(false)
-      expect(mockDataIntegrityVerifyProof).toHaveBeenCalledWith(testInput)
+      expect(mockDataIntegrityVerifyProof).toHaveBeenCalledWith(testInput, { expectedProofPurpose: 'assertionMethod' })
     })
 
     it('should return false when core Data Integrity verification throws', async () => {
@@ -819,7 +827,7 @@ describe('WebVhAnonCredsRegistry', () => {
 
       const result = await registry.verifyProof(agentContext, testInput)
       expect(result).toBe(false)
-      expect(mockDataIntegrityVerifyProof).toHaveBeenCalledWith(testInput)
+      expect(mockDataIntegrityVerifyProof).toHaveBeenCalledWith(testInput, { expectedProofPurpose: 'assertionMethod' })
     })
 
     it('should return false when proof verification fails for invalid proof value', async () => {
@@ -842,7 +850,7 @@ describe('WebVhAnonCredsRegistry', () => {
 
       const result = await registry.verifyProof(agentContext, testInput)
       expect(result).toBe(false)
-      expect(mockDataIntegrityVerifyProof).toHaveBeenCalledWith(testInput)
+      expect(mockDataIntegrityVerifyProof).toHaveBeenCalledWith(testInput, { expectedProofPurpose: 'assertionMethod' })
     })
 
     it('should handle proof without optional fields', async () => {
@@ -850,7 +858,7 @@ describe('WebVhAnonCredsRegistry', () => {
       const result = await registry.verifyProof(agentContext, testInput)
 
       expect(result).toBe(true)
-      expect(mockDataIntegrityVerifyProof).toHaveBeenCalledWith(testInput)
+      expect(mockDataIntegrityVerifyProof).toHaveBeenCalledWith(testInput, { expectedProofPurpose: 'assertionMethod' })
     })
   })
 })

--- a/packages/webvh/src/anoncreds/services/__tests__/mock-resources.ts
+++ b/packages/webvh/src/anoncreds/services/__tests__/mock-resources.ts
@@ -1,3 +1,5 @@
+import { DidDocument, JsonTransformer } from '@credo-ts/core'
+
 export const issuerId = 'did:webvh:QmXysm9EF3kPH4fdCWf48YqCzREgiAe5nFXG3RCXaCShFX:id.test-suite.app:credo:01'
 export const verificationMethodId = `${issuerId}#z6MkukEa8GPVCEPy7EzRSbeHPXD1vsuPy3eD13CkDKQsoCGS`
 export const schemaId = `${issuerId}/resources/zQmSmhgCkiknv5HpLWiiNjgcurgQvwhUqiu8MSGMDVJt3xK`
@@ -65,7 +67,7 @@ export const mockSchemaResource = {
 export const mockResolvedDidRecord = {
   did: 'did:webvh:QmXysm9EF3kPH4fdCWf48YqCzREgiAe5nFXG3RCXaCShFX:id.test-suite.app:credo:01',
   role: 'created',
-  didDocument: mockResolvedDidDocument,
+  didDocument: JsonTransformer.fromJSON(mockResolvedDidDocument, DidDocument),
   getTag: (key: string) => {
     if (key === 'domain') return 'id.test-suite.app/credo/01'
     return undefined

--- a/packages/webvh/src/dids/WebVhDidRegistrar.ts
+++ b/packages/webvh/src/dids/WebVhDidRegistrar.ts
@@ -82,6 +82,12 @@ export class WebVhDidRegistrar implements DidRegistrar {
       const verifier = new WebVhDidCrypto(agentContext)
       const baseDid = `did:webvh:{SCID}:${encodeURIComponent(domain)}`
 
+      // didwebvh-ts derives verification method ids as `<did>#<last 8 chars of publicKeyMultibase>`.
+      // We reference the key relatively, as the full id is only known once the SCID has been
+      // derived, and a relative reference is unaffected by the {SCID} substitution that happens
+      // while the initial log entry is hashed.
+      const verificationMethodFragment = `#${publicKeyMultibase.slice(-8)}`
+
       // Create DID
       const { did, doc, log } = await createDID({
         domain,
@@ -95,6 +101,11 @@ export class WebVhDidRegistrar implements DidRegistrar {
             publicKeyMultibase,
           },
         ],
+        // didwebvh-ts places verification methods without a purpose in `authentication` only, and
+        // emits an empty `assertionMethod`. Without this, every attested resource signed by this
+        // did would be unverifiable. Setting `purpose: 'assertionMethod'` on the verification
+        // method is not an alternative, as that would empty `authentication` instead.
+        assertionMethod: [verificationMethodFragment],
         verifier,
       })
 
@@ -171,8 +182,17 @@ export class WebVhDidRegistrar implements DidRegistrar {
         service: services,
         verificationMethod: inputVerificationMethod,
       } = inputDidDocument
-      const verificationMethods =
-        inputVerificationMethod ?? (log[log.length - 1].state.verificationMethod as VerificationMethod[])
+      const lastState = log[log.length - 1].state
+      const verificationMethods = inputVerificationMethod ?? (lastState.verificationMethod as VerificationMethod[])
+      // didwebvh-ts resets the verification relationships whenever verification methods are
+      // supplied, so we fall back to the last log state to avoid dropping `assertionMethod` for
+      // callers that only intend to update e.g. the services. References to keys that the update
+      // removes are left behind, as carrying them over would publish a dangling reference.
+      const assertionMethodRefs =
+        normalizeMethodArray(assertionMethod) ??
+        (lastState.assertionMethod as string[] | undefined)?.filter((reference) =>
+          verificationMethods?.some((vm) => vm.id.endsWith(reference))
+        )
       const { updateKeys } = log[log.length - 1].parameters
       const verificationMethod = verificationMethods?.find((vm) => vm.publicKeyMultibase)
       if (!verificationMethod?.publicKeyMultibase)
@@ -192,7 +212,7 @@ export class WebVhDidRegistrar implements DidRegistrar {
         verificationMethods: verificationMethods as unknown as WebVhVerificationMethod[],
         controller: Array.isArray(controller) ? controller[0] : controller,
         authentication: normalizeMethodArray(authentication),
-        assertionMethod: normalizeMethodArray(assertionMethod),
+        assertionMethod: assertionMethodRefs,
         keyAgreement: normalizeMethodArray(keyAgreement),
         services: services as unknown as WebVhServiceEndpoint[],
       })

--- a/packages/webvh/src/dids/__tests__/WebVhDidRegistrar.boundary.test.ts
+++ b/packages/webvh/src/dids/__tests__/WebVhDidRegistrar.boundary.test.ts
@@ -16,10 +16,12 @@
 
 import {
   CacheModuleConfig,
+  DidDocument,
   DidDocumentService,
   DidRepository,
   InjectionSymbols,
   InMemoryLruCache,
+  VerificationMethod,
 } from '@credo-ts/core'
 import { resolveDIDFromLog } from 'didwebvh-ts'
 import { Subject } from 'rxjs'
@@ -185,6 +187,77 @@ describe('WebVhDidRegistrar boundary contracts', () => {
       expect(resolved.did).toBe(did)
       expect(resolved.meta.error).toBeUndefined()
       expect(resolved.doc.service).toBeDefined()
+    })
+  })
+
+  describe('assertionMethod conformance', () => {
+    it('references the created key from assertionMethod, and the log still resolves upstream', async () => {
+      const result = await registrar.create(agentContext, { domain: 'id.boundary-test.app', path: 'credo/01' })
+      const { did, didDocument } = result.didState
+      if (!did || !didDocument) throw new Error('create failed')
+
+      // Without an explicit assertionMethod, didwebvh-ts emits an empty array here, which makes
+      // every attested resource signed by this did unverifiable.
+      expect(didDocument.assertionMethod).toHaveLength(1)
+      const verificationMethod = didDocument.dereferenceKey(didDocument.assertionMethod?.[0] as string, [
+        'assertionMethod',
+      ])
+      expect(verificationMethod.publicKeyMultibase).toBe(didDocument.verificationMethod?.[0].publicKeyMultibase)
+
+      // The relative reference must not disturb the {SCID} substitution the initial entry is hashed over
+      const record = await repository.findSingleByQuery(agentContext, { did })
+      const log = record?.metadata.get(WebVhDidRecordMetadataKeys.DidLog) as WebVhDidLog
+      const resolved = await resolveDIDFromLog(log, { verifier: new WebVhDidCrypto(agentContext) })
+
+      expect(resolved.meta.error).toBeUndefined()
+      expect(resolved.doc.assertionMethod).toEqual(didDocument.assertionMethod)
+    })
+
+    it('preserves assertionMethod across an update that does not set it', async () => {
+      const createResult = await registrar.create(agentContext, { domain: 'id.boundary-test.app' })
+      const { did, didDocument } = createResult.didState
+      if (!did || !didDocument) throw new Error('create failed')
+      const assertionMethod = didDocument.assertionMethod
+
+      // didwebvh-ts resets the verification relationships whenever verification methods are
+      // supplied, so an update that only changes the services must not drop assertionMethod.
+      didDocument.assertionMethod = undefined
+      didDocument.service = [
+        new DidDocumentService({ id: '#test', type: 'TestService', serviceEndpoint: 'https://example.com' }),
+      ]
+      const updateResult = await registrar.update(agentContext, { did, didDocument })
+
+      expect(updateResult.didState.state).toBe('finished')
+      expect(updateResult.didState.didDocument?.assertionMethod).toEqual(assertionMethod)
+    })
+
+    it('drops assertionMethod references to verification methods an update removes', async () => {
+      const createResult = await registrar.create(agentContext, { domain: 'id.boundary-test.app' })
+      const { did, didDocument } = createResult.didState
+      if (!did || !didDocument) throw new Error('create failed')
+
+      // The update key must stay first, as the registrar signs the log entry with it
+      const updateKeyVerificationMethod = didDocument.verificationMethod?.[0] as VerificationMethod
+      const extraVerificationMethod = new VerificationMethod({
+        id: `${did}#extrakey1`,
+        type: 'Multikey',
+        controller: did,
+        publicKeyMultibase: 'z6MkukEa8GPVCEPy7EzRSbeHPXD1vsuPy3eD13CkDKQsoCGS',
+      })
+
+      didDocument.verificationMethod = [updateKeyVerificationMethod, extraVerificationMethod]
+      didDocument.assertionMethod = [updateKeyVerificationMethod.id, extraVerificationMethod.id]
+      const withExtraKey = await registrar.update(agentContext, { did, didDocument })
+      expect(withExtraKey.didState.didDocument?.assertionMethod).toHaveLength(2)
+
+      // Removing the extra key without restating assertionMethod must not carry its reference over
+      const rotated = withExtraKey.didState.didDocument as DidDocument
+      rotated.verificationMethod = [updateKeyVerificationMethod]
+      rotated.assertionMethod = undefined
+      const updateResult = await registrar.update(agentContext, { did, didDocument: rotated })
+
+      expect(updateResult.didState.state).toBe('finished')
+      expect(updateResult.didState.didDocument?.assertionMethod).toEqual([updateKeyVerificationMethod.id])
     })
   })
 


### PR DESCRIPTION
Attested resource proofs use the `assertionMethod` proof purpose, but the signing key was selected as `verificationMethod[0]` without checking that it is referenced from `assertionMethod`. Resources were written successfully and then failed to resolve with `Resolved resource proof is invalid.`

The mismatch dates to #2396, but was masked by the vendored `eddsa-jcs-2022` cryptosuite, which dereferenced the key without validating the verification relationship. #2925 routed verification through the core `W3cDataIntegrityApi`, which does validate it, so this surfaces there and has not been in a stable release.

- Resource registration selects a verification method authorized for `assertionMethod`, preferring one the agent holds a key for, and validates an explicitly passed `options.verificationMethod` against the purpose.
- `createDID` now references the created key from `assertionMethod`; previously didwebvh-ts placed it in `authentication` only, so no did the registrar created could sign a verifiable resource. Updating a did no longer drops the reference, and drops stale ones for removed keys.
- `verifyProof` asserts the expected proof purpose and logs the verifier's issues.

Existing dids need an `agent.dids.update` adding the reference, and the updated log republished, before their resources verify.