### PR TITLE
fix(indy): re-point docker image repository

### DIFF
--- a/network/indy-pool.dockerfile
+++ b/network/indy-pool.dockerfile
@@ -1,4 +1,4 @@
-FROM bcgovimages/von-image:node-1.12-6
+FROM ghcr.io/bcgov/von-image:node-1.12-6
 
 USER root
 


### PR DESCRIPTION
Dockerhub bcgov image marked deprecated, recommends using `gchr` image instead