### PR TITLE
feat(DidDocument): keyType and Purpose-aware Verification Method helpers

### DIFF
--- a/.changeset/bright-keys-search.md
+++ b/.changeset/bright-keys-search.md
@@ -1,0 +1,20 @@
+---
+"@credo-ts/core": minor
+"@credo-ts/anoncreds": patch
+"@credo-ts/cheqd": patch
+"@credo-ts/didcomm": patch
+"@credo-ts/webvh": patch
+---
+
+Add `DidDocument.findVerificationMethodsByPurpose` and
+`DidDocument.findVerificationMethodsByTypeAndPurpose`.
+
+The relationship-aware methods resolve inline and referenced methods and
+return them in requested relationship order while preserving entry order
+within each relationship. The type-filtered method accepts one or more
+verification-method representations and delegates relationship traversal to
+the purpose-only method. DIDComm JSON-LD, JWT credentials, presentation
+selection, DIDComm messaging, AnonCreds data integrity, Cheqd signing, peer
+DID conversion, and did:webvh signing now use the appropriate shared lookup.
+AnonCreds credential signing prefers verification methods authorized for
+`assertionMethod`, with declared `verificationMethod` entries as a fallback.

--- a/packages/anoncreds/src/formats/DataIntegrityDidCommCredentialFormatService.ts
+++ b/packages/anoncreds/src/formats/DataIntegrityDidCommCredentialFormatService.ts
@@ -557,18 +557,18 @@ export class DataIntegrityDidCommCredentialFormatService
 
     let verificationMethod: VerificationMethod
     if (issuerVerificationMethod) {
-      verificationMethod = didDocument.dereferenceKey(issuerVerificationMethod, ['authentication', 'assertionMethod'])
+      verificationMethod = didDocument.dereferenceKey(issuerVerificationMethod, [
+        'assertionMethod',
+        'verificationMethod',
+      ])
     } else {
-      const vms = didDocument.authentication ?? didDocument.assertionMethod ?? didDocument.verificationMethod
+      const vms = didDocument.findVerificationMethodsByPurpose(['assertionMethod', 'verificationMethod'])
+
       if (!vms || vms.length === 0) {
-        throw new CredoError('Missing authenticationMethod, assertionMethod, and verificationMethods in did document')
+        throw new CredoError('Missing assertionMethod or verificationMethod in did document')
       }
 
-      if (typeof vms[0] === 'string') {
-        verificationMethod = didDocument.dereferenceVerificationMethod(vms[0])
-      } else {
-        verificationMethod = vms[0]
-      }
+      verificationMethod = vms[0]
     }
 
     const signatureSuiteRegistry = agentContext.dependencyManager.resolve(SignatureSuiteRegistry)

--- a/packages/cheqd/src/dids/CheqdDidRegistrar.ts
+++ b/packages/cheqd/src/dids/CheqdDidRegistrar.ts
@@ -227,9 +227,7 @@ export class CheqdDidRegistrar implements DidRegistrar {
       const didDocumentJson = didDocument.toJSON() as DIDDocument
       const payloadToSign = await createMsgCreateDidDocPayloadToSign(didDocumentJson, versionId)
 
-      const authentication = didDocument.authentication?.map((authentication) =>
-        typeof authentication === 'string' ? didDocument.dereferenceVerificationMethod(authentication) : authentication
-      )
+      const authentication = didDocument.findVerificationMethodsByPurpose(['authentication'])
       if (!authentication || authentication.length === 0) {
         return {
           didDocumentMetadata: {},
@@ -440,9 +438,7 @@ export class CheqdDidRegistrar implements DidRegistrar {
 
       const payloadToSign = await createMsgCreateDidDocPayloadToSign(didDocument.toJSON() as DIDDocument, versionId)
 
-      const authentication = didDocument.authentication?.map((authentication) =>
-        typeof authentication === 'string' ? didDocument.dereferenceVerificationMethod(authentication) : authentication
-      )
+      const authentication = didDocument.findVerificationMethodsByPurpose(['authentication'])
       if (!authentication || authentication.length === 0) {
         return {
           didDocumentMetadata: {},
@@ -523,11 +519,7 @@ export class CheqdDidRegistrar implements DidRegistrar {
       const payloadToSign = createMsgDeactivateDidDocPayloadToSign(didDocument, versionId)
       const didDocumentInstance = DidDocument.fromJSON(didDocument)
 
-      const authentication = didDocumentInstance.authentication?.map((authentication) =>
-        typeof authentication === 'string'
-          ? didDocumentInstance.dereferenceVerificationMethod(authentication)
-          : authentication
-      )
+      const authentication = didDocumentInstance.findVerificationMethodsByPurpose(['authentication'])
       if (!authentication || authentication.length === 0) {
         return {
           didDocumentMetadata: {},

--- a/packages/core/src/modules/dcql/DcqlService.ts
+++ b/packages/core/src/modules/dcql/DcqlService.ts
@@ -993,11 +993,7 @@ export class DcqlService {
 
     // the signature suite to use for the presentation is dependant on the credentials we share.
     // 1. Get the verification method for this given proof purpose in this DID document
-    let [verificationMethod] = didDocument.authentication
-    if (typeof verificationMethod === 'string') {
-      verificationMethod = didDocument.dereferenceKey(verificationMethod, ['authentication'])
-    }
-
+    const [verificationMethod] = didDocument.findVerificationMethodsByPurpose(['authentication'])
     return verificationMethod
   }
 

--- a/packages/core/src/modules/dids/domain/DidDocument.ts
+++ b/packages/core/src/modules/dids/domain/DidDocument.ts
@@ -148,6 +148,29 @@ export class DidDocument {
     throw new CredoError(`Unable to locate verification method with id '${keyId}' in purposes ${purposes}`)
   }
 
+  public findVerificationMethodsByPurpose(allowedPurposes: readonly DidVerificationMethods[]): VerificationMethod[] {
+    const methods: VerificationMethod[] = []
+
+    for (const purpose of allowedPurposes) {
+      for (const entry of this[purpose] ?? []) {
+        methods.push(typeof entry === 'string' ? this.dereferenceVerificationMethod(entry) : entry)
+      }
+    }
+
+    return methods
+  }
+
+  public findVerificationMethodsByTypeAndPurpose(
+    verificationMethodTypes: string | readonly string[],
+    allowedPurposes: readonly DidVerificationMethods[]
+  ): VerificationMethod[] {
+    const acceptedTypes = new Set(
+      typeof verificationMethodTypes === 'string' ? [verificationMethodTypes] : verificationMethodTypes
+    )
+
+    return this.findVerificationMethodsByPurpose(allowedPurposes).filter((method) => acceptedTypes.has(method.type))
+  }
+
   private matchKeyId(externalKeyId: string, didDocumentKeyId: string) {
     // Compact is did removed from start but only if it matches the id of this document.
     const compactExternalKeyId = externalKeyId.startsWith(this.id) ? externalKeyId.slice(this.id.length) : externalKeyId
@@ -326,41 +349,4 @@ export class DidDocument {
   public static fromJSON(didDocument: unknown) {
     return JsonTransformer.fromJSON(didDocument, DidDocument)
   }
-}
-
-/**
- * Extracting the verification method for signature type
- * @param keyType Signature key type
- * @param didDocument DidDocument
- * @param allowedPurposes Optional array of purposes to search in order. Defaults to all purposes.
- * @returns verification method
- */
-export async function findVerificationMethodByKeyType(
-  keyType: string,
-  didDocument: DidDocument,
-  allowedPurposes?: DidVerificationMethods[]
-): Promise<VerificationMethod | null> {
-  const allPurposes: DidVerificationMethods[] = [
-    'verificationMethod',
-    'authentication',
-    'keyAgreement',
-    'assertionMethod',
-    'capabilityInvocation',
-    'capabilityDelegation',
-  ]
-  const purposes = allowedPurposes ?? allPurposes
-  for (const purpose of purposes) {
-    const key: VerificationMethod[] | (string | VerificationMethod)[] | undefined = didDocument[purpose]
-    if (Array.isArray(key)) {
-      for (const method of key) {
-        if (typeof method !== 'string') {
-          if (method.type === keyType) {
-            return method
-          }
-        }
-      }
-    }
-  }
-
-  return null
 }

--- a/packages/core/src/modules/dids/domain/__tests__/DidDocument.test.ts
+++ b/packages/core/src/modules/dids/domain/__tests__/DidDocument.test.ts
@@ -2,7 +2,7 @@ import { ClassValidationError } from '../../../../error/ClassValidationError'
 import { JsonTransformer } from '../../../../utils/JsonTransformer'
 import didExample123Fixture from '../../__tests__/__fixtures__/didExample123.json'
 import didExample456Invalid from '../../__tests__/__fixtures__/didExample456Invalid.json'
-import { DidDocument, findVerificationMethodByKeyType } from '../DidDocument'
+import { DidDocument } from '../DidDocument'
 import { DidCommV1Service, DidDocumentService, IndyAgentService } from '../service'
 import { VerificationMethod } from '../verificationMethod'
 
@@ -244,11 +244,100 @@ describe('Did | DidDocument', () => {
     })
   })
 
-  describe('findVerificationMethodByKeyType', () => {
-    it('return first verification method that match key type', async () => {
-      expect(await findVerificationMethodByKeyType('Ed25519VerificationKey2018', didDocumentInstance)).toBeInstanceOf(
-        VerificationMethod
+  describe('findVerificationMethodsByTypeAndPurpose', () => {
+    it('matches an inline method by type and relationship', () => {
+      const inlineMethod = new VerificationMethod({
+        id: 'did:example:123#inline-1',
+        type: 'RsaVerificationKey2018',
+        controller: 'did:example:123',
+        publicKeyPem: '-----BEGIN PUBLIC INLINE...',
+      })
+      const didDocument = new DidDocument({
+        id: 'did:example:123',
+        verificationMethod: [inlineMethod],
+        assertionMethod: [inlineMethod],
+      })
+      const method = didDocument.findVerificationMethodsByTypeAndPurpose('RsaVerificationKey2018', ['assertionMethod'])
+
+      expect(method[0]?.id).toBe('did:example:123#inline-1')
+    })
+
+    it('resolves referenced methods and preserves relationship entry order', () => {
+      const method = didDocumentInstance.findVerificationMethodsByTypeAndPurpose('RsaVerificationKey2018', [
+        'authentication',
+      ])
+
+      expect(method[0]?.id).toBe('did:example:123#key-1')
+    })
+
+    it('matches any accepted type without using input type order as preference', () => {
+      const method = didDocumentInstance.findVerificationMethodsByTypeAndPurpose(
+        ['RsaVerificationKey2018', 'Ed25519VerificationKey2018'],
+        ['verificationMethod']
       )
+
+      expect(method[0]?.id).toBe('did:example:123#key-1')
+    })
+
+    it('selects matching types from a mixed assertionMethod relationship', () => {
+      const ed25519Method = new VerificationMethod({
+        id: 'did:example:123#ed25519-2018',
+        type: 'Ed25519VerificationKey2018',
+        controller: 'did:example:123',
+        publicKeyBase58: 'ed25519-public-key',
+      })
+      const multikeyMethod = new VerificationMethod({
+        id: 'did:example:123#multikey',
+        type: 'Multikey',
+        controller: 'did:example:123',
+        publicKeyMultibase: 'z6Mk-multikey-public-key',
+      })
+      const authenticationMethod = new VerificationMethod({
+        id: 'did:example:123#multikey-authentication',
+        type: 'Multikey',
+        controller: 'did:example:123',
+        publicKeyMultibase: 'z6Mk-authentication-public-key',
+      })
+      const didDocument = new DidDocument({
+        id: 'did:example:123',
+        verificationMethod: [ed25519Method, multikeyMethod, authenticationMethod],
+        assertionMethod: [ed25519Method.id, multikeyMethod.id],
+        authentication: [authenticationMethod.id],
+      })
+
+      expect(
+        didDocument
+          .findVerificationMethodsByTypeAndPurpose('Ed25519VerificationKey2018', ['assertionMethod'])
+          .map((method) => method.id)
+      ).toEqual([ed25519Method.id])
+      expect(
+        didDocument.findVerificationMethodsByTypeAndPurpose('Multikey', ['authentication']).map((method) => method.id)
+      ).toEqual([authenticationMethod.id])
+      expect(
+        didDocument.findVerificationMethodsByTypeAndPurpose('Multikey', ['assertionMethod']).map((method) => method.id)
+      ).toEqual([multikeyMethod.id])
+      expect(
+        didDocument
+          .findVerificationMethodsByTypeAndPurpose(['Multikey', 'Ed25519VerificationKey2018'], ['assertionMethod'])
+          .map((method) => method.id)
+      ).toEqual([ed25519Method.id, multikeyMethod.id])
+      expect(didDocument.findVerificationMethodsByTypeAndPurpose('JsonWebKey2020', ['assertionMethod'])).toEqual([])
+    })
+
+    it('matches every type when no type filter is provided', () => {
+      const methods = didDocumentInstance.findVerificationMethodsByPurpose(['verificationMethod'])
+
+      expect(methods.map((method) => method.id)).toEqual([
+        'did:example:123#key-1',
+        'did:example:123#key-2',
+        'did:example:123#key-3',
+      ])
+    })
+
+    it('returns an empty array when no method matches the type and relationship', () => {
+      expect(
+        didDocumentInstance.findVerificationMethodsByTypeAndPurpose('Ed25519VerificationKey2018', ['authentication'])
+      ).toEqual([])
     })
   })
 })

--- a/packages/core/src/modules/dids/methods/peer/peerDidNumAlgo2.ts
+++ b/packages/core/src/modules/dids/methods/peer/peerDidNumAlgo2.ts
@@ -2,7 +2,7 @@ import { CredoError } from '../../../../error'
 import type { JsonObject } from '../../../../types'
 import { JsonEncoder, JsonTransformer } from '../../../../utils'
 import { PublicJwk } from '../../../kms'
-import type { DidDocument, VerificationMethod } from '../../domain'
+import type { DidDocument, DidPurpose, VerificationMethod } from '../../domain'
 import { DidDocumentService } from '../../domain'
 import { DidDocumentBuilder } from '../../domain/DidDocumentBuilder'
 import {
@@ -90,32 +90,26 @@ export function didToNumAlgo2DidDocument(did: string) {
 }
 
 export function didDocumentToNumAlgo2Did(didDocument: DidDocument) {
-  const purposeMapping = {
-    [DidPeerPurpose.Assertion]: didDocument.assertionMethod,
-    [DidPeerPurpose.Encryption]: didDocument.keyAgreement,
+  const purposeMapping: Array<[DidPeerPurpose, DidPurpose]> = [
+    [DidPeerPurpose.Assertion, 'assertionMethod'],
+    [DidPeerPurpose.Encryption, 'keyAgreement'],
     // FIXME: should verification be authentication or verificationMethod
     // verificationMethod is general so it doesn't make a lot of sense to add
     // it to the verificationMethod list
-    [DidPeerPurpose.Verification]: didDocument.authentication,
-    [DidPeerPurpose.CapabilityInvocation]: didDocument.capabilityInvocation,
-    [DidPeerPurpose.CapabilityDelegation]: didDocument.capabilityDelegation,
-  }
+    [DidPeerPurpose.Verification, 'authentication'],
+    [DidPeerPurpose.CapabilityInvocation, 'capabilityInvocation'],
+    [DidPeerPurpose.CapabilityDelegation, 'capabilityDelegation'],
+  ]
 
   let did = 'did:peer:2'
 
   const keys: { id: string; encoded: string }[] = []
 
-  for (const [purpose, entries] of Object.entries(purposeMapping)) {
+  for (const [purpose, entries] of purposeMapping) {
     // Not all entries are required to be defined
-    if (entries === undefined) continue
-
     // Dereference all entries to full verification methods
-    const dereferenced = entries.map((entry) =>
-      typeof entry === 'string' ? didDocument.dereferenceVerificationMethod(entry) : entry
-    )
-
     // Transform all verification methods into a fingerprint (multibase, multicodec)
-    for (const entry of dereferenced) {
+    for (const entry of didDocument.findVerificationMethodsByPurpose([entries])) {
       const key = getPublicJwkFromVerificationMethod(entry)
 
       // Encode as '.PurposeFingerprint'

--- a/packages/core/src/modules/dif-presentation-exchange/DifPresentationExchangeService.ts
+++ b/packages/core/src/modules/dif-presentation-exchange/DifPresentationExchangeService.ts
@@ -639,11 +639,7 @@ export class DifPresentationExchangeService {
 
     // the signature suite to use for the presentation is dependant on the credentials we share.
     // 1. Get the verification method for this given proof purpose in this DID document
-    let [verificationMethod] = didDocument.authentication
-    if (typeof verificationMethod === 'string') {
-      verificationMethod = didDocument.dereferenceKey(verificationMethod, ['authentication'])
-    }
-
+    const [verificationMethod] = didDocument.findVerificationMethodsByPurpose(['authentication'])
     return verificationMethod
   }
 

--- a/packages/core/src/modules/vc/jwt-vc/W3cJwtCredentialService.ts
+++ b/packages/core/src/modules/vc/jwt-vc/W3cJwtCredentialService.ts
@@ -514,10 +514,10 @@ export class W3cJwtCredentialService {
       const supportedVerificationMethodTypes = getSupportedVerificationMethodTypesForPublicJwk(jwkClass)
 
       const didDocument = await didResolver.resolveDidDocument(agentContext, signerId)
-      const verificationMethods =
-        didDocument.assertionMethod
-          ?.map((v) => (typeof v === 'string' ? didDocument.dereferenceVerificationMethod(v) : v))
-          .filter((v) => supportedVerificationMethodTypes.includes(v.type)) ?? []
+      const verificationMethods = didDocument.findVerificationMethodsByTypeAndPurpose(
+        supportedVerificationMethodTypes,
+        ['assertionMethod']
+      )
 
       if (verificationMethods.length === 0) {
         throw new CredoError(

--- a/packages/core/src/modules/vc/v2-jwt-utils.ts
+++ b/packages/core/src/modules/vc/v2-jwt-utils.ts
@@ -199,10 +199,9 @@ export async function getVerificationMethodForJwt(
     const supportedVerificationMethodTypes = getSupportedVerificationMethodTypesForPublicJwk(jwkClass)
 
     const didDocument = await didResolver.resolveDidDocument(agentContext, iss)
-    const verificationMethods =
-      didDocument.assertionMethod
-        ?.map((v) => (typeof v === 'string' ? didDocument.dereferenceVerificationMethod(v) : v))
-        .filter((v) => supportedVerificationMethodTypes.includes(v.type)) ?? []
+    const verificationMethods = didDocument.findVerificationMethodsByTypeAndPurpose(supportedVerificationMethodTypes, [
+      'assertionMethod',
+    ])
 
     if (verificationMethods.length === 0) {
       throw new CredoError(

--- a/packages/core/src/modules/vc/v2-jwt-utils.ts
+++ b/packages/core/src/modules/vc/v2-jwt-utils.ts
@@ -60,10 +60,7 @@ export async function extractHolderFromPresentationCredentials(
     const dids = agentContext.resolve(DidsApi)
     const { didDocument, keys } = await dids.resolveCreatedDidDocumentWithKeys(holderDid)
 
-    const authenticationMethods =
-      didDocument.authentication
-        ?.map((entry) => (typeof entry === 'string' ? didDocument.dereferenceVerificationMethod(entry) : entry))
-        .filter((entry): entry is VerificationMethod => !!entry) ?? []
+    const authenticationMethods = didDocument.findVerificationMethodsByPurpose(['authentication'])
 
     const candidateMethods = authenticationMethods.filter((method) =>
       keys?.some(({ didDocumentRelativeKeyId }) => method.id.endsWith(didDocumentRelativeKeyId))

--- a/packages/didcomm/src/DidCommMessageSender.ts
+++ b/packages/didcomm/src/DidCommMessageSender.ts
@@ -279,9 +279,9 @@ export class DidCommMessageSender {
       )
     })
 
-    const authentication = didDocument.authentication
-      ?.map((a) => {
-        const verificationMethod = typeof a === 'string' ? didDocument.dereferenceVerificationMethod(a) : a
+    const authentication = didDocument
+      .findVerificationMethodsByPurpose(['authentication'])
+      .map((verificationMethod) => {
         const publicJwk = getPublicJwkFromVerificationMethod(verificationMethod)
         const kmsKeyId = keys?.find((key) => verificationMethod.id.endsWith(key.didDocumentRelativeKeyId))?.kmsKeyId
 

--- a/packages/didcomm/src/modules/connections/DidExchangeProtocol.ts
+++ b/packages/didcomm/src/modules/connections/DidExchangeProtocol.ts
@@ -695,16 +695,11 @@ export class DidExchangeProtocol {
     const json = didDocumentAttachment.getDataAsJson()
     const didDocument = JsonTransformer.fromJSON(json, DidDocument)
     const didDocumentKeys = didDocument.authentication
-      ?.map((authentication) => {
-        const verificationMethod =
-          typeof authentication === 'string'
-            ? didDocument.dereferenceVerificationMethod(authentication)
-            : authentication
-
-        const publicJwk = getPublicJwkFromVerificationMethod(verificationMethod)
-        return publicJwk
-      })
-      .concat(invitationKeys)
+      ? didDocument
+          .findVerificationMethodsByPurpose(['authentication'])
+          .map((verificationMethod) => getPublicJwkFromVerificationMethod(verificationMethod))
+          .concat(invitationKeys)
+      : undefined
 
     this.logger.trace('JWS verification result', { isValid, jwsSigners })
 

--- a/packages/didcomm/src/modules/credentials/formats/jsonld/DidCommJsonLdCredentialFormatService.ts
+++ b/packages/didcomm/src/modules/credentials/formats/jsonld/DidCommJsonLdCredentialFormatService.ts
@@ -3,7 +3,6 @@ import {
   ClaimFormat,
   CredoError,
   DidResolverService,
-  findVerificationMethodByKeyType,
   JsonEncoder,
   JsonTransformer,
   utils,
@@ -300,10 +299,10 @@ export class DidCommJsonLdCredentialFormatService
       throw new CredoError(`No Key Type found for proofType ${proofType}`)
     }
 
-    const verificationMethod = await findVerificationMethodByKeyType(keyType[0], issuerDidDocument, [
+    const verificationMethod = issuerDidDocument.findVerificationMethodsByTypeAndPurpose(keyType, [
       'assertionMethod',
       'verificationMethod',
-    ])
+    ])[0]
 
     if (!verificationMethod) {
       throw new CredoError(`Missing verification method for key type ${keyType}`)

--- a/packages/webvh/src/anoncreds/services/WebVhAnonCredsRegistry.ts
+++ b/packages/webvh/src/anoncreds/services/WebVhAnonCredsRegistry.ts
@@ -833,15 +833,8 @@ export class WebVhAnonCredsRegistry implements AnonCredsRegistry {
       }
     }
 
-    const authorizedIds: string[] = []
-    for (const entry of didDocument.assertionMethod ?? []) {
-      const entryId = typeof entry === 'string' ? entry : entry.id
-      try {
-        authorizedIds.push(toAbsoluteId(didDocument.dereferenceKey(entryId, [ATTESTED_RESOURCE_PROOF_PURPOSE]).id))
-      } catch {
-        // Skip entries that cannot be dereferenced within this did document
-      }
-    }
+    const authorizedMethods = didDocument.findVerificationMethodsByTypeAndPurpose('Multikey', ['assertionMethod'])
+    const authorizedIds = authorizedMethods.map((method) => toAbsoluteId(method.id))
 
     if (authorizedIds.length === 0) {
       throw new CredoError(


### PR DESCRIPTION
Multiple points in the codebase use the same logic to resolve keys within a DID document

Created 2 self-describing helpers inside `didDocument.ts` for:

* `findVerificationMethodsByPurpose()`
* `findVerificationMethodsByTypeAndPurpose()`

Wired these helpers into call sites throughout the codebase to simplify reasoning:
* DQCL
* DidComm
* PEX
* Cheqd
* Webvh
* W3cJwt

Helpers necessary for fixing currently-broken `linked-data-proofs` when using `Ed25519-2020` keys in subsequent PR